### PR TITLE
elf: provide method to access known symbols in an object

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -224,6 +224,17 @@ class ELF(MetaELF):
         else:
             raise CLEError("Bad symbol identifier: %r" % (symid,))
 
+    @property
+    def symbols(self):
+        """
+        Returns an iterator of the (known) symbols in this object.
+
+        Note that this may return a subset of all symbols in an object since it is not always possible
+        to find all available symbols. When new symbols are accessed more symbols of the object may
+        become known.
+        """
+        return self._symbol_cache.itervalues()
+
     #
     # Private Methods
     #


### PR DESCRIPTION
This function does not guarantee to return all the symbols in an object, as
that may be hard or impossible to compute. Instead it only promises to return
a subset of all symbols.

For objects which have section headers (such as non-stripped binaries), this set
should be complete though, because we register all symbols from the section headers
in the ELF class `__init__`.

I made this an iterator because the set of symbols may be very large for libraries exposing many functions. I can make it a list instead though as well if that is preferred.