### PR TITLE
Fixed missing sections_map in PE backend

### DIFF
--- a/cle/backends/pe.py
+++ b/cle/backends/pe.py
@@ -226,3 +226,4 @@ class PE(Backend):
         for pe_section in self._pe.sections:
             section = PESection(pe_section)
             self.sections.append(section)
+            self.sections_map[section.name] = section


### PR DESCRIPTION
`sections_map` property was missing from the PE backend. So I added it in.