### PR TITLE
Fix problem in arm binaries R_ARM_CALL resolution

### DIFF
--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -68,7 +68,7 @@ class R_ARM_CALL(ELFReloc):
 
         self.owner_obj.memory.write_addr_at(self.relative_addr, result)
         l.debug("%s relocated as R_ARM_CALL with new instruction: %#x", self.symbol.name, result)
-        return True
+        return result
 
 class R_ARM_PREL31(ELFReloc):
     """

--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -66,7 +66,6 @@ class R_ARM_CALL(ELFReloc):
             mask = 0xFFFFFF
             result = _applyReloc(inst, imm24, mask)
 
-        self.owner_obj.memory.write_addr_at(self.relative_addr, result)
         l.debug("%s relocated as R_ARM_CALL with new instruction: %#x", self.symbol.name, result)
         return result
 


### PR DESCRIPTION
Before all the symbols of type R_ARM_CALL were resolved with 0x1 because the method "value" in backend/elf/relocation/arm.py always returned True instead of the actual result (typo?).
Now the method returns the correct result.

Signed-off-by: Sebastiano Mariani <mariani.sebastiano@gmail.com>