### PR TITLE
Adding objfile name to Loader._parse_gdb_map() function

### DIFF
--- a/cle/loader.py
+++ b/cle/loader.py
@@ -538,7 +538,7 @@ class Loader(object):
                 # Get rid of all metadata, just extract lines containing addresses
                 if "0x" not in line_items[0]:
                     continue
-                elif "linux-vdso" in line_items[-1]:
+                elif any(s in line_items[-1] for s in ("linux-vdso", "[vdso]")):
                     continue
                 addr, objfile = int(line_items[0], 16), line_items[-1].strip()
 


### PR DESCRIPTION
 Due to Linux kernel updates, as discussed with @rhelmot . Sorry for the belated PR