### PR TITLE
Fix blob pickling

### DIFF
--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -1,6 +1,7 @@
 
 import nose
 import os
+import pickle
 
 import cle
 
@@ -27,6 +28,10 @@ def test_blob_0():
     nose.tools.assert_equal(ld.main_object.entry, ENTRYPOINT)
     nose.tools.assert_true(ld.main_object.contains_addr(BASE_ADDR))
     nose.tools.assert_false(ld.main_object.contains_addr(BASE_ADDR - 1))
+
+    # ensure that pickling works
+    ld_pickled = pickle.loads(pickle.dumps(ld))
+    nose.tools.assert_equal(ld_pickled.main_object.mapped_base, BASE_ADDR)
 
 
 def test_blob_1():


### PR DESCRIPTION
I copy-pasted the code already used for the PE and the ELF loader... not sure if there is a better way that would avoid repeating this code?

Alternatives I thought about:

1. Implement `__getstate__` and `__setstate__` in the `Backend` base class, which would then be called by all deriving classes to obtain the "initial" dict.

    *Problem:* Now the derived classes depend on the fact that `__getstate__` / `__setstate__` for Backend return dictionaries, which is not usually a requirement for `__getstate__` / `__setstate__`.
2. Same as 1, but use helper methods and not the `__getstate__` / `__setstate__` special functions

    *Problem:* Every backend has to remember to overwrite `__getstate__` / `__setstate__`

I am not sure if the reduced duplication is actually worth the decrease in clarity caused by spreading the code over multiple classes.