### PR TITLE
Fixing ELF file class (32-bit or 64-bit) reading

### DIFF
--- a/cle/backends/elf.py
+++ b/cle/backends/elf.py
@@ -143,7 +143,7 @@ class ELF(MetaELF):
         try:
             self.reader = elffile.ELFFile(self.binary_stream)
         except ELFError:
-            self.binary_stream.seek(5)
+            self.binary_stream.seek(4)
             ty = self.binary_stream.read(1)
             if ty not in ('\1', '\2'):
                 raise CLECompatibilityError


### PR DESCRIPTION
As discussed a long time ago, we should read the 4th byte to identify the file class, not the 5th byte which specifies file endianness.