### PR TITLE
Fix formula used to compute the target address of the symbol R_ARM_CALL

### DIFF
--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -55,8 +55,8 @@ class R_ARM_CALL(ELFReloc):
         T = _isThumbFunc(self.symbol, S)
 
         if inst & 0x00800000: A |= 0xFF000000           # Sign extend to 32-bits
-        result = ((S + A) | T) - P                      # Do the initial work
-        imm24 = (result & 0x03FFFFFC) >> 2              # Sign_extend(inst[25:2])
+        result = ((S + (A << 2)) | T) - P               # Do the initial work
+        imm24 = (result & 0x03FFFFFE) >> 2              # Sign_extend(inst[25:2])
 
         if T:                                           # Do Thumb relocation
             mask = 0xFF000000


### PR DESCRIPTION
The formula used before returned a wrong target address (correct_target + 4) because of a missing operation

Signed-off-by: Sebastiano Mariani <mariani.sebastiano@gmail.com>