### PR TITLE
Formatting of comments.

### DIFF
--- a/cle/__init__.py
+++ b/cle/__init__.py
@@ -1,16 +1,5 @@
 """
 CLE
-
-..  automodule:: cle.loader
-    :members:
-..  automodule:: cle.memory
-    :members:
-..  automodule:: cle.tls
-    :members:
-..  automodule:: cle.relocations
-    :members:
-..  automodule:: cle.backends
-    :members:
 """
 
 import logging

--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -97,7 +97,7 @@ class Symbol(object):
     Representation of a symbol from a binary file. Smart enough to rebase itself.
 
     There should never be more than one Symbol instance representing a single symbol. To make sure of this, only use
-    the get_symbol method in the backend objects.
+    the :func:`get_symbol` method in the backend objects.
     """
     def __init__(self, owner, name, addr, size, binding, sym_type, sh_info):
         super(Symbol, self).__init__()
@@ -117,7 +117,6 @@ class Symbol(object):
             #demangled = self.demangled_name
             #if demangled is not None:
             #    self.owner_obj.demangled_names[self.name] = demangled
-
 
     def resolve(self, obj):
         self.resolved = True

--- a/cle/backends/backedcgc.py
+++ b/cle/backends/backedcgc.py
@@ -1,6 +1,7 @@
 from ..backends import Segment
 from .cgc import CGC
 
+
 class FakeSegment(Segment):
     def __init__(self, start, size):
         super(FakeSegment, self).__init__(0, start, 0, size)
@@ -8,18 +9,22 @@ class FakeSegment(Segment):
         self.is_writable = True
         self.is_executable = False
 
-class BackedCGC(CGC):
-    def __init__(self, path, memory_backer=None, register_backer=None, writes_backer=None, permissions_map=None, current_allocation_base=None, *args, **kwargs):
-        """
-        This is a backend for CGC executables that allows user provide a memory backer and a register backer as the
-        initial state of the running binary.
 
-        :param path: File path to CGC executable
-        :param memory_backer: A dict of memory content, with beginning address of each segment as key and actual memory
-                            content as data
-        :param register_backer: A dict of all register contents. EIP will be used as the entry point of this executable
-        :param permissions_map: A dict of memory region to permission flags
-        :param current_allocation_base: integer representing the current address of the top of the CGC heap
+class BackedCGC(CGC):
+    """
+    This is a backend for CGC executables that allows user provide a memory backer and a register backer as the
+    initial state of the running binary.
+    """
+    def __init__(self, path, memory_backer=None, register_backer=None, writes_backer=None, permissions_map=None,
+                 current_allocation_base=None, *args, **kwargs):
+        """
+        :param path:                    File path to CGC executable.
+        :param memory_backer:           A dict of memory content, with beginning address of each segment as key and
+                                        actual memory content as data.
+        :param register_backer:         A dict of all register contents. EIP will be used as the entry point of this
+                                        executable.
+        :param permissions_map:         A dict of memory region to permission flags
+        :param current_allocation_base: An integer representing the current address of the top of the CGC heap.
         """
         super(BackedCGC, self).__init__(path, *args, **kwargs)
 

--- a/cle/backends/blob.py
+++ b/cle/backends/blob.py
@@ -7,19 +7,16 @@ l = logging.getLogger("cle.blob")
 
 __all__ = ('Blob',)
 
+
 class Blob(Backend):
     """
-        Representation of a binary blob, i.e. an executable in an unknown file
-        format.
+    Representation of a binary blob, i.e. an executable in an unknown file format.
     """
-
     def __init__(self, path, custom_arch=None, custom_offset=None, *args, **kwargs):
         """
-        Arguments we expect in kwargs:
-            @custom_arch: required, an archinfo.Arch for the binary blob
-            @custom_offset: skip this many bytes from the beginning of the file
+        :param custom_arch:   (required) an :class:`archinfo.Arch` for the binary blob.
+        :param custom_offset: Skip this many bytes from the beginning of the file.
         """
-
 
         if custom_arch is None:
             raise CLEError("Must specify custom_arch when loading blob!")
@@ -49,7 +46,9 @@ class Blob(Backend):
         return self._max_addr
 
     def _load(self, offset, size=None):
-        """ Load a segment into memory """
+        """
+        Load a segment into memory.
+        """
         try:
             f = open(self.binary, 'rb')
         except IOError:

--- a/cle/backends/cgc.py
+++ b/cle/backends/cgc.py
@@ -6,7 +6,13 @@ from ..loader import Loader
 ELF_HEADER = "7f45 4c46 0101 0100 0000 0000 0000 0000".replace(" ","").decode('hex')
 CGC_HEADER = "7f43 4743 0101 0143 014d 6572 696e 6f00".replace(" ","").decode('hex')
 
+
 class CGC(ELF):
+    """
+    Backend to support the CGC elf format used by the Cyber Grand Challenge competition.
+
+    See : https://github.com/CyberGrandChallenge/libcgcef/blob/master/cgc_executable_format.md
+    """
     def __init__(self, path, *args, **kwargs):
         self.cgc_path = path
         self.elf_path = self.make_elf_copy(path)

--- a/cle/backends/elf.py
+++ b/cle/backends/elf.py
@@ -15,7 +15,11 @@ l = logging.getLogger('cle.elf')
 
 __all__ = ('ELFSymbol', 'ELF')
 
+
 class ELFSymbol(Symbol):
+    """
+    Represents a symbol for the ELF format.
+    """
     def __init__(self, owner, symb):
         realtype = owner.arch.translate_symbol_type(symb.entry.st_info.type)
         super(ELFSymbol, self).__init__(owner,
@@ -26,7 +30,11 @@ class ELFSymbol(Symbol):
                                         realtype,
                                         symb.entry.st_shndx)
 
+
 class ELFSegment(Segment):
+    """
+    Represents a segment for the ELF format.
+    """
     def __init__(self, readelf_seg):
         self.flags = readelf_seg.header.p_flags
         super(ELFSegment, self).__init__(readelf_seg.header.p_offset,
@@ -45,6 +53,7 @@ class ELFSegment(Segment):
     @property
     def is_executable(self):
         return self.flags & 1 != 0
+
 
 class ELFSection(Section):
     SHF_WRITE = 0x1
@@ -83,9 +92,10 @@ class ELFSection(Section):
     def is_strings(self):
         return self.flags & self.SHF_STRINGS != 0
 
+
 class ELF(MetaELF):
     """
-    The main loader class for statically loading elves. Uses the pyreadelf library where useful.
+    The main loader class for statically loading ELF executables. Uses the pyreadelf library where useful.
     """
     def __init__(self, binary, **kwargs):
         super(ELF, self).__init__(binary, **kwargs)
@@ -184,7 +194,7 @@ class ELF(MetaELF):
         """
         Gets a Symbol object for the specified symbol.
 
-        :param symid: either an index into .dynsym or the name of a symbol.
+        :param symid: Either an index into .dynsym or the name of a symbol.
         """
         if symbol_table is None:
             symbol_table = self.dynsym

--- a/cle/backends/elfcore.py
+++ b/cle/backends/elfcore.py
@@ -6,8 +6,11 @@ from ..errors import CLEError, CLECompatibilityError
 import logging
 l = logging.getLogger('cle.elfcore')
 
-class CoreNote(object):
 
+class CoreNote(object):
+    """
+    This class is used when parsing the NOTES section of a core file.
+    """
     n_type_lookup = {
             1: 'NT_PRSTATUS',
             2: 'NT_PRFPREG',
@@ -29,9 +32,10 @@ class CoreNote(object):
     def __repr__(self):
         return "<Note %s %s %#x>" % (self.name, self.n_type, len(self.desc))
 
+
 class ELFCore(ELF):
     """
-     Loader class for ELF core files.
+    Loader class for ELF core files.
     """
 
     def __init__(self, binary, **kwargs):
@@ -149,19 +153,19 @@ class ELFCore(ELF):
         usec = struct.unpack("<" + fmt, prstatus.desc[pos:pos+arch_bytes])[0] * 1000
         self.pr_utime_usec = struct.unpack("<" + fmt, prstatus.desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
 
-        pos = pos + arch_bytes*2
+        pos += arch_bytes * 2
         usec = struct.unpack("<" + fmt, prstatus.desc[pos:pos+arch_bytes])[0] * 1000
         self.pr_stime_usec = struct.unpack("<" + fmt, prstatus.desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
 
-        pos = pos + arch_bytes*2
+        pos += arch_bytes * 2
         usec = struct.unpack("<" + fmt, prstatus.desc[pos:pos+arch_bytes])[0] * 1000
         self.pr_cutime_usec = struct.unpack("<" + fmt, prstatus.desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
 
-        pos = pos + arch_bytes*2
+        pos += arch_bytes * 2
         usec = struct.unpack("<" + fmt, prstatus.desc[pos:pos+arch_bytes])[0] * 1000
         self.pr_cstime_usec = struct.unpack("<" + fmt, prstatus.desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
 
-        pos = pos + arch_bytes*2
+        pos += arch_bytes * 2
 
         # parse out general purpose registers
         if self.arch.name == 'AMD64':
@@ -200,5 +204,5 @@ class ELFCore(ELF):
         self.registers = dict(zip(rnames, regvals))
         del self.registers['xxx']
 
-        pos = pos + nreg * arch_bytes
+        pos += nreg * arch_bytes
         self.pr_fpvalid = struct.unpack("<I", prstatus.desc[pos:pos+4])[0]

--- a/cle/backends/idabin.py
+++ b/cle/backends/idabin.py
@@ -11,9 +11,10 @@ l = logging.getLogger("cle.idabin")
 
 __all__ = ('IDABin',)
 
+
 class IDABin(Backend):
     """
-     Get informations from binaries using IDA.
+    Get information from binaries using IDA.
     """
     def __init__(self, binary, *args, **kwargs):
         if idalink is None:
@@ -62,7 +63,7 @@ class IDABin(Backend):
 
     def in_which_segment(self, addr):
         """
-        Return the segment name at address `addr` ( (IDA).
+        Return the segment name at address `addr` (IDA).
         """
         seg = self.ida.idc.SegName(addr)
         if len(seg) == 0:
@@ -70,7 +71,8 @@ class IDABin(Backend):
         return seg
 
     def _find_got(self):
-        """ Locate the section (e.g. .got) that should be updated when relocating functions (that's where we want to
+        """
+        Locate the section (e.g. .got) that should be updated when relocating functions (that's where we want to
         write absolute addresses).
         """
         sec_name = self.arch.got_section_name
@@ -108,7 +110,7 @@ class IDABin(Backend):
         """
         Resolves a bunch of symbols denoted by the list `symbols`.
 
-        :returns: a dict of the form {symb:addr}.
+        :returns: A dict of the form {symb:addr}.
         """
         addrs = {}
 
@@ -124,7 +126,7 @@ class IDABin(Backend):
         """
         Get the address of the symbol `sym` from IDA.
 
-        :returns: an address
+        :returns: An address.
         """
         #addr = self.ida.idaapi.get_name_ea(self.ida.idc.BADADDR, sym)
         addr = self.ida.idc.LocByName(sym)
@@ -236,9 +238,9 @@ class IDABin(Backend):
 
     def resolve_import_dirty(self, sym, new_val):
         """
-        Resolve import for symbol *sym* the dirty way, i.e. find all references to it in the code and replace it with
-        the address *new_val* inline (instead of updating GOT slots). Don't use this unless you really have to, use
-        resolve_import_with instead.
+        Resolve import for symbol `sym` the dirty way, i.e. find all references to it in the code and replace it with
+        the address `new_val` inline (instead of updating GOT slots). Don't use this unless you really have to, use
+        :func:`resolve_import_with` instead.
         """
 
         #l.debug("\t %s resolves to 0x%x", sym, new_val)
@@ -271,7 +273,8 @@ class IDABin(Backend):
         l.warning("Could not find references to symbol %s (IDA)", sym)
 
     def set_got_entry(self, name, newaddr):
-        """ Resolve import *name* with address *newaddr*, That is, update the GOT entry for *name* with *newaddr*.
+        """
+        Resolve import `name` with address `newaddr`. That is, update the GOT entry for `name` with `newaddr`.
         """
         if name not in self.imports:
             l.warning("%s not in imports", name)
@@ -291,6 +294,8 @@ class IDABin(Backend):
     def get_strings(self):
         """
         Extract strings from binary (IDA).
+
+        :returns:   An array of strings.
         """
         ss = self.ida.idautils.Strings()
         string_list = []
@@ -301,7 +306,7 @@ class IDABin(Backend):
 
     def _get_linking_type(self):
         """
-        Define whether a binary is statically or dynamically linked based on its imports.
+        Returns whether a binary is statically or dynamically linked based on its imports.
         """
         # TODO: this is not the best, and with the Elf class we actually look for the presence of a dynamic table. We
         # should do it with IDA too.

--- a/cle/backends/metaelf.py
+++ b/cle/backends/metaelf.py
@@ -3,6 +3,7 @@ from ..errors import CLEOperationError
 
 __all__ = ('MetaELF',)
 
+
 class MetaELF(Backend):
     """
     A base class that implements functions used by all backends that can load an ELF.
@@ -26,10 +27,10 @@ class MetaELF(Backend):
 
     def _get_plt_stub_addr(self, name):
         """
-        Guess the address of the PLT stub for function *name*. Functions must have a know GOT entry in self.jmprel.
+        Guess the address of the PLT stub for function `name`. Functions must have a known GOT entry in self.jmprel.
 
-        It should be safe to call regardless of if you've resolved simprocedures or not, since those modifications are
-        on the root clemory, and we're manipulating one of its backers here.
+        It should be safe to call regardless of if you haveve resolved simprocedures or not, since those modifications
+        are on the root :class:`Clemory`, and we're manipulating one of its backers here.
 
         NOTE: you probably want to call get_call_stub_addr() instead.
         """

--- a/cle/backends/pe.py
+++ b/cle/backends/pe.py
@@ -11,7 +11,11 @@ l = logging.getLogger('cle.pe')
 
 # Reference: https://msdn.microsoft.com/en-us/library/ms809762.aspx
 
+
 class WinSymbol(Symbol):
+    """
+    Represents a symbol for the PE format.
+    """
     def __init__(self, owner, name, addr, is_import, is_export):
         super(WinSymbol, self).__init__(owner, name, addr, owner.arch.bytes, None, None, None)
         self._is_import = is_import
@@ -33,6 +37,9 @@ class WinSymbol(Symbol):
         return True
 
 class WinReloc(Relocation):
+    """
+    Represents a relocation for the PE format.
+    """
     def __init__(self, owner, symbol, addr, resolvewith):
         super(WinReloc, self).__init__(owner, symbol, addr, None)
         self.resolvewith = resolvewith
@@ -45,6 +52,9 @@ class WinReloc(Relocation):
         return self.resolvedby.rebased_addr
 
 class PESection(Section):
+    """
+    Represents a section for the PE format.
+    """
     def __init__(self, pe_section):
         super(PESection, self).__init__(
             pe_section.Name,

--- a/cle/errors.py
+++ b/cle/errors.py
@@ -7,24 +7,42 @@ __all__ = (
 )
 
 class CLEError(Exception):
+    """
+    Base class for errors raised by CLE.
+    """
     pass
 
 
 class CLEUnknownFormatError(CLEError):
+    """
+    Error raised when CLE encounters an unknown executable file format.
+    """
     pass
 
 
 class CLEFileNotFoundError(CLEError):
+    """
+    Error raised when a file does not exist.
+    """
     pass
 
 
 class CLEInvalidBinaryError(CLEError):
+    """
+    Error raised when an executable file is invalid or corrupted.
+    """
     pass
 
 
 class CLEOperationError(CLEError):
+    """
+    Error raised when a problem is encountered in the process of loading an executable.
+    """
     pass
 
 
 class CLECompatibilityError(CLEError):
+    """
+    Error raised when loading an executable that is not currently supported by CLE.
+    """
     pass

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -28,11 +28,12 @@ class Loader(object):
 
     When reference is made to a dictionary of options, it requires a dictionary with zero or more of the following keys:
 
-    * backend             "elf", "pe", "ida", "blob": which loader backend to use
-    * custom_arch         The archinfo.Arch object to use for the binary
-    * custom_base_addr    The address to rebase the object at
-    * custom_entry_point  The entry point to use for the object
-    * ???                 More, defined on a per-backend basis
+    - backend :             "elf", "pe", "ida", "blob": which loader backend to use
+    - custom_arch :         The archinfo.Arch object to use for the binary
+    - custom_base_addr :    The address to rebase the object at
+    - custom_entry_point :  The entry point to use for the object
+
+    More keys are defined on a per-backend basis.
     """
 
     def __init__(self, main_binary, auto_load_libs=True,
@@ -258,7 +259,7 @@ class Loader(object):
 
     def add_object(self, obj, base_addr=None):
         """
-        Add object `obj` to the memory map, rebased at `base_add`*. If `base_addr` is None CLE will pick a safe one.
+        Add object `obj` to the memory map, rebased at `base_add`. If `base_addr` is None CLE will pick a safe one.
         Registers all its dependencies.
         """
 
@@ -439,9 +440,10 @@ class Loader(object):
                 return os.path.basename(o.binary)
 
     def find_symbol_got_entry(self, symbol):
-        """ Look for the address of a GOT entry for symbol *symbol*.
+        """
+        Look for the address of a GOT entry for `symbol`.
 
-        :returns;   The address of the symbol if found, None otherwise.
+        :returns:   The address of the symbol if found, None otherwise.
         """
         if isinstance(self.main_bin, IDABin):
             if symbol in self.main_bin.imports:
@@ -585,7 +587,7 @@ class Loader(object):
     @staticmethod
     def _parse_gdb_map(gdb_map):
         """
-        Parser for gdb's `info proc mappings`, or `info sharedlibs`, or custom
+        Parser for gdb's ``info proc mappings``, or ``info sharedlibs``, or custom
         mapping file of the form base_addr : /path/to/lib.
         """
         if os.path.exists(gdb_map):
@@ -680,7 +682,7 @@ class Loader(object):
 
     def _get_lib_path(self, libname):
         """
-        Get a path for *libname*. We pick the first plausible candidate that is binary compatible.
+        Get a path for `libname`. We pick the first plausible candidate that is binary compatible.
         """
         # Valid path
         if os.path.exists(libname) and self._check_compatibility(libname):

--- a/cle/memory.py
+++ b/cle/memory.py
@@ -28,7 +28,7 @@ class Clemory(object):
         Adds a backer to the memory.
 
         :param start:   The address where the backer should be loaded.
-        :param data:    The backer itself. Can be either a string or another Clemory.
+        :param data:    The backer itself. Can be either a string or another :class:`Clemory`.
         """
         if not isinstance(data, (str, Clemory)):
             raise TypeError("Data must be a string or a Clemory")
@@ -105,7 +105,8 @@ class Clemory(object):
         self.__dict__.update(data)
 
     def read_bytes(self, addr, n):
-        """ Read *n* bytes at address *addr* in memory and return an array of bytes.
+        """
+        Read `n` bytes at address `addr` in memory and return an array of bytes.
         """
         b = []
         for i in range(addr, addr+n):
@@ -114,14 +115,14 @@ class Clemory(object):
 
     def write_bytes(self, addr, data):
         """
-        Write bytes from *data* at address *addr*.
+        Write bytes from `data` at address `addr`.
         """
         for i, c in enumerate(data):
             self[addr+i] = c
 
     def write_bytes_to_backer(self, addr, data):
         """
-        Write bytes from @data at address *addr* to backer instead of self._updates. This is only needed when writing a
+        Write bytes from `data` at address `addr` to backer instead of self._updates. This is only needed when writing a
         huge amount of data.
         """
 
@@ -177,13 +178,13 @@ class Clemory(object):
 
     def read_addr_at(self, where):
         """
-        Read addr stored in memory as a series of bytes starting at *where*.
+        Read addr stored in memory as a series of bytes starting at `where`.
         """
         return struct.unpack(self._arch.struct_fmt(), ''.join(self.read_bytes(where, self._arch.bytes)))[0]
 
     def write_addr_at(self, where, addr):
         """
-        Writes *addr* into a series of bytes in memory at *where*.
+        Writes `addr` into a series of bytes in memory at `where`.
         """
         by = struct.pack(self._arch.struct_fmt(), addr % (2**self._arch.bits))
         self.write_bytes(where, by)
@@ -214,7 +215,7 @@ class Clemory(object):
 
     def seek(self, value):
         """
-        The stream-like function that sets the "file's" current position. Use with read().
+        The stream-like function that sets the "file's" current position. Use with :func:`read()`.
 
         :param value:        The position to seek to.
         """
@@ -223,7 +224,7 @@ class Clemory(object):
     def read(self, nbytes):
         """
         The stream-like function that reads a number of bytes starting from the current position and updates the current
-        position. Use with seek().
+        position. Use with :func:`seek`.
 
         :param nbytes:   The number of bytes to read.
         """
@@ -284,7 +285,7 @@ class Clemory(object):
 
     def read_bytes_c(self, addr):
         """
-        Read *n* bytes at address *addr* in cbacked memory, and returns a cffi buffer pointer.
+        Read `n` bytes at address `addr` in cbacked memory, and returns a cffi buffer pointer.
 
         Note: We don't support reading across segments for performance concerns.
         """

--- a/cle/relocations/__init__.py
+++ b/cle/relocations/__init__.py
@@ -11,6 +11,7 @@ ALL_RELOCATIONS = defaultdict(dict)
 complaint_log = set()
 path = os.path.dirname(os.path.abspath(__file__))
 
+
 def load_relocations():
     for filename in os.listdir(path):
         if not filename.endswith('.py'):
@@ -38,6 +39,7 @@ def load_relocations():
 
             ALL_RELOCATIONS[arch_name][archinfo.defines[item_name]] = item
 
+
 def get_relocation(arch, r_type):
     if r_type == 0:
         return None
@@ -49,19 +51,21 @@ def get_relocation(arch, r_type):
             l.warning("Unknown reloc %d on %s", r_type, arch)
         return None
 
+
 class Relocation(object):
     """
     A representation of a relocation in a binary file. Smart enough to
     relocate itself.
 
-    Properties you may care about:
-    - owner_obj: the binary this relocation was originaly found in, as a cle object
-    - symbol: the Symbol object this relocation refers to
-    - addr: the address in owner_obj this relocation would like to write to
-    - rebased_addr: the address in the global memory space this relocation would like to write to
-    - resolvedby: If the symbol this relocation refers to is an import symbol and that import has been resolved,
-                  this attribute holds the symbol from a different binary that was used to resolve the import.
-    - resolved: Whether the application of this relocation was succesful
+    Properties you may care about :
+
+    :ivar owner_obj:    The binary this relocation was originaly found in, as a cle object
+    :ivar symbol:       The Symbol object this relocation refers to
+    :ivar addr:         The address in owner_obj this relocation would like to write to
+    :ivar rebased_addr: The address in the global memory space this relocation would like to write to
+    :ivar resolvedby:   If the symbol this relocation refers to is an import symbol and that import has been resolved,
+                        this attribute holds the symbol from a different binary that was used to resolve the import.
+    :ivar resolved:     Whether the application of this relocation was succesful
     """
     def __init__(self, owner, symbol, addr, addend=None):
         super(Relocation, self).__init__()
@@ -132,7 +136,7 @@ class Relocation(object):
 
         This implementation is a generic version that can be overridden in subclasses.
 
-        @param solist       A list of objects from which to resolve symbols
+        :param solist:       A list of objects from which to resolve symbols.
         """
         if not self.resolve_symbol(solist):
             return False

--- a/cle/tls.py
+++ b/cle/tls.py
@@ -25,14 +25,15 @@ TLS_HEAD_ALIGN = 0x10000
 TLS_DTV_INITIAL_CAPACITY = 0x10
 TLS_ALLOC_SIZE = 0x30000
 
+
 def roundup(val, to=TLS_BLOCK_ALIGN):
-    #val -= 1
-    #diff = to - (val % to)
-    #val += diff
-    #return val
     return val - 1 + (to - ((val - 1) % to))
 
+
 class TLSObj(Backend):
+    """
+    This class is used when parsing the Thread Local Storage of a binary.
+    """
     def __init__(self, modules):
         super(TLSObj, self).__init__('##cle_tls##')
         self.modules = modules
@@ -103,7 +104,7 @@ class TLSObj(Backend):
 
     def get_addr(self, module_id, offset):
         """
-         basically __tls_get_addr
+        basically ``__tls_get_addr``.
         """
         return self.thread_pointer + self.modules[module_id-1].tls_block_offset + offset
 


### PR DESCRIPTION
This commit is mostly reformatting of comments for the api-docs plus the following items.

- I added descriptions of the errors in cle/errors.py, please double check they're accurate.
- I added a comment for some classes as it's needed for them to show up in the api-docs.
- 2 blank lines are added before class definitions as per PEP8 