### PR TITLE
Bug fix when automatically stubbing out unresolved PE symbols

### DIFF
--- a/cle/backends/pe.py
+++ b/cle/backends/pe.py
@@ -45,7 +45,7 @@ class WinReloc(Relocation):
         self.resolvewith = resolvewith
 
     def resolve_symbol(self, solist):
-        return super(WinReloc, self).resolve_symbol([x for x in solist if self.resolvewith == x.provides])
+        return super(WinReloc, self).resolve_symbol([x for x in solist if self.resolvewith == x.provides or x.provides == None])
 
     @property
     def value(self):


### PR DESCRIPTION
Hi guys,

I believe there is a bug when angr attempts to automatically stub out unresolved PE symbols.

Let's use angr-doc/examples/whitehatevn2015_re400/re400.exe as our test case. Running the following code results in an errored path:

```python
import angr

b = angr.Project('re400.exe')
p = b.factory.path()
p.step()

while len(p.successors) == 1:
    p = p.successors[0]
    p.step()
```

If we trac execution flow, we can see that the last valid code block was at 0x408a7b. `b.factory.block(0x408a7b).pp()` produces:

```
0x408a7b:	push	esi
0x408a7c:	lea	eax, dword ptr [ebp - 8]
0x408a7f:	push	eax
0x408a80:	call	dword ptr [0x40e0d4]
```

If we were to inspect re400.exe, we would see that 0x40e0d4 corresponds to the kernel32 import GetSystemTimeAsFileTime (you can verify this by running `b.loader.main_bin.imports['GetSystemTimeAsFileTime'].addr`). 0x40e0d4 contains the value 0x11070, which is the last "function" in our callstack backtrace and the cause of our errored path (there is nothing loaded at 0x11070).

If we run with DEBUG logging, we can see that angr stubs out all of re400.exe's unresolved symbols. For GetSystemTimeAsFileTime, a "SimProcedure with pseudo_addr 0x10002f0" is generated. We can verify this using `b.is_hooked` and `b.hooked_by` on address 0x10002f0. However, we can see from the previous run that the GetSystemTimeAsFileTime import does not point to the simprocedure at 0x10002f0 (it points to 0x11070).

I believe that the bug occurs when angr tries to stub out the unresolved symbols ("step 3" of `Project.__init__`). `Project.__init__` calls `hook_symbol` which uses the "externs object" to provide addresses for hook functions. However, when `loader.provide_symbol` attempts to relocate the symbol (and thus point it to our simprocedure stub), the symbol fails to resolve. Symbol resolution fails becauase `WinReloc.resolve_symbol` iterates over `solist` and only attempts to resolve against shared objects where the `WinReloc` object's `resolvewith` equals the `provides` of the shared object. However, the "externs object" has `provides == None`, which causes an empty list to be passed to `Relocation.resolve_symbol` and the symbol failing to resolve.

The simplest fix is to also include those shared objects who's `provides == None`. Symbol resolution will complete successfully and the symbol is correctly relocated to point to the simprocedure stub and our `step` loop through re400.exe no longer results in an errored path!

Hopefully this all makes sense! Sorry for the long write up, I also wanted to see if it made sense to me too :-)