### PR TITLE
demangled_name prop returns the name if symbol is not mangled

### DIFF
--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -123,7 +123,7 @@ class Symbol(object):
             if demangled:
                 return demangled[0]
 
-        return None
+        return self.name
 
     def resolve_forwarder(self):
         """


### PR DESCRIPTION
Oneliner.
symbol.demangled_name should return the normal name if the name is not mangled.