### PR TITLE
Allow binary search of regions.

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from collections import OrderedDict as _ordered_dict
 
 import archinfo
 from ..memory import Clemory
@@ -236,6 +235,137 @@ class Symbol(object):
 
         return None
 
+
+#
+# Container
+#
+
+
+class Regions(object):
+    """
+    A container class acting as a list of regions (sections or segments). Additionally, it keeps an sorted list of
+    those regions to allow fast lookups.
+
+    We assume none of the regions overlap with others.
+    """
+
+    def __init__(self, lst=None):
+        self._list = lst if lst is not None else [ ]
+
+        if self._list:
+            self._sorted_list = self._make_sorted(self._list)
+        else:
+            self._sorted_list = [ ]
+
+    @property
+    def raw_list(self):
+        """
+        Get the internal list. Any change to it is not tracked, and therefore _sorted_list will not be updated.
+        Therefore you probably does not want to modify the list.
+
+        :return:  The internal list container.
+        :rtype:   list
+        """
+
+        return self._list
+
+    @property
+    def max_addr(self):
+        """
+        Get the highest address of all regions.
+
+        :return: The highest address of all regions, or None if there is no region available.
+        rtype:   int or None
+        """
+
+        if self._sorted_list:
+            return self._sorted_list[-1].max_addr
+        return None
+
+    def __getitem__(self, idx):
+        return self._list[idx]
+
+    def __setitem__(self, idx, item):
+        self._list[idx] = item
+
+        # update self._sorted_list
+        self._sorted_list = self._make_sorted(self._list)
+
+    def __len__(self):
+        return len(self._list)
+
+    def __repr__(self):
+        return "<Regions: %s>" % repr(self._list)
+
+    def append(self, region):
+        """
+        Append a new Region instance into the list.
+
+        :param Region region: The region to append.
+        :return: None
+        """
+
+        self._list.append(region)
+        self.bisect_insort_left(self._sorted_list, region, keyfunc=lambda r: r.vaddr)
+
+    def find_region_containing(self, addr):
+        """
+        Find the region that contains a specific address. Returns None if none of the regions covers the address.
+
+        :param int addr:  The address.
+        :return:          The region that covers the specific address, or None if no such region is found.
+        :rtype:    Region or None
+        """
+
+        pos = self.bisect_find(self._sorted_list, addr,
+                                    keyfunc=lambda r: r if type(r) in (int, long) else r.vaddr + r.memsize
+                                    )
+        region = self._sorted_list[pos]
+        if region.contains_addr(addr):
+            return region
+        return None
+
+    @staticmethod
+    def bisect_find(lst, item, lo=0, hi=None, keyfunc=lambda x: x):
+        if lo < 0:
+            raise ValueError('lo must be non-negative')
+        if hi is None:
+            hi = len(lst)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if keyfunc(lst[mid]) <= keyfunc(item):
+                lo = mid + 1
+            else:
+                hi = mid
+        return hi
+
+    @staticmethod
+    def bisect_insort_left(lst, item, lo=0, hi=None, keyfunc=lambda x: x):
+        if lo < 0:
+            raise ValueError('lo must be non-negative')
+        if hi is None:
+            hi = len(lst)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if keyfunc(lst[mid]) < keyfunc(item):
+                lo = mid + 1
+            else:
+                hi = mid
+        lst.insert(lo, item)
+
+    @staticmethod
+    def _make_sorted(lst):
+        """
+        Return a sorted list of regions.
+
+        :param list lst:  A list of regions.
+        :return:          A sorted list of regions.
+        :rtype:           list
+        """
+
+        return sorted(lst, lambda x: x.vaddr)
+
+
 class Backend(object):
     """
     Main base class for CLE binary objects.
@@ -291,8 +421,8 @@ class Backend(object):
 
         self.is_main_bin = is_main_bin
         self._entry = None
-        self.segments = [] # List of segments
-        self.sections = []      # List of sections
+        self._segments = Regions() # List of segments
+        self._sections = Regions() # List of sections
         self.sections_map = {}  # Mapping from section name to section
         self.symbols_by_addr = {}
         self.imports = {}
@@ -358,6 +488,32 @@ class Backend(object):
             return self._custom_entry_point + self.rebase_addr
         return self._entry + self.rebase_addr
 
+    @property
+    def segments(self):
+        return self._segments
+
+    @segments.setter
+    def segments(self, v):
+        if isinstance(v, list):
+            self._segments = Regions(lst=v)
+        elif isinstance(v, Regions):
+            self._segments = v
+        else:
+            raise ValueError('Unsupported type %s set as sections.' % type(v))
+
+    @property
+    def sections(self):
+        return self._sections
+
+    @sections.setter
+    def sections(self, v):
+        if isinstance(v, list):
+            self._sections = Regions(lst=v)
+        elif isinstance(v, Regions):
+            self._sections = v
+        else:
+            raise ValueError('Unsupported type %s set as sections.' % type(v))
+
     def contains_addr(self, addr):
         """
         Is `addr` in one of the binary's segments/sections we have loaded? (i.e. is it mapped into memory ?)
@@ -372,21 +528,15 @@ class Backend(object):
         """
         Returns the segment that contains `addr`, or ``None``.
         """
-        for s in self.segments:
-            if s.contains_addr(addr - self.rebase_addr):
-                return s
 
-        return None
+        return self.segments.find_region_containing(addr - self.rebase_addr)
 
     def find_section_containing(self, addr):
         """
         Returns the section that contains `addr` or ``None``.
         """
-        for s in self.sections:
-            if s.contains_addr(addr - self.rebase_addr):
-                return s
 
-        return None
+        return self.sections.find_region_containing(addr - self.rebase_addr)
 
     def addr_to_offset(self, addr):
         loadable = self.find_loadable_containing(addr)
@@ -433,15 +583,10 @@ class Backend(object):
         This returns the highest virtual address contained in any loaded segment of the binary.
         """
 
-        out = None
-        for segment in self.segments:
-            if out is None or segment.max_addr > out:
-                out = segment.max_addr
+        out = self.segments.max_addr
 
         if out is None:
-            for section in self.sections:
-                if out is None or section.max_addr > out:
-                    out = section.max_addr
+            out = self.sections.max_addr
 
         if out is None:
             return self.rebase_addr

--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -320,6 +320,8 @@ class Regions(object):
         pos = self.bisect_find(self._sorted_list, addr,
                                     keyfunc=lambda r: r if type(r) in (int, long) else r.vaddr + r.memsize
                                     )
+        if pos >= len(self._sorted_list):
+            return None
         region = self._sorted_list[pos]
         if region.contains_addr(addr):
             return region
@@ -337,7 +339,7 @@ class Regions(object):
                 lo = mid + 1
             else:
                 hi = mid
-        return hi
+        return lo
 
     @staticmethod
     def bisect_insort_left(lst, item, lo=0, hi=None, keyfunc=lambda x: x):

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -24,7 +24,7 @@ def test_exe():
                                      '.gfids\x00\x00',
                                      '.00cfg\x00\x00',
                                      '.rsrc\x00\x00\x00']))
-    nose.tools.assert_equals(ld.main_bin.segments, [])
+    nose.tools.assert_equals(ld.main_bin.segments.raw_list, [])
     nose.tools.assert_equals(sorted(ld.main_bin.deps),
                              sorted(['KERNEL32.dll',
                                      'VCRUNTIME140D.dll',

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -92,6 +92,7 @@ def test_sections(arch, filename, sections):
                 nose.tools.assert_is_none(ld.main_bin.find_section_containing(a))
                 nose.tools.assert_is_none(ld.main_bin.sections.find_region_containing(a))
 
+    nose.tools.assert_is_none(ld.main_bin.find_section_containing(0xffffffff), None)
 
 def test_segments(arch, filename, segments):
 
@@ -131,6 +132,8 @@ def test_segments(arch, filename, segments):
                 a = seg_a.vaddr + seg_a.memsize + j
                 nose.tools.assert_is_none(ld.main_bin.find_segment_containing(a))
                 nose.tools.assert_is_none(ld.main_bin.segments.find_region_containing(a))
+
+    nose.tools.assert_is_none(ld.main_bin.find_segment_containing(0xffffffff), None)
 
 
 def run_all():

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -15,7 +15,7 @@ groundtruth = {
     ('x86_64', 'allcmps'): {
         'sections': [
                         Section('', 0x0, 0x0, 0x0),
-                        Section('.interp', 0x238, 0x400238, 0x1c), 
+                        Section('.interp', 0x238, 0x400238, 0x1c),
                         Section('.note.ABI-tag', 0x254, 0x400254, 0x20),
                         Section('.note.gnu.build-id', 0x274, 0x400274, 0x24),
                         Section('.gnu.hash', 0x298, 0x400298, 0x1c),
@@ -53,7 +53,7 @@ groundtruth = {
 }
 
 
-def test_sections(arch, filename, sections):
+def run_sections(arch, filename, sections):
 
     binary_path = os.path.join(TESTS_BASE, arch, filename)
 
@@ -94,7 +94,7 @@ def test_sections(arch, filename, sections):
 
     nose.tools.assert_is_none(ld.main_bin.find_section_containing(0xffffffff), None)
 
-def test_segments(arch, filename, segments):
+def run_segments(arch, filename, segments):
 
     binary_path = os.path.join(TESTS_BASE, arch, filename)
 
@@ -136,12 +136,12 @@ def test_segments(arch, filename, segments):
     nose.tools.assert_is_none(ld.main_bin.find_segment_containing(0xffffffff), None)
 
 
-def run_all():
+def test_all():
 
     for (arch, filename), data in groundtruth.iteritems():
-        test_sections(arch, filename, data['sections'])
-        test_segments(arch, filename, data['segments'])
+        yield run_sections, arch, filename, data['sections']
+        yield run_segments, arch, filename, data['segments']
 
 
 if __name__ == "__main__":
-    run_all()
+    test_all()

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,0 +1,144 @@
+
+import os
+
+import nose
+
+import cle
+from cle.backends import Section, Segment
+
+
+TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                          os.path.join('..','..','binaries','tests'))
+
+
+groundtruth = {
+    ('x86_64', 'allcmps'): {
+        'sections': [
+                        Section('', 0x0, 0x0, 0x0),
+                        Section('.interp', 0x238, 0x400238, 0x1c), 
+                        Section('.note.ABI-tag', 0x254, 0x400254, 0x20),
+                        Section('.note.gnu.build-id', 0x274, 0x400274, 0x24),
+                        Section('.gnu.hash', 0x298, 0x400298, 0x1c),
+                        Section('.dynsym', 0x2b8, 0x4002b8, 0x48),
+                        Section('.dynstr', 0x300, 0x400300, 0x38),
+                        Section('.gnu.version', 0x338, 0x400338, 0x6),
+                        Section('.gnu.version_r', 0x340, 0x400340, 0x20),
+                        Section('.rela.dyn', 0x360, 0x400360, 0x18),
+                        Section('.rela.plt', 0x378, 0x400378, 0x30),
+                        Section('.init', 0x3a8, 0x4003a8, 0x1a),
+                        Section('.plt', 0x3d0, 0x4003d0, 0x30),
+                        Section('.text', 0x400, 0x400400, 0x2c4),
+                        Section('.fini', 0x6c4, 0x4006c4, 0x9),
+                        Section('.rodata', 0x6d0, 0x4006d0, 0x4),
+                        Section('.eh_frame_hdr', 0x6d4, 0x4006d4, 0x3c),
+                        Section('.eh_frame', 0x710, 0x400710, 0xf4),
+                        Section('.init_array', 0xe10, 0x600e10, 0x8),
+                        Section('.fini_array', 0xe18, 0x600e18, 0x8),
+                        Section('.jcr', 0xe20, 0x600e20, 0x8),
+                        Section('.dynamic', 0xe28, 0x600e28, 0x1d0),
+                        Section('.got', 0xff8, 0x600ff8, 0x8),
+                        Section('.got.plt', 0x1000, 0x601000, 0x28),
+                        Section('.data', 0x1028, 0x601028, 0x10),
+                        Section('.bss', 0x1038, 0x601038, 0x8),
+                        Section('.comment', 0x1038, 0x0, 0x2a),
+                        Section('.shstrtab', 0x1062, 0x0, 0x108),
+                        Section('.symtab', 0x18f0, 0x0, 0x630),
+                        Section('.strtab', 0x1f20, 0x0, 0x232),
+        ],
+        'segments': [
+            Segment(0, 0x400000, 0x804, 0x804),
+            Segment(0xe10, 0x600e10, 0x228, 0x230),
+        ],
+    }
+}
+
+
+def test_sections(arch, filename, sections):
+
+    binary_path = os.path.join(TESTS_BASE, arch, filename)
+
+    ld = cle.Loader(binary_path, auto_load_libs=False)
+
+    nose.tools.assert_equal(len(ld.main_bin.sections), len(sections))
+    for i, section in enumerate(ld.main_bin.sections):
+        nose.tools.assert_equal(section.name, sections[i].name)
+        nose.tools.assert_equal(section.offset, sections[i].offset)
+        nose.tools.assert_equal(section.vaddr, sections[i].vaddr)
+        nose.tools.assert_equal(section.memsize, sections[i].memsize)
+
+    # address lookups
+    nose.tools.assert_is_none(ld.main_bin.sections.find_region_containing(-1))
+
+    # skip all sections that are not mapped into memory
+    mapped_sections = [ section for section in sections if section.vaddr != 0 ]
+
+    for section in mapped_sections:
+        nose.tools.assert_equal(ld.main_bin.find_section_containing(section.vaddr).name, section.name)
+        nose.tools.assert_equal(ld.main_bin.sections.find_region_containing(section.vaddr).name, section.name)
+        if section.memsize > 0:
+            nose.tools.assert_equal(ld.main_bin.find_section_containing(section.vaddr + 1).name, section.name)
+            nose.tools.assert_equal(ld.main_bin.sections.find_region_containing(section.vaddr + 1).name, section.name)
+            nose.tools.assert_equal(ld.main_bin.find_section_containing(section.vaddr + section.memsize - 1).name,
+                                    section.name)
+            nose.tools.assert_equal(
+                ld.main_bin.sections.find_region_containing(section.vaddr + section.memsize - 1).name, section.name)
+
+    for i in xrange(len(mapped_sections) - 1):
+        sec_a, sec_b = mapped_sections[i], mapped_sections[i + 1]
+        if sec_a.vaddr + sec_a.memsize < sec_b.vaddr:
+            # there is a gap between sec_a and sec_b
+            for j in xrange(min(sec_b.vaddr - (sec_a.vaddr + sec_a.memsize), 20)):
+                a = sec_a.vaddr + sec_a.memsize + j
+                nose.tools.assert_is_none(ld.main_bin.find_section_containing(a))
+                nose.tools.assert_is_none(ld.main_bin.sections.find_region_containing(a))
+
+
+def test_segments(arch, filename, segments):
+
+    binary_path = os.path.join(TESTS_BASE, arch, filename)
+
+    ld = cle.Loader(binary_path, auto_load_libs=False)
+
+    nose.tools.assert_equal(len(ld.main_bin.segments), len(segments))
+    for i, segment in enumerate(ld.main_bin.segments):
+        nose.tools.assert_equal(segment.offset, segments[i].offset)
+        nose.tools.assert_equal(segment.vaddr, segments[i].vaddr)
+        nose.tools.assert_equal(segment.memsize, segments[i].memsize)
+        nose.tools.assert_equal(segment.filesize, segments[i].filesize)
+
+    # address lookups
+    nose.tools.assert_is_none(ld.main_bin.segments.find_region_containing(-1))
+
+    # skip all segments that are not mapped into memory
+    mapped_segments = [ segment for segment in segments if segment.vaddr != 0 ]
+
+    for segment in mapped_segments:
+        nose.tools.assert_equal(ld.main_bin.find_segment_containing(segment.vaddr).vaddr, segment.vaddr)
+        nose.tools.assert_equal(ld.main_bin.segments.find_region_containing(segment.vaddr).vaddr, segment.vaddr)
+        if segment.memsize > 0:
+            nose.tools.assert_equal(ld.main_bin.find_segment_containing(segment.vaddr + 1).vaddr, segment.vaddr)
+            nose.tools.assert_equal(ld.main_bin.segments.find_region_containing(segment.vaddr + 1).vaddr, segment.vaddr)
+            nose.tools.assert_equal(ld.main_bin.find_segment_containing(segment.vaddr + segment.memsize - 1).vaddr,
+                                    segment.vaddr)
+            nose.tools.assert_equal(
+                ld.main_bin.segments.find_region_containing(segment.vaddr + segment.memsize - 1).vaddr, segment.vaddr)
+
+    for i in xrange(len(mapped_segments) - 1):
+        seg_a, seg_b = mapped_segments[i], mapped_segments[i + 1]
+        if seg_a.vaddr + seg_a.memsize < seg_b.vaddr:
+            # there is a gap between seg_a and seg_b
+            for j in xrange(min(seg_b.vaddr - (seg_a.vaddr + seg_a.memsize), 20)):
+                a = seg_a.vaddr + seg_a.memsize + j
+                nose.tools.assert_is_none(ld.main_bin.find_segment_containing(a))
+                nose.tools.assert_is_none(ld.main_bin.segments.find_region_containing(a))
+
+
+def run_all():
+
+    for (arch, filename), data in groundtruth.iteritems():
+        test_sections(arch, filename, data['sections'])
+        test_segments(arch, filename, data['segments'])
+
+
+if __name__ == "__main__":
+    run_all()


### PR DESCRIPTION
Implement Regions, an ordered list containing Region objects (most
notably, sections and segments). It makes find_{section,
region}_containing() faster by performing a binary search among regions
instead of a linear search.