### PR TITLE
ARM Relocation implementation R_ARM_MOVW_ABS_NC R_ARM_MOVT_ABS

### DIFF
--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -208,8 +208,8 @@ class R_ARM_MOVT_ABS(ELFReloc):
         X = (S + A)
         MaskX = X & 0xffff0000
         # inst modification:
-        part1 = (X >> 16) >> 12
-        part2 = (X >> 16) & 0xFFF
+        part1 = (MaskX >> 16) >> 12
+        part2 = (MaskX >> 16) & 0xFFF
         inst &= 0xfff0f000  # clears inst[11, 0] and inst[19, 16]
         inst |= ((part1 << 16) & 0xf0000)  # inst[19, 16] = part1
         inst |= (part2 & 0xfff)  # inst[11, 0] = part2

--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -153,6 +153,7 @@ class R_ARM_ABS32(ELFReloc):
 class R_ARM_MOVW_ABS_NC(ELFReloc):
     """
     Relocate R_ARM_MOVW_ABS_NC symbols.
+
     - Class: Static
     - Type: Instruction
     - Code: 43
@@ -187,6 +188,7 @@ class R_ARM_MOVW_ABS_NC(ELFReloc):
 class R_ARM_MOVT_ABS(ELFReloc):
     """
     Relocate R_ARM_MOVT_ABS symbols.
+
     - Class: Static
     - Type: Instruction
     - Code: 44


### PR DESCRIPTION
This adds support for  R_ARM_MOVW_ABS_NC and R_ARM_MOVT_ABS

My implementation is based on this document:
http://infocenter.arm.com/help/topic/com.arm.doc.ihi0044f/IHI0044F_aaelf.pdf

Here is the explanation for the implementation:

**Part 1**
```
A = ((inst & 0xf0000) >> 4) | (inst & 0xfff)
if (A & 0x8000):
    # two's complement
    A = -((A ^ 0xffff) + 1)
```
As explained in section 4.6.1.1:
For relocations processing MOVW and MOVT instructions (in both ARM and Thumb state), the initial addend is formed by interpreting the 16-bit literal field of the instruction as a 16-bit signed value in the range -32768 <= A < 32768. The interpretation is the same whether the relocated place contains a MOVW instruction or a MOVT instruction

**Part 2**
```
X = (S + A)
MaskX = X & 0xffff0000
```
Does the operation described in table 4-9 and table 4-11

**Part 3**
```
part1 = MaskX >> 12
part2 = MaskX & 0xFFF
inst &= 0xfff0f000  # clears inst[11, 0] and inst[19, 16]
inst |= ((part1 << 16) & 0xf0000)  # inst[19, 16] = part1
inst |= (part2 & 0xfff)  # inst[11, 0] = part2
```
Modify the instruction as described in the table 4-12 (page 33):

insn[19:16] = Result_Mask(X) >> 12
insn[11:0] = Result_Mask(X) & 0xFFF

