### PR TITLE
Basic implementation of DT_RUNPATH/DT_RPATH

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -87,6 +87,8 @@ class Backend(object):
         self.os = None  # Let other stuff override this
         self.engine_preset = None
         self._symbol_cache = {}
+        # a list of directories to search for libraries specified by the object
+        self.extra_load_path = []
 
         self.mapped_base_symbolic = 0
         # These are set by cle, and should not be overriden manually

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -787,6 +787,9 @@ class Loader(object):
             if self.main_object.binary is not None:
                 dirs.append(os.path.dirname(self.main_object.binary))
             if self._use_system_libs:
+                # Ideally this should be taken into account for each shared
+                # object, not just the main object.
+                dirs.extend(self.main_object.extra_load_path)
                 if sys.platform.startswith('linux'):
                     dirs.extend(self.main_object.arch.library_search_path())
                 elif sys.platform == 'win32':

--- a/tests/test_runpath.py
+++ b/tests/test_runpath.py
@@ -1,0 +1,31 @@
+import nose
+import os
+import shutil
+import tempfile
+
+import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                         os.path.join('..', '..', 'binaries'))
+
+def test_runpath():
+    tempdir = tempfile.mkdtemp()
+    try:
+        runpath_file = os.path.join(TEST_BASE, 'tests', 'x86_64', 'runpath')
+        relocated_file = os.path.join(tempdir, 'runpath')
+
+        expected_libs = []
+        os.mkdir(os.path.join(tempdir, 'lib'))
+        for lib in ["libc.so.6", "ld-linux-x86-64.so.2"]:
+            src = os.path.join(TEST_BASE, 'tests', 'x86_64', lib)
+            dst = os.path.join(tempdir, 'lib', lib)
+            expected_libs.append(os.path.realpath(dst))
+            shutil.copy(src, dst)
+
+        shutil.copy(runpath_file, relocated_file)
+
+        loader = cle.Loader(relocated_file, except_missing_libs=True)
+        nose.tools.assert_in(loader.all_objects[1].binary, expected_libs)
+        nose.tools.assert_in(loader.all_objects[2].binary, expected_libs)
+    finally:
+        shutil.rmtree(tempdir)


### PR DESCRIPTION
Elf objects support a field that works similar to the LD_LIBRARY_PATH variable
embedded in the binary:

```console
$ readelf -a ./main | grep RUNPATH
 0x000000000000001d (RUNPATH)            Library runpath: [/nix/store/sf3qh8ayxbhybmscanjrd3y3igrng304-env/lib64:/nix/store/sf3qh8ayxbhybmscanjrd3y3igrng304-env/lib:/nix/store/4h0allsz28x9mdirzb4wv51algacxzr7-glibc-2.26-131/lib:/nix/store/kzqrxkxs6lcbhxlalcim7zz6xay0i2f2-gcc-6.4.0-lib/lib]
```

DT_RPATH takes precedence over DT_RUNPATH and LD_LIBRARY_PATH, but is
ignored if DT_RUNPATH is set.
DT_RUNPATH comes after LD_LIBRARY_PATH.
The current implementation is incomplete as those flags can be also set
in shared libraries while here only the main object is take into
account.

After applying this patch it is possible to load such executables:

``` python
>>> import angr
>>> proj = angr.Project('./main', load_options={'except_missing_libs': True})
>>> print(proj.loader.all_objects)
[<ELF Object main, maps [0x400000:0x601017]>, <ELF Object libc-2.26.so, maps [0x1000000:0x13b18ff]>, <ELF Object ld-2.26.so, maps [0x2000000:0x222610f]>, <ELFTLSObject Object cle##tls, maps [0x3000000:0x300d010]>, <ExternObject Object cle##externs, maps [0x4000000:0x4008000]>, <KernelObject Object cle##kernel, maps [0x5000000:0x5008000]>]
````

This change comes at the moment without tests. 
I would like to hear your feedback on this feature first and how a test should look like