### PR TITLE
Change arch-generic relocs to real classes

### DIFF
--- a/cle/backends/relocations/amd64.py
+++ b/cle/backends/relocations/amd64.py
@@ -3,16 +3,32 @@ from . import generic_elf
 
 arch = 'AMD64'
 
-R_X86_64_64 = generic.GenericAbsoluteAddendReloc
-R_X86_64_COPY = generic.GenericCopyReloc
-R_X86_64_GLOB_DAT = generic.GenericJumpslotReloc
-R_X86_64_JUMP_SLOT = generic.GenericJumpslotReloc
-R_X86_64_RELATIVE = generic.GenericRelativeReloc
-R_X86_64_IRELATIVE = generic_elf.GenericIRelativeReloc
+class R_X86_64_64(generic.GenericAbsoluteAddendReloc):
+    pass
 
-R_X86_64_DTPMOD64 = generic_elf.GenericTLSModIdReloc
-R_X86_64_DTPOFF64 = generic_elf.GenericTLSDoffsetReloc
-R_X86_64_TPOFF64 = generic_elf.GenericTLSOffsetReloc
+class R_X86_64_COPY(generic.GenericCopyReloc):
+    pass
+
+class R_X86_64_RELATIVE(generic.GenericRelativeReloc):
+    pass
+
+class R_X86_64_IRELATIVE(generic_elf.GenericIRelativeReloc):
+    pass
+
+class R_X86_64_GLOB_DAT(generic.GenericJumpslotReloc):
+    pass
+
+class R_X86_64_JUMP_SLOT(generic.GenericJumpslotReloc):
+    pass
+
+class R_X86_64_DTPMOD64(generic_elf.GenericTLSModIdReloc):
+    pass
+
+class R_X86_64_DTPOFF64(generic_elf.GenericTLSDoffsetReloc):
+    pass
+
+class R_X86_64_TPOFF64(generic_elf.GenericTLSOffsetReloc):
+    pass
 
 class R_X86_64_PC32(generic.RelocTruncate32Mixin, generic.GenericPCRelativeAddendReloc):
     check_sign_extend = True

--- a/cle/backends/relocations/arm.py
+++ b/cle/backends/relocations/arm.py
@@ -153,16 +153,35 @@ class R_ARM_ABS32(Relocation):
         l.debug("%s relocated as R_ARM_ABS32 to: 0x%x", self.symbol.name, result)
         return result
 
-R_ARM_COPY          = generic.GenericCopyReloc
-R_ARM_GLOB_DAT      = generic.GenericJumpslotReloc
-R_ARM_JUMP_SLOT     = generic.GenericJumpslotReloc
-R_ARM_RELATIVE      = generic.GenericRelativeReloc
-R_ARM_ABS32_NOI     = generic.GenericAbsoluteAddendReloc
-R_ARM_REL32_NOI     = generic.GenericPCRelativeAddendReloc
+class R_ARM_COPY(generic.GenericCopyReloc):
+    pass
 
-R_ARM_TLS_DTPMOD32  = generic_elf.GenericTLSModIdReloc
-R_ARM_TLS_DTPOFF32  = generic_elf.GenericTLSDoffsetReloc
-R_ARM_TLS_TPOFF32   = generic_elf.GenericTLSOffsetReloc
+class R_ARM_GLOB_DAT(generic.GenericJumpslotReloc):
+    pass
 
-R_ARM_JUMP24        = R_ARM_CALL
-R_ARM_PC24          = R_ARM_CALL
+class R_ARM_JUMP_SLOT(generic.GenericJumpslotReloc):
+    pass
+
+class R_ARM_RELATIVE(generic.GenericRelativeReloc):
+    pass
+
+class R_ARM_ABS32_NOI(generic.GenericAbsoluteAddendReloc):
+    pass
+
+class R_ARM_REL32_NOI(generic.GenericPCRelativeAddendReloc):
+    pass
+
+class R_ARM_TLS_DTPMOD32(generic_elf.GenericTLSModIdReloc):
+    pass
+
+class R_ARM_TLS_DTPOFF32(generic_elf.GenericTLSDoffsetReloc):
+    pass
+
+class R_ARM_TLS_TPOFF32(generic_elf.GenericTLSOffsetReloc):
+    pass
+
+class R_ARM_JUMP24(R_ARM_CALL):
+    pass
+
+class R_ARM_PC24(R_ARM_CALL):
+    pass

--- a/cle/backends/relocations/arm64.py
+++ b/cle/backends/relocations/arm64.py
@@ -4,13 +4,29 @@ from . import generic_elf
 # http://infocenter.arm.com/help/topic/com.arm.doc.ihi0056b/IHI0056B_aaelf64.pdf
 arch = 'AARCH64'
 
-R_AARCH64_ABS64 = generic.GenericAbsoluteAddendReloc
-R_AARCH64_COPY = generic.GenericCopyReloc
-R_AARCH64_GLOB_DAT = generic.GenericJumpslotReloc
-R_AARCH64_JUMP_SLOT = generic.GenericJumpslotReloc
-R_AARCH64_RELATIVE = generic.GenericRelativeReloc
-R_AARCH64_IRELATIVE = generic_elf.GenericIRelativeReloc
+class R_AARCH64_ABS64(generic.GenericAbsoluteAddendReloc):
+    pass
 
-R_AARCH64_TLS_DTPREL = generic_elf.GenericTLSDoffsetReloc
-R_AARCH64_TLS_DTPMOD = generic_elf.GenericTLSModIdReloc
-R_AARCH64_TLS_TPREL = generic_elf.GenericTLSOffsetReloc
+class R_AARCH64_COPY(generic.GenericCopyReloc):
+    pass
+
+class R_AARCH64_GLOB_DAT(generic.GenericJumpslotReloc):
+    pass
+
+class R_AARCH64_JUMP_SLOT(generic.GenericJumpslotReloc):
+    pass
+
+class R_AARCH64_RELATIVE(generic.GenericRelativeReloc):
+    pass
+
+class R_AARCH64_IRELATIVE(generic_elf.GenericIRelativeReloc):
+    pass
+
+class R_AARCH64_TLS_DTPREL(generic_elf.GenericTLSDoffsetReloc):
+    pass
+
+class R_AARCH64_TLS_DTPMOD(generic_elf.GenericTLSModIdReloc):
+    pass
+
+class R_AARCH64_TLS_TPREL(generic_elf.GenericTLSOffsetReloc):
+    pass

--- a/cle/backends/relocations/i386.py
+++ b/cle/backends/relocations/i386.py
@@ -3,14 +3,32 @@ from . import generic_elf
 
 arch = 'X86'
 
-R_386_32 = generic.GenericAbsoluteAddendReloc
-R_386_PC32 = generic.GenericPCRelativeAddendReloc
-R_386_COPY = generic.GenericCopyReloc
-R_386_GLOB_DAT = generic.GenericJumpslotReloc
-R_386_JMP_SLOT = generic.GenericJumpslotReloc
-R_386_RELATIVE = generic.GenericRelativeReloc
-R_386_IRELATIVE = generic_elf.GenericIRelativeReloc
+class R_386_32(generic.GenericAbsoluteAddendReloc):
+    pass
 
-R_386_TLS_DTPMOD32 = generic_elf.GenericTLSModIdReloc
-R_386_TLS_TPOFF = generic_elf.GenericTLSOffsetReloc
-R_386_TLS_DTPOFF32 = generic_elf.GenericTLSDoffsetReloc
+class R_386_PC32(generic.GenericPCRelativeAddendReloc):
+    pass
+
+class R_386_COPY(generic.GenericCopyReloc):
+    pass
+
+class R_386_GLOB_DAT(generic.GenericJumpslotReloc):
+    pass
+
+class R_386_JMP_SLOT(generic.GenericJumpslotReloc):
+    pass
+
+class R_386_RELATIVE(generic.GenericRelativeReloc):
+    pass
+
+class R_386_IRELATIVE(generic_elf.GenericIRelativeReloc):
+    pass
+
+class R_386_TLS_DTPMOD32(generic_elf.GenericTLSModIdReloc):
+    pass
+
+class R_386_TLS_TPOFF(generic_elf.GenericTLSOffsetReloc):
+    pass
+
+class R_386_TLS_DTPOFF32(generic_elf.GenericTLSDoffsetReloc):
+    pass

--- a/cle/backends/relocations/mips.py
+++ b/cle/backends/relocations/mips.py
@@ -3,11 +3,23 @@ from . import generic_elf
 
 arch = 'MIPS32'
 
-R_MIPS_32 = generic.GenericAbsoluteAddendReloc
-R_MIPS_REL32 = generic.GenericRelativeReloc
-R_MIPS_JUMP_SLOT = generic.GenericAbsoluteReloc
-R_MIPS_GLOB_DAT = generic.GenericAbsoluteReloc
+class R_MIPS_32(generic.GenericAbsoluteAddendReloc):
+    pass
 
-R_MIPS_TLS_DTPMOD32 = generic_elf.GenericTLSModIdReloc
-R_MIPS_TLS_TPREL32 = generic_elf.GenericTLSOffsetReloc
-R_MIPS_TLS_DTPREL32 = generic_elf.GenericTLSDoffsetReloc
+class R_MIPS_REL32(generic.GenericRelativeReloc):
+    pass
+
+class R_MIPS_JUMP_SLOT(generic.GenericAbsoluteReloc):
+    pass
+
+class R_MIPS_GLOB_DAT(generic.GenericAbsoluteReloc):
+    pass
+
+class R_MIPS_TLS_DTPMOD32(generic_elf.GenericTLSModIdReloc):
+    pass
+
+class R_MIPS_TLS_TPREL32(generic_elf.GenericTLSOffsetReloc):
+    pass
+
+class R_MIPS_TLS_DTPREL32(generic_elf.GenericTLSDoffsetReloc):
+    pass

--- a/cle/backends/relocations/mips64.py
+++ b/cle/backends/relocations/mips64.py
@@ -3,10 +3,20 @@ from . import generic_elf
 
 arch = 'MIPS64'
 
-R_MIPS_64 = generic.GenericAbsoluteAddendReloc
-R_MIPS_REL32 = generic.GenericRelativeReloc
-R_MIPS_COPY = generic.GenericCopyReloc
+class R_MIPS_64(generic.GenericAbsoluteAddendReloc):
+    pass
 
-R_MIPS_TLS_DTPMOD64 = generic_elf.GenericTLSModIdReloc
-R_MIPS_TLS_DTPREL64 = generic_elf.GenericTLSDoffsetReloc
-R_MIPS_TLS_TPREL64 = generic_elf.GenericTLSOffsetReloc
+class R_MIPS_REL32(generic.GenericRelativeReloc):
+    pass
+
+class R_MIPS_COPY(generic.GenericCopyReloc):
+    pass
+
+class R_MIPS_TLS_DTPMOD64(generic_elf.GenericTLSModIdReloc):
+    pass
+
+class R_MIPS_TLS_DTPREL64(generic_elf.GenericTLSDoffsetReloc):
+    pass
+
+class R_MIPS_TLS_TPREL64(generic_elf.GenericTLSOffsetReloc):
+    pass

--- a/cle/backends/relocations/ppc.py
+++ b/cle/backends/relocations/ppc.py
@@ -4,12 +4,26 @@ from . import generic_elf
 # http://www.polyomino.org.uk/publications/2011/Power-Arch-32-bit-ABI-supp-1.0-Unified.pdf
 arch = 'PPC32'
 
-R_PPC_ADDR32 = generic.GenericAbsoluteAddendReloc
-R_PPC_COPY = generic.GenericCopyReloc
-R_PPC_GLOB_DAT = generic.GenericJumpslotReloc
-R_PPC_JMP_SLOT = generic.GenericJumpslotReloc
-R_PPC_RELATIVE = generic.GenericRelativeReloc
+class R_PPC_ADDR32(generic.GenericAbsoluteAddendReloc):
+    pass
 
-R_PPC_DTPMOD32 = generic_elf.GenericTLSModIdReloc
-R_PPC_DTPREL32 = generic_elf.GenericTLSDoffsetReloc
-R_PPC_TPREL32 = generic_elf.GenericTLSOffsetReloc
+class R_PPC_COPY(generic.GenericCopyReloc):
+    pass
+
+class R_PPC_GLOB_DAT(generic.GenericJumpslotReloc):
+    pass
+
+class R_PPC_JMP_SLOT(generic.GenericJumpslotReloc):
+    pass
+
+class R_PPC_RELATIVE(generic.GenericRelativeReloc):
+    pass
+
+class R_PPC_DTPMOD32(generic_elf.GenericTLSModIdReloc):
+    pass
+
+class R_PPC_DTPREL32(generic_elf.GenericTLSDoffsetReloc):
+    pass
+
+class R_PPC_TPREL32(generic_elf.GenericTLSOffsetReloc):
+    pass

--- a/cle/backends/relocations/ppc64.py
+++ b/cle/backends/relocations/ppc64.py
@@ -24,11 +24,23 @@ class R_PPC64_JMP_SLOT(Relocation):
             self.owner_obj.memory.write_addr_at(self.relative_addr, self.resolvedby.rebased_addr)
         return True
 
-R_PPC64_RELATIVE = generic.GenericRelativeReloc
-R_PPC64_IRELATIVE = generic_elf.GenericIRelativeReloc
-R_PPC64_ADDR64 = generic.GenericAbsoluteAddendReloc
-R_PPC64_GLOB_DAT = generic.GenericJumpslotReloc
+class R_PPC64_RELATIVE(generic.GenericRelativeReloc):
+    pass
 
-R_PPC64_DTPMOD64 = generic_elf.GenericTLSModIdReloc
-R_PPC64_DTPREL64 = generic_elf.GenericTLSDoffsetReloc
-R_PPC64_TPREL64 = generic_elf.GenericTLSOffsetReloc
+class R_PPC64_IRELATIVE(generic_elf.GenericIRelativeReloc):
+    pass
+
+class R_PPC64_ADDR64(generic.GenericAbsoluteAddendReloc):
+    pass
+
+class R_PPC64_GLOB_DAT(generic.GenericJumpslotReloc):
+    pass
+
+class R_PPC64_DTPMOD64(generic_elf.GenericTLSModIdReloc):
+    pass
+
+class R_PPC64_DTPREL64(generic_elf.GenericTLSDoffsetReloc):
+    pass
+
+class R_PPC64_TPREL64(generic_elf.GenericTLSOffsetReloc):
+    pass


### PR DESCRIPTION
Rather than using type aliases, this creates actual classes for all of the generic relocations. The point of this is to allow something like `type(project.main_obj.relocs[0]).__name__` to return `R_X86_64_JUMP_SLOT` or `R_X86_64_GLOB_DAT` rather than `GenericJumpslotReloc`. There was no other reliable way to get the actual relocation type/name through a standard interface; you'd have to use `elftools` or `pefile` to manually look it up.

This doesn't resolve the issue with Windows PE binaries though, since that interface is completely different.