### PR TITLE
Add ARM relocations

### DIFF
--- a/cle/backends/relocations/arm.py
+++ b/cle/backends/relocations/arm.py
@@ -1,15 +1,112 @@
 from . import generic
 from . import generic_elf
+import logging
+from . import Relocation
+from ...address_translator import AT
 
-# http://infocenter.arm.com/help/topic/com.arm.doc.ihi0044e/IHI0044E_aaelf.pdf
+l = logging.getLogger('cle.relocations.arm')
 arch = 'ARM'
 
-R_ARM_COPY = generic.GenericCopyReloc
-R_ARM_GLOB_DAT = generic.GenericJumpslotReloc
-R_ARM_JUMP_SLOT = generic.GenericJumpslotReloc
-R_ARM_RELATIVE = generic.GenericRelativeReloc
-R_ARM_ABS32 = generic.GenericAbsoluteAddendReloc
+# Reference: "ELF for the ARM Architecture ABI r2.10"
+# http://infocenter.arm.com/help/topic/com.arm.doc.ihi0044e/IHI0044E_aaelf.pdf
 
-R_ARM_TLS_DTPMOD32 = generic_elf.GenericTLSModIdReloc
-R_ARM_TLS_DTPOFF32 = generic_elf.GenericTLSDoffsetReloc
-R_ARM_TLS_TPOFF32 = generic_elf.GenericTLSOffsetReloc
+
+class ARMRelocation:
+    """
+    Some shared functionality for ARM relocations.
+    """
+    @staticmethod
+    def _applyReloc(inst, result, mask=0xFFFFFFFF):
+        assert not (result & ~mask)
+        return ((inst & ~mask) | (result & mask))
+        
+    @staticmethod
+    def _isThumbFunc(symbol, addr):
+        return (addr % 2 == 1) and symbol.is_function
+
+class R_ARM_CALL(Relocation):
+    """
+    Relocate R_ARM_CALL symbols via instruction modification. It additionally
+    handles R_ARM_PC24 and R_ARM_JUMP24. The former is deprecated and is now
+    just the same as R_ARM_CALL. 
+    
+    R_ARM_JUMP24 doesn't need the Thumb check. Technically, if the Thumb check
+    succeeds on R_ARM_JUMP24, it's a bad call that shouldn't have been generated
+    by the linker, so we may as well as just treat it like R_ARM_CALL.
+    
+    Class: Static
+    Type: ARM (R_ARM_CALL, R_ARM_JUMP24); Deprecated (R_ARM_PC24)
+    Code: 1 (R_ARM_PC24), 28 (R_ARM_CALL), 29 (R_ARM_JUMP24)
+    Operation: ((S + A) | T) - P
+        - S is the address of the symbol
+        - A is the addend
+        - P is the target location (place being relocated)
+        - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
+    """
+        
+    @property
+    def value(self):
+        P = self.rebased_addr                           # Location of this instruction
+        A = inst = self.addend                          # The instruction
+        S = self.resolvedby.rebased_addr                # The symbol's "value", where it points to
+        T = ARMRelocation._isThumbFunc(self.symbol, S)
+        
+        if inst & 0x00800000: A |= 0xFF000000           # Sign extend to 32-bits
+        result = ((S + A) | T) - P                      # Do the initial work
+        imm24 = (result & 0x03FFFFFC) >> 2              # Sign_extend(inst[25:2])
+        
+        if T:                                           # Do Thumb relocation
+            mask = 0xFF000000
+            bit_h = (result & 0x02) >> 1
+            result = ARMRelocation._applyReloc(inst, (0xFA | bit_h), mask)
+        else:                                           # Do ARM relocation
+            mask = 0xFFFFFF
+            result = ARMRelocation._applyReloc(inst, imm24, mask)
+            
+        self.owner_obj.memory.write_addr_at(AT.from_lva(self.addr, self.owner_obj).to_rva(), result)
+        l.debug("%s relocated as R_ARM_CALL/R_ARM_JUMP24 with new instruction: 0x%x", self.symbol.name, result)
+        return True
+     
+class R_ARM_PREL31(Relocation):
+    """
+    Relocate R_ARM_PREL31 symbols via instruction modification. The difference
+    between this and R_ARM_CALL/R_ARM_PC24/R_ARM_JUMP24 is that it's a data
+    relocation
+    
+    Class: Static
+    Type: Data
+    Code: 42
+    Operation: ((S + A) | T) - P
+        - S is the address of the symbol
+        - A is the addend
+        - P is the target location (place being relocated)
+        - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
+    """
+    @property
+    def value(self):
+        P = self.rebased_addr                           # Location of this instruction
+        A = self.addend                                 # The instruction
+        S = self.resolvedby.rebased_addr                # The symbol's "value", where it points to
+        T = ARMRelocation._isThumbFunc(self.symbol, S)
+        
+        if A & 0x01000000: A |= 0xF1000000              # Sign extend 31-bits
+        result = ((S + A) | T) - P                      # Do the initial work
+        mask = 0x7FFFFFFF
+        rel31 = result & mask
+        result = ARMRelocation._applyReloc(A, rel31, mask)
+        l.debug("%s relocated as R_ARM_PREL31 to: 0x%x", self.symbol.name, result)
+        return result
+
+
+R_ARM_COPY          = generic.GenericCopyReloc
+R_ARM_GLOB_DAT      = generic.GenericJumpslotReloc
+R_ARM_JUMP_SLOT     = generic.GenericJumpslotReloc
+R_ARM_RELATIVE      = generic.GenericRelativeReloc
+R_ARM_ABS32         = generic.GenericAbsoluteAddendReloc
+
+R_ARM_TLS_DTPMOD32  = generic_elf.GenericTLSModIdReloc
+R_ARM_TLS_DTPOFF32  = generic_elf.GenericTLSDoffsetReloc
+R_ARM_TLS_TPOFF32   = generic_elf.GenericTLSOffsetReloc
+
+R_ARM_JUMP24        = R_ARM_CALL
+R_ARM_PC24          = R_ARM_CALL

--- a/cle/backends/relocations/arm.py
+++ b/cle/backends/relocations/arm.py
@@ -1,6 +1,6 @@
+import logging
 from . import generic
 from . import generic_elf
-import logging
 from . import Relocation
 from ...address_translator import AT
 
@@ -10,30 +10,35 @@ arch = 'ARM'
 # Reference: "ELF for the ARM Architecture ABI r2.10"
 # http://infocenter.arm.com/help/topic/com.arm.doc.ihi0044e/IHI0044E_aaelf.pdf
 
+def _applyReloc(inst, result, mask=0xFFFFFFFF):
+    """
+    Applies the specified mask to the relocation and verifies that the mask
+    is valid for the given result.
+    """
+    try:
+        assert not (result & ~mask)                 # pylint: disable=superfluous-parens
+    except AssertionError as e:
+        l.warning("Relocation failed: %r", e)
+        return 0                                    # worst case, you hook it yourself
+    return ((inst & ~mask) | (result & mask))       # pylint: disable=superfluous-parens
 
-class ARMRelocation:
+def _isThumbFunc(symbol, addr):
     """
-    Some shared functionality for ARM relocations.
+    Checks whether the provided symbol and address is a Thumb function by
+    verifying the LSB is 1 and the symbol is STT_FUNC.
     """
-    @staticmethod
-    def _applyReloc(inst, result, mask=0xFFFFFFFF):
-        assert not (result & ~mask)
-        return ((inst & ~mask) | (result & mask))
-        
-    @staticmethod
-    def _isThumbFunc(symbol, addr):
-        return (addr % 2 == 1) and symbol.is_function
+    return (addr % 2 == 1) and symbol.is_function
 
 class R_ARM_CALL(Relocation):
     """
     Relocate R_ARM_CALL symbols via instruction modification. It additionally
     handles R_ARM_PC24 and R_ARM_JUMP24. The former is deprecated and is now
-    just the same as R_ARM_CALL. 
-    
+    just the same as R_ARM_CALL.
+
     R_ARM_JUMP24 doesn't need the Thumb check. Technically, if the Thumb check
     succeeds on R_ARM_JUMP24, it's a bad call that shouldn't have been generated
     by the linker, so we may as well as just treat it like R_ARM_CALL.
-    
+
     Class: Static
     Type: ARM (R_ARM_CALL, R_ARM_JUMP24); Deprecated (R_ARM_PC24)
     Code: 1 (R_ARM_PC24), 28 (R_ARM_CALL), 29 (R_ARM_JUMP24)
@@ -43,36 +48,36 @@ class R_ARM_CALL(Relocation):
         - P is the target location (place being relocated)
         - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
-        
+
     @property
     def value(self):
         P = self.rebased_addr                           # Location of this instruction
         A = inst = self.addend                          # The instruction
         S = self.resolvedby.rebased_addr                # The symbol's "value", where it points to
-        T = ARMRelocation._isThumbFunc(self.symbol, S)
-        
+        T = _isThumbFunc(self.symbol, S)
+
         if inst & 0x00800000: A |= 0xFF000000           # Sign extend to 32-bits
         result = ((S + A) | T) - P                      # Do the initial work
         imm24 = (result & 0x03FFFFFC) >> 2              # Sign_extend(inst[25:2])
-        
+
         if T:                                           # Do Thumb relocation
             mask = 0xFF000000
             bit_h = (result & 0x02) >> 1
-            result = ARMRelocation._applyReloc(inst, (0xFA | bit_h), mask)
+            result = _applyReloc(inst, (0xFA | bit_h), mask)
         else:                                           # Do ARM relocation
             mask = 0xFFFFFF
-            result = ARMRelocation._applyReloc(inst, imm24, mask)
-            
+            result = _applyReloc(inst, imm24, mask)
+
         self.owner_obj.memory.write_addr_at(AT.from_lva(self.addr, self.owner_obj).to_rva(), result)
-        l.debug("%s relocated as R_ARM_CALL/R_ARM_JUMP24 with new instruction: 0x%x", self.symbol.name, result)
+        l.debug("%s relocated as R_ARM_CALL with new instruction: 0x%x", self.symbol.name, result)
         return True
-     
+
 class R_ARM_PREL31(Relocation):
     """
     Relocate R_ARM_PREL31 symbols via instruction modification. The difference
     between this and R_ARM_CALL/R_ARM_PC24/R_ARM_JUMP24 is that it's a data
     relocation
-    
+
     Class: Static
     Type: Data
     Code: 42
@@ -82,28 +87,28 @@ class R_ARM_PREL31(Relocation):
         - P is the target location (place being relocated)
         - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
-    
+
     @property
     def value(self):
         P = self.rebased_addr                           # Location of this instruction
         A = self.addend                                 # The instruction
         S = self.resolvedby.rebased_addr                # The symbol's "value", where it points to
-        T = ARMRelocation._isThumbFunc(self.symbol, S)
-        
+        T = _isThumbFunc(self.symbol, S)
+
         if A & 0x01000000: A |= 0xF1000000              # Sign extend 31-bits
         result = ((S + A) | T) - P                      # Do the initial work
         mask = 0x7FFFFFFF
         rel31 = result & mask
-        result = ARMRelocation._applyReloc(A, rel31, mask)
+        result = _applyReloc(A, rel31, mask)
         l.debug("%s relocated as R_ARM_PREL31 to: 0x%x", self.symbol.name, result)
         return result
 
 class R_ARM_REL32(Relocation):
     """
-    Relocate R_ARM_REL32 symbols. This is essentially the same as 
+    Relocate R_ARM_REL32 symbols. This is essentially the same as
     generic.GenericPCRelativeAddendReloc with the addition of a check
     for whether or not the target is Thumb.
-    
+
     Class: Static
     Type: Data
     Code: 3
@@ -113,22 +118,23 @@ class R_ARM_REL32(Relocation):
         - P is the target location (place being relocated)
         - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
-    
+
     @property
     def value(self):
         P = self.rebased_addr                           # Location of this instruction
         A = self.addend                                 # The instruction
         S = self.resolvedby.rebased_addr                # The symbol's "value", where it points to
-        T = ARMRelocation._isThumbFunc(self.symbol, S)
-        result = ((S + A) | T) - P        
+        T = _isThumbFunc(self.symbol, S)
+        result = ((S + A) | T) - P
+        l.debug("%s relocated as R_ARM_REL32 to: 0x%x", self.symbol.name, result)
         return result
 
 class R_ARM_ABS32(Relocation):
     """
-    Relocate R_ARM_REL32 symbols. This is essentially the same as 
+    Relocate R_ARM_REL32 symbols. This is essentially the same as
     generic.GenericAbsoluteAddendReloc with the addition of a check
     for whether or not the target is Thumb.
-    
+
     Class: Static
     Type: Data
     Code: 3
@@ -137,15 +143,16 @@ class R_ARM_ABS32(Relocation):
         - A is the addend
         - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
-    
+
     @property
     def value(self):
         A = self.addend                                 # The instruction
         S = self.resolvedby.rebased_addr                # The symbol's "value", where it points to
-        T = ARMRelocation._isThumbFunc(self.symbol, S)
+        T = _isThumbFunc(self.symbol, S)
         result = (S + A) | T
+        l.debug("%s relocated as R_ARM_ABS32 to: 0x%x", self.symbol.name, result)
         return result
-        
+
 R_ARM_COPY          = generic.GenericCopyReloc
 R_ARM_GLOB_DAT      = generic.GenericJumpslotReloc
 R_ARM_JUMP_SLOT     = generic.GenericJumpslotReloc

--- a/cle/backends/relocations/arm.py
+++ b/cle/backends/relocations/arm.py
@@ -82,6 +82,7 @@ class R_ARM_PREL31(Relocation):
         - P is the target location (place being relocated)
         - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
+    
     @property
     def value(self):
         P = self.rebased_addr                           # Location of this instruction
@@ -97,12 +98,60 @@ class R_ARM_PREL31(Relocation):
         l.debug("%s relocated as R_ARM_PREL31 to: 0x%x", self.symbol.name, result)
         return result
 
+class R_ARM_REL32(Relocation):
+    """
+    Relocate R_ARM_REL32 symbols. This is essentially the same as 
+    generic.GenericPCRelativeAddendReloc with the addition of a check
+    for whether or not the target is Thumb.
+    
+    Class: Static
+    Type: Data
+    Code: 3
+    Operation: ((S + A) | T) - P
+        - S is the address of the symbol
+        - A is the addend
+        - P is the target location (place being relocated)
+        - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
+    """
+    
+    @property
+    def value(self):
+        P = self.rebased_addr                           # Location of this instruction
+        A = self.addend                                 # The instruction
+        S = self.resolvedby.rebased_addr                # The symbol's "value", where it points to
+        T = ARMRelocation._isThumbFunc(self.symbol, S)
+        result = ((S + A) | T) - P        
+        return result
 
+class R_ARM_ABS32(Relocation):
+    """
+    Relocate R_ARM_REL32 symbols. This is essentially the same as 
+    generic.GenericAbsoluteAddendReloc with the addition of a check
+    for whether or not the target is Thumb.
+    
+    Class: Static
+    Type: Data
+    Code: 3
+    Operation: (S + A) | T
+        - S is the address of the symbol
+        - A is the addend
+        - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
+    """
+    
+    @property
+    def value(self):
+        A = self.addend                                 # The instruction
+        S = self.resolvedby.rebased_addr                # The symbol's "value", where it points to
+        T = ARMRelocation._isThumbFunc(self.symbol, S)
+        result = (S + A) | T
+        return result
+        
 R_ARM_COPY          = generic.GenericCopyReloc
 R_ARM_GLOB_DAT      = generic.GenericJumpslotReloc
 R_ARM_JUMP_SLOT     = generic.GenericJumpslotReloc
 R_ARM_RELATIVE      = generic.GenericRelativeReloc
-R_ARM_ABS32         = generic.GenericAbsoluteAddendReloc
+R_ARM_ABS32_NOI     = generic.GenericAbsoluteAddendReloc
+R_ARM_REL32_NOI     = generic.GenericPCRelativeAddendReloc
 
 R_ARM_TLS_DTPMOD32  = generic_elf.GenericTLSModIdReloc
 R_ARM_TLS_DTPOFF32  = generic_elf.GenericTLSDoffsetReloc


### PR DESCRIPTION
Okay, I've run this against enough binaries and all the tests so I feel comfortable submitting. I figured I'd get it in now before more big changes come down.  

This adds support for R_ARM_CALL, R_ARM_JUMP24, R_ARM_PC24, R_ARM_PREL31, R_ARM_ABS32_NOI and R_ARM_REL32_NOI. Several are generally only seen in object files (or kernel modules). This resolves [my issue](https://github.com/angr/angr/issues/546) in angr.

Assuming @rhelmot agrees, this also fixes #74, allowing R_ARM_ABS32 to understand (likely rare, if not non-existent) odd-aligned non-Thumb relocations.

**EDIT:** Force-pushed to rebase on yesterday's changes and cleanup a bit with the last commit.