### PR TITLE
fixed ELF segment mapping to map entire pages like ld.so. 

### DIFF
--- a/cle/__init__.py
+++ b/cle/__init__.py
@@ -9,6 +9,7 @@ import logging
 logging.getLogger("cle").addHandler(logging.NullHandler())
 
 # pylint: disable=wildcard-import
+from .libc_utils import *
 from .loader import *
 from .memory import *
 from .errors import *

--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -63,6 +63,9 @@ class Region(object):
             return None
         return addr
 
+    def __repr__(self):
+        return '{}({})'.format(self.__class__, ', '.join(['{}=0x{:x}'.format(k, v) for k, v in self.__dict__.iteritems()]))
+
     @property
     def max_addr(self):
         """

--- a/cle/backends/elf.py
+++ b/cle/backends/elf.py
@@ -441,14 +441,14 @@ class ELF(MetaELF):
 
         if allocend > dataend:
             zero = dataend
-            zeroend = allocend
             zeropage = (zero + _DL_PAGESIZE - 1) & ~(_DL_PAGESIZE - 1)
 
             if zeropage > zero:
                 data = data[:zero - mapstart].ljust(zeropage - mapstart, '\0')
 
+            zeroend = ALIGN_UP(allocend, _DL_PAGESIZE) # mmap maps to the next page boundary
             if zeroend > zeropage:
-                data.ljust(zeroend - zeropage, '\0')
+                data = data.ljust(zeroend - mapstart, '\0')
 
         self.memory.add_backer(mapstart, data)
 

--- a/cle/backends/elf.py
+++ b/cle/backends/elf.py
@@ -422,8 +422,8 @@ class ELF(MetaELF):
         # see https://code.woboq.org/userspace/glibc/elf/dl-load.c.html#1066
         ph = seg.header
 
-        if ph.p_align & (_DL_PAGESIZE - 1) != 0:
-            raise CLEInvalidBinaryError("dl-load.c: ELF load command alignment not page-aligned")
+        #if ph.p_align & (_DL_PAGESIZE - 1) != 0:
+        #    raise CLEInvalidBinaryError("dl-load.c: ELF load command alignment not page-aligned")
 
         if (ph.p_vaddr - ph.p_offset) & (ph.p_align - 1) != 0:
             raise CLEInvalidBinaryError("dl-load.c: ELF load command address/offset not properly aligned")

--- a/cle/backends/elf.py
+++ b/cle/backends/elf.py
@@ -435,7 +435,6 @@ class ELF(MetaELF):
         allocend = ph.p_vaddr + ph.p_memsz
 
         mapoff = ALIGN_DOWN(ph.p_offset, _DL_PAGESIZE)
-        fileend = ph.p_offset + ph.p_filesz
 
         # see https://code.woboq.org/userspace/glibc/elf/dl-map-segments.h.html#88
         data = get_mmaped_data(seg.stream, mapoff, mapend - mapstart)
@@ -446,7 +445,7 @@ class ELF(MetaELF):
             zeropage = (zero + _DL_PAGESIZE - 1) & ~(_DL_PAGESIZE - 1)
 
             if zeropage > zero:
-                data = data[:zero].ljust(zeropage, '\0')
+                data = data[:zero - mapstart].ljust(zeropage - mapstart, '\0')
 
             if zeroend > zeropage:
                 data.ljust(zeroend - zeropage, '\0')

--- a/cle/libc_utils.py
+++ b/cle/libc_utils.py
@@ -2,6 +2,7 @@ from .errors import CLEError
 
 _DL_PAGESIZE = 0x1000
 
+
 # https://code.woboq.org/userspace/glibc/include/libc-pointer-arith.h.html#43
 def ALIGN_DOWN(base, size):
     return base & -size
@@ -49,11 +50,10 @@ int main(int argc, char* argv[])
 }"""
 def get_mmaped_data(stream, offset, length):
     if offset % _DL_PAGESIZE != 0:
-        raise CLEError("libc helper for mmap: Invalid page offset, should be multiple of page size! Stream {}, offset {}, length".format(stream, offset, length))
+        raise CLEError("libc helper for mmap: Invalid page offset, should be multiple of page size! Stream {}, offset {}, length: {}".format(stream, offset, length))
 
     read_length = ALIGN_UP(length, _DL_PAGESIZE)
     stream.seek(offset)
     data = stream.read(read_length)
     return data.ljust(read_length, '\0')
-
 

--- a/cle/libc_utils.py
+++ b/cle/libc_utils.py
@@ -1,0 +1,59 @@
+from .errors import CLEError
+
+_DL_PAGESIZE = 0x1000
+
+# https://code.woboq.org/userspace/glibc/include/libc-pointer-arith.h.html#43
+def ALIGN_DOWN(base, size):
+    return base & -size
+
+
+# https://code.woboq.org/userspace/glibc/include/libc-pointer-arith.h.html#50
+def ALIGN_UP(base, size):
+    return ALIGN_DOWN(base + size - 1, size)
+
+# To verify the mmap behavior you can compile and run the following program. Fact is that mmap file mappings
+# always map in the entire page into memory from the file if available. If not, it gets zero padded
+"""#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+
+void make_test_file()
+{
+    void* data = (void*)0xdead0000;
+    int fd = open("./test.data", O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    for (int i = 0; i < 0x1800; i += sizeof(void*)) // Only write 1 1/2 pages worth
+    {
+        write(fd, &data, sizeof(void*));
+        data += sizeof(void*);
+    }
+    close(fd);
+}
+int main(int argc, char* argv[])
+{
+    make_test_file();
+
+    int fd = open("./test.data", O_RDONLY);
+    unsigned char* mapping = mmap(NULL, 0x123, PROT_READ, MAP_PRIVATE, fd, 4096);
+
+    for (int i=0; i < 0x1000; i++)
+    {
+        printf("%02x ", mapping[i]);
+        if (i % sizeof(void*) == (sizeof(void*) - 1))
+            printf("| ");
+        if (i % 16 == 15)
+            printf("\n");
+    }
+}"""
+def get_mmaped_data(stream, offset, length):
+    if offset % _DL_PAGESIZE != 0:
+        raise CLEError("libc helper for mmap: Invalid page offset, should be multiple of page size! Stream {}, offset {}, length".format(stream, offset, length))
+
+    read_length = ALIGN_UP(length, _DL_PAGESIZE)
+    stream.seek(offset)
+    data = stream.read(read_length)
+    return data.ljust(read_length, '\0')
+
+

--- a/cle/libc_utils.py
+++ b/cle/libc_utils.py
@@ -14,6 +14,7 @@ def ALIGN_UP(base, size):
 
 # To verify the mmap behavior you can compile and run the following program. Fact is that mmap file mappings
 # always map in the entire page into memory from the file if available. If not, it gets zero padded
+# pylint: disable=pointless-string-statement
 """#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -56,4 +57,3 @@ def get_mmaped_data(stream, offset, length):
     stream.seek(offset)
     data = stream.read(read_length)
     return data.ljust(read_length, '\0')
-

--- a/cle/memory.py
+++ b/cle/memory.py
@@ -189,7 +189,8 @@ class Clemory(object):
         """
         Read addr stored in memory as a series of bytes starting at `where`.
         """
-        return struct.unpack(self._arch.struct_fmt(), ''.join(self.read_bytes(where, self._arch.bytes, orig=orig)))[0]
+        by = ''.join(self.read_bytes(where, self._arch.bytes, orig=orig))
+        return struct.unpack(self._arch.struct_fmt(), by)[0]
 
     def write_addr_at(self, where, addr):
         """


### PR DESCRIPTION
This allows angr to pass the self-protection checks on YAN01_00015