### PR TITLE
Loader: ELF non-zero based PIC binaries support

### DIFF
--- a/cle/backends/pe.py
+++ b/cle/backends/pe.py
@@ -81,9 +81,15 @@ class PESection(Section):
     """
     Represents a section for the PE format.
     """
-    def __init__(self, name, offset, vaddr, size, chars):
-        super(PESection, self).__init__(name, offset, vaddr, size)
-        self.characteristics = chars
+    def __init__(self, pe_section, remap_offset=0):
+        super(PESection, self).__init__(
+            pe_section.Name,
+            pe_section.Misc_PhysicalAddress,
+            pe_section.VirtualAddress + remap_offset,
+            pe_section.Misc_VirtualSize,
+        )
+
+        self.characteristics = pe_section.Characteristics
 
     #
     # Public properties
@@ -248,11 +254,7 @@ class PE(Backend):
         """
 
         for pe_section in self._pe.sections:
-            section = PESection(
-                pe_section.Name, pe_section.Misc_PhysicalAddress,
-                AT.from_rva(pe_section.VirtualAddress, self).to_mva(),
-                pe_section.Misc_VirtualSize, pe_section.Characteristics
-            )
+            section = PESection(pe_section, remap_offset=self.linked_base)
             self.sections.append(section)
             self.sections_map[section.name] = section
 

--- a/cle/backends/relocations/generic_elf.py
+++ b/cle/backends/relocations/generic_elf.py
@@ -16,8 +16,7 @@ class GenericTLSModIdReloc(Relocation):
             if not self.resolve_symbol(solist):
                 return False
             self.owner_obj.memory.write_addr_at(
-                AT.from_lva(self.addr, self.resolvedby.owner_obj).to_rva(),
-                self.resolvedby.owner_obj.tls_module_id)
+                AT.from_lva(self.addr, self.owner_obj).to_rva(), self.resolvedby.owner_obj.tls_module_id)
         return True
 
 


### PR DESCRIPTION
Last fixes for #65.
As _**angr/angr**:wip/the_end_times_ is broken now, I've tested it with app from ARM32 prelinked environment and also with my state of _**angr/angr**:feat/elf-non-zero-based-pic-support_ branch. It looks like everything is working like expected.