### PR TITLE
Name demangling now through ctypes instead of external c++filt

### DIFF
--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -123,7 +123,7 @@ class Symbol(object):
             if demangled:
                 return demangled[0]
 
-        return None
+        return self.name
 
     def resolve_forwarder(self):
         """

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -121,6 +121,13 @@ class Symbol(object):
         """
         return self
 
+    def _find_any_lib(*choices):
+    for choice in choices:
+        lib = ctypes.util.find_library(choice)
+        if lib is not None:
+            return lib
+    raise Exception("Could not find any libraries for {}".format(choices))
+
     libc = ctypes.CDLL(_find_any_lib('c'))
     libc.free.argtypes = [ctypes.c_void_p]
 
@@ -157,11 +164,3 @@ class Symbol(object):
             raise Exception("One of the arguments to name demangling is invalid")
         else:
             raise Exception("Unknown status code: {}".format(status.value))
-
-
-    def _find_any_lib(*choices):
-        for choice in choices:
-            lib = ctypes.util.find_library(choice)
-            if lib is not None:
-                return lib
-        raise Exception("Could not find any libraries for {}".format(choices))

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -122,11 +122,11 @@ class Symbol(object):
         return self
 
     def _find_any_lib(*choices):
-    for choice in choices:
-        lib = ctypes.util.find_library(choice)
-        if lib is not None:
-            return lib
-    raise Exception("Could not find any libraries for {}".format(choices))
+        for choice in choices:
+            lib = ctypes.util.find_library(choice)
+            if lib is not None:
+                return lib
+        raise Exception("Could not find any libraries for {}".format(choices))
 
     libc = ctypes.CDLL(_find_any_lib('c'))
     libc.free.argtypes = [ctypes.c_void_p]

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -52,7 +52,7 @@ class Symbol(object):
             self.owner_obj._symbols_by_addr[self.relative_addr] = self
             if "MachO" not in str(type(self.owner_obj)): # Type comparison without adding dependency. MachO has no demangled_names.
                 if self.name != self.demangled_name: # populating demangled_names
-                        self.owner_obj.demangled_names[self.name] = demangled
+                        self.owner_obj.demangled_names[self.name] = self.demangled_name
 
     def __repr__(self):
         if self.is_import:

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -51,8 +51,7 @@ class Symbol(object):
         if (claripy and isinstance(self.relative_addr, claripy.ast.Base)) or self.relative_addr != 0:
             self.owner_obj._symbols_by_addr[self.relative_addr] = self
             if "MachO" not in str(type(self.owner_obj)): # Type comparison without adding dependency. MachO has no demangled_names.
-                demangled = self.demangled_name
-                if demangled != self.name:
+                if self.name != self.demangled_name: # populating demangled_names
                         self.owner_obj.demangled_names[self.name] = demangled
 
     def __repr__(self):
@@ -147,6 +146,7 @@ class Symbol(object):
             demangled = retval.value
         finally:
             libc.free(retval)
+
         if status.value == 0:
             return demangled
         elif status.value == -1:
@@ -164,4 +164,4 @@ class Symbol(object):
             lib = ctypes.util.find_library(choice)
             if lib is not None:
                 return lib
-        raise Exception("Could not find any of libraries: {}".format(choices))
+        raise Exception("Could not find any libraries for {}".format(choices))

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -50,7 +50,7 @@ class Symbol(object):
         self.resolvedby = None
         if (claripy and isinstance(self.relative_addr, claripy.ast.Base)) or self.relative_addr != 0:
             self.owner_obj._symbols_by_addr[self.relative_addr] = self
-            if "MachO" not in str(type(self.owner_obj)): # Type comparision without addind dependency. MachO has no demangled_names.
+            if "MachO" not in str(type(self.owner_obj)): # Type comparison without adding dependency. MachO has no demangled_names.
                 demangled = self.demangled_name
                 if demangled != self.name:
                         self.owner_obj.demangled_names[self.name] = demangled
@@ -126,7 +126,7 @@ class Symbol(object):
     libc.free.argtypes = [ctypes.c_void_p]
 
     libcxx = ctypes.CDLL(_find_any_lib('c++', 'stdc++'))
-    libcxx["__cxa_demangle"].restype = ctypes.c_char_p # Dict notation necessary here since ctypes would otherwise prepend the classname to the symbol. Why?
+    libcxx["__cxa_demangle"].restype = ctypes.c_char_p # Dict notation is necessary here, since ctypes would otherwise prepend the classname to the symbol property. Why?
 
     def _demangle(mangled_name):
         """


### PR DESCRIPTION
Replaced name demangling with call to __cxa_demangle through ctypes instead of calling an external program. 