### PR TITLE
Blob: The custom base address shouldn't be ignored if an offset is specified.

### DIFF
--- a/cle/backends/blob.py
+++ b/cle/backends/blob.py
@@ -46,7 +46,7 @@ class Blob(Backend):
                 l.error("You can't specify both custom_offset and segments. Taking only the segments data")
             else:
                 self.binary_stream.seek(0, 2)
-                segments = [(custom_offset, 0, self.binary_stream.tell() - custom_offset)]
+                segments = [(custom_offset, self.linked_base, self.binary_stream.tell() - custom_offset)]
         else:
             if segments is not None:
                 pass

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -1,0 +1,54 @@
+
+import nose
+import os
+
+import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                         os.path.join('..', '..', 'binaries'))
+
+
+def test_blob_0():
+
+    BASE_ADDR = 0x8000000
+    ENTRYPOINT = 0x8001337
+
+    blob_file = os.path.join(TEST_BASE, 'tests', 'i386', 'all')
+    ld = cle.Loader(blob_file, main_opts={
+        'backend': 'blob',
+        'custom_base_addr': BASE_ADDR,
+        'custom_entry_point': ENTRYPOINT,
+        'custom_arch': "ARM",
+    })
+
+    nose.tools.assert_equal(ld.main_object.linked_base, BASE_ADDR)
+    nose.tools.assert_equal(ld.main_object.mapped_base, BASE_ADDR)
+    nose.tools.assert_equal(ld.main_object.min_addr, BASE_ADDR)
+    nose.tools.assert_equal(ld.main_object.entry, ENTRYPOINT)
+
+
+def test_blob_1():
+
+    # Make sure the base address behaves as expected regardless of whether custom_offset is specified or not.
+
+    BASE_ADDR = 0x8000000
+    ENTRYPOINT = 0x8001337
+
+    blob_file = os.path.join(TEST_BASE, 'tests', 'i386', 'all')
+    ld = cle.Loader(blob_file, main_opts={
+        'backend': 'blob',
+        'custom_base_addr': BASE_ADDR,
+        'custom_entry_point': ENTRYPOINT,
+        'custom_arch': "ARM",
+        'custom_offset': 0x200,
+    })
+
+    nose.tools.assert_equal(ld.main_object.linked_base, BASE_ADDR)
+    nose.tools.assert_equal(ld.main_object.mapped_base, BASE_ADDR)
+    nose.tools.assert_equal(ld.main_object.min_addr, BASE_ADDR)
+    nose.tools.assert_equal(ld.main_object.entry, ENTRYPOINT)
+
+
+if __name__ == "__main__":
+    test_blob_0()
+    test_blob_1()


### PR DESCRIPTION
Thanks @XingweiLin for reporting this bug.