### PR TITLE
fix for statically linked PPC binary with no .plt

### DIFF
--- a/cle/backends/metaelf.py
+++ b/cle/backends/metaelf.py
@@ -75,9 +75,10 @@ class MetaELF(Backend):
         # right before the resolution stubs.
         if self.arch.name in ('PPC32',):
             resolver_stubs = sorted((self.memory.read_addr_at(reloc.addr), name) for name, reloc in self.jmprel.iteritems())
-            stubs_table = resolver_stubs[0][0] - 16 * len(resolver_stubs)
-            for i, (_, name) in enumerate(resolver_stubs):
-                self._add_plt_stub(name, stubs_table + i*16)
+            if resolver_stubs:
+                stubs_table = resolver_stubs[0][0] - 16 * len(resolver_stubs)
+                for i, (_, name) in enumerate(resolver_stubs):
+                    self._add_plt_stub(name, stubs_table + i*16)
 
         if len(self._plt) == len(self.jmprel):
             # real quick, bail out before shit hits the fan


### PR DESCRIPTION
this PPC binary is statically linked, and **seems** to not have a .plt section:
https://github.com/ctfs/write-ups-2016/tree/master/hitcon-ctf-2016/ppc/flame-150

loading the binary fails with:
`  File "/home/ocean/.venvironments/angr/local/lib/python2.7/site-packages/cle/backends/metaelf.py", line 78, in _load_plt
    stubs_table = resolver_stubs[0][0] - 16 * len(resolver_stubs)
IndexError: list index out of range`

just added a check on resolver_stubs to be non-empty