### PR TITLE
Added a PE test

### DIFF
--- a/tests/test_got.py
+++ b/tests/test_got.py
@@ -5,10 +5,11 @@ import logging
 import cle
 
 import os
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                             os.path.join('..', '..', 'binaries', 'tests'))
 
 def test_ppc():
-    libc = os.path.join(test_location, "ppc/libc.so.6")
+    libc = os.path.join(test_location, 'ppc', 'libc.so.6')
     ld = cle.Loader(libc, auto_load_libs=True, main_opts={'custom_base_addr': 0})
     # This tests the relocation of _rtld_global_ro in ppc libc6.
     # This relocation is of type 20, and relocates a non-local symbol
@@ -16,7 +17,7 @@ def test_ppc():
     nose.tools.assert_equal(relocated % 0x1000, 0xf666e320 % 0x1000)
 
 def test_mipsel():
-    ping = os.path.join(test_location, "mipsel/darpa_ping")
+    ping = os.path.join(test_location, 'mipsel', 'darpa_ping')
     skip=['libgcc_s.so.1', 'libresolv.so.0']
     ld = cle.Loader(ping, skip_libs=skip)
     dep = ld._satisfied_deps

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+import logging
+import nose
+import os
+
+import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                         os.path.join('..', '..', 'binaries'))
+
+def check_exe():
+    exe = os.path.join(TEST_BASE, 'tests', 'x86', 'windows', 'TLS.exe')
+    ld = cle.Loader(exe, auto_load_libs=False)
+
+    nose.tools.assert_equals(ld.main_bin.filetype, 'pe')
+    nose.tools.assert_equals(ld.main_bin.os, 'windows')
+    nose.tools.assert_equals(sorted([sec.name for sec in ld.main_bin.sections]),
+                             sorted(['.textbss',
+                                     '.text\x00\x00\x00',
+                                     '.rdata\x00\x00',
+                                     '.data\x00\x00\x00',
+                                     '.idata\x00\x00',
+                                     '.tls\x00\x00\x00\x00',
+                                     '.gfids\x00\x00',
+                                     '.00cfg\x00\x00',
+                                     '.rsrc\x00\x00\x00']))
+    nose.tools.assert_equals(ld.main_bin.segments, [])
+    nose.tools.assert_equals(sorted(ld.main_bin.deps),
+                             sorted(['KERNEL32.dll',
+                                     'VCRUNTIME140D.dll',
+                                     'ucrtbased.dll']))
+    nose.tools.assert_equals(sorted(ld.main_bin.imports),
+                             sorted(['_configure_narrow_argv',
+                                     'GetLastError',
+                                     'HeapFree',
+                                     'IsProcessorFeaturePresent',
+                                     '__vcrt_GetModuleFileNameW',
+                                     '_configthreadlocale',
+                                     '__setusermatherr',
+                                     'memset',
+                                     'terminate',
+                                     '_register_onexit_function',
+                                     'WaitForSingleObject',
+                                     '_set_fmode',
+                                     'FreeLibrary',
+                                     'QueryPerformanceCounter',
+                                     '_controlfp_s',
+                                     'IsDebuggerPresent',
+                                     'HeapAlloc',
+                                     '_initialize_onexit_table',
+                                     'wcscpy_s',
+                                     '__std_type_info_destroy_list',
+                                     '_set_app_type',
+                                     '_cexit',
+                                     '_seh_filter_exe',
+                                     '_c_exit',
+                                     'GetCurrentProcess',
+                                     '_set_new_mode',
+                                     '__vcrt_LoadLibraryExW',
+                                     '__stdio_common_vsprintf_s',
+                                     'GetCurrentProcessId',
+                                     '_execute_onexit_table',
+                                     'WideCharToMultiByte',
+                                     'UnhandledExceptionFilter',
+                                     'MultiByteToWideChar',
+                                     'GetStartupInfoW',
+                                     'exit',
+                                     'GetProcAddress',
+                                     'InitializeSListHead',
+                                     '_crt_at_quick_exit',
+                                     'GetProcessHeap',
+                                     '_CrtDbgReportW',
+                                     'RaiseException',
+                                     '__telemetry_main_invoke_trigger',
+                                     'CreateThread',
+                                     '_exit',
+                                     '__p__commode',
+                                     '_get_initial_narrow_environment',
+                                     '__p___argc',
+                                     'SetUnhandledExceptionFilter',
+                                     '_except_handler4_common',
+                                     '_register_thread_local_exe_atexit_callback',
+                                     'GetSystemTimeAsFileTime',
+                                     '_initialize_narrow_environment',
+                                     '__vcrt_GetModuleHandleW',
+                                     '__p___argv',
+                                     'GetModuleHandleW',
+                                     'TerminateProcess',
+                                     '_initterm_e',
+                                     '_wmakepath_s',
+                                     '_seh_filter_dll',
+                                     '_CrtDbgReport',
+                                     'VirtualQuery',
+                                     '__telemetry_main_return_trigger',
+                                     '_wsplitpath_s',
+                                     '_initterm',
+                                     'GetCurrentThreadId',
+                                     '_crt_atexit']))
+    nose.tools.assert_is_none(ld.main_bin.provides)
+
+def check_dll():
+    pass
+
+def check_tls():
+    exe = os.path.join(TEST_BASE, 'tests', 'x86', 'windows', 'TLS.exe')
+    ld = cle.Loader(exe, auto_load_libs=False)
+
+    nose.tools.assert_true(ld.main_bin.tls_used)
+    nose.tools.assert_equals(ld.main_bin.tls_data_start, 0x41b000)
+    nose.tools.assert_equals(ld.main_bin.tls_data_size, 520)
+    nose.tools.assert_equals(ld.main_bin.tls_index_address, 0x41913C)
+    nose.tools.assert_equals(ld.main_bin.tls_callbacks, [0x411302])
+    nose.tools.assert_equals(ld.main_bin.tls_size_of_zero_fill, 0)
+
+    tls = ld.tls_object
+    nose.tools.assert_is_not_none(tls)
+    nose.tools.assert_equals(len(tls.modules), 1)
+    nose.tools.assert_equals(tls.get_tls_data_addr(0), 0x1000004)
+    nose.tools.assert_raises(IndexError, tls.get_tls_data_addr, 1)
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    check_exe()
+    check_dll()
+    check_tls()

--- a/tests/test_plt.py
+++ b/tests/test_plt.py
@@ -4,14 +4,29 @@ import subprocess
 import pickle
 import cle
 
-TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries')
-TESTS_ARCHES = ['i386/libc.so.6', 'i386/fauxware', 'x86_64/libc.so.6', 'x86_64/fauxware', 'armel/libc.so.6', 'armel/fauxware', 'armhf/libc.so.6', 'ppc/libc.so.6', 'ppc/fauxware', 'mips/libc.so.6', 'mips/fauxware', 'mips64/libc.so.6', 'mips64/test_arrays', 'aarch64/libc.so.6', 'aarch64/test_arrays']
+TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                          os.path.join('..', '..', 'binaries'))
+TESTS_ARCHES = [os.path.join('i386', 'libc.so.6'),
+                os.path.join('i386', 'fauxware'),
+                os.path.join('x86_64', 'libc.so.6'),
+                os.path.join('x86_64', 'fauxware'),
+                os.path.join('armel', 'libc.so.6'),
+                os.path.join('armel', 'fauxware'),
+                os.path.join('armhf', 'libc.so.6'),
+                os.path.join('ppc', 'libc.so.6'),
+                os.path.join('ppc', 'fauxware'),
+                os.path.join('mips', 'libc.so.6'),
+                os.path.join('mips', 'fauxware'),
+                os.path.join('mips64', 'libc.so.6'),
+                os.path.join('mips64', 'test_arrays'),
+                os.path.join('aarch64', 'libc.so.6'),
+                os.path.join('aarch64', 'test_arrays')]
 
 def check_plt_entries(filename):
     real_filename = os.path.join(TESTS_BASE, 'tests', filename)
     ld = cle.Loader(real_filename, auto_load_libs=False)
 
-    if filename == 'ppc/libc.so.6':
+    if filename == os.path.join('ppc', 'libc.so.6'):
         # objdump can't find PLT stubs for this...
         nose.tools.assert_not_equal(ld.main_bin._plt, {})
         sorted_keys = sorted(ld.main_bin._plt.values())
@@ -19,20 +34,20 @@ def check_plt_entries(filename):
         nose.tools.assert_equal(diffs, [4]*len(diffs))
         return
 
-    if filename == 'mips/libc.so.6':
+    if filename == os.path.join('mips', 'libc.so.6'):
         nose.tools.assert_in('__tls_get_addr', ld.main_bin._plt)
         nose.tools.assert_equal(ld.main_bin._plt['__tls_get_addr'], 1331168)
         return
 
-    if filename == 'mips/fauxware':
+    if filename == os.path.join('mips', 'fauxware'):
         nose.tools.assert_equal(ld.main_bin._plt, {'puts': 4197264, 'read': 4197232, '__libc_start_main': 4197312, 'printf': 4197248, 'exit': 4197280, 'open': 4197296, 'strcmp': 4197216})
         return
 
-    if filename == 'mips64/libc.so.6':
+    if filename == os.path.join('mips64', 'libc.so.6'):
         nose.tools.assert_equal(ld.main_bin._plt, {'__tls_get_addr': 1458432, '_dl_find_dso_for_object': 1458448})
         return
 
-    if filename == 'mips64/test_arrays':
+    if filename == os.path.join('mips64', 'test_arrays'):
         nose.tools.assert_equal(ld.main_bin._plt, {'__libc_start_main': 4831841456, 'puts': 4831841440})
         return
 
@@ -53,7 +68,7 @@ def check_plt_entries(filename):
 
     ld.main_bin._plt.pop('__gmon_start__', None)
 
-    if filename == 'armhf/libc.so.6':
+    if filename == os.path.join('armhf', 'libc.so.6'):
         # objdump does these cases wrong as far as I can tell?
         # or maybe not wrong just... different
         # there's a prefix to this stub that jumps out of thumb mode

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -4,7 +4,8 @@ import os
 import nose
 import cle
 
-test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../binaries/tests'))
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                             os.path.join('..', '..', 'binaries', 'tests'))
 
 def test_stream():
     dirpath = os.path.join(test_location, "i386")


### PR DESCRIPTION
I also made the unix-style addresses more generic for the other tests (in case you ever wanted to run cle on Windows or something. I dunno).

The DLL test is empty for now, but I'll find an interesting DLL to stick into `binaries` and use it as a test case.