### PR TITLE
Fixed address checks in the base Backend class

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -380,11 +380,13 @@ class Backend(object):
         for i in self.segments:
             if i.contains_addr(addr - self.rebase_addr):
                 out = True
+                break
 
         if not out:
             for i in self.sections:
                 if i.contains_addr(addr - self.rebase_addr):
                     out = True
+                    break
 
         return out
 
@@ -413,11 +415,13 @@ class Backend(object):
         for s in self.segments:
             if s.contains_addr(addr - self.rebase_addr):
                 out = s.addr_to_offset(addr - self.rebase_addr)
+                break
 
         if out is None:
             for s in self.sections:
                 if s.contains_addr(addr - self.rebase_addr):
                     out = s.addr_to_offset(addr - self.rebase_addr)
+                    break
 
         return out
 
@@ -426,11 +430,13 @@ class Backend(object):
         for s in self.segments:
             if s.contains_offset(offset):
                 out = s.offset_to_addr(offset) + self.rebase_addr
+                break
 
         if out is None:
             for s in self.sections:
                 if s.contains_offset(offset):
                     out = s.offset_to_addr(offset) + self.rebase_addr
+                    break
 
         return out
 

--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -374,12 +374,19 @@ class Backend(object):
 
     def contains_addr(self, addr):
         """
-        Is `vaddr` in one of the binary's segments we have loaded ? (i.e. is it mapped into memory ?)
+        Is `vaddr` in one of the binary's segments/sections we have loaded ? (i.e. is it mapped into memory ?)
         """
+        out = False
         for i in self.segments:
             if i.contains_addr(addr - self.rebase_addr):
-                return True
-        return False
+                out = True
+
+        if not out:
+            for i in self.sections:
+                if i.contains_addr(addr - self.rebase_addr):
+                    out = True
+
+        return out
 
     def find_segment_containing(self, addr):
         """
@@ -402,15 +409,30 @@ class Backend(object):
         return None
 
     def addr_to_offset(self, addr):
+        out = None
         for s in self.segments:
             if s.contains_addr(addr - self.rebase_addr):
-                return s.addr_to_offset(addr - self.rebase_addr)
-        return None
+                out = s.addr_to_offset(addr - self.rebase_addr)
+
+        if out is None:
+            for s in self.sections:
+                if s.contains_addr(addr - self.rebase_addr):
+                    out = s.addr_to_offset(addr - self.rebase_addr)
+
+        return out
 
     def offset_to_addr(self, offset):
+        out = None
         for s in self.segments:
             if s.contains_offset(offset):
-                return s.offset_to_addr(offset) + self.rebase_addr
+                out = s.offset_to_addr(offset) + self.rebase_addr
+
+        if out is None:
+            for s in self.sections:
+                if s.contains_offset(offset):
+                    out = s.offset_to_addr(offset) + self.rebase_addr
+
+        return out
 
     def get_min_addr(self):
         """


### PR DESCRIPTION
The following code fails:

```python
import angr

b = angr.Project('/path/to/some/pefile')
b.loader.main_bin.contains_addr(b.loader.main_bin.entry)
# Should return True, instead returns False
```

This is because all of the address checks in the `Backend` class only search segments and PE files only use sections. There I've added in code to also search the sections if the segment search fails. This is similar to what is already done in the `get_min_addr` and `get_max_addr` methods.