### PR TITLE
replace distutils with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(
     name='cle',


### PR DESCRIPTION
apparently setuptools is the hot new way to go
https://asciinema.org/a/2zea01ld4hpf32y9ame7jx17o
http://stackoverflow.com/questions/9810603/adding-install-requires-to-setup-py-when-making-a-python-package