### PR TITLE
Add support for R_ARM_THM_CALL relocation

### DIFF
--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -231,15 +231,11 @@ class R_ARM_THM_CALL(ELFReloc):
       - S is the address of the symbol
       - A is the addend
       - P is the target location (place being relocated)
-      - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
-        - This bit is entirely irrelevant because the 1-bit of the address gets shifted off in the encoding
+      - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction (This bit is entirely irrelevant because the 1-bit of the address gets shifted off in the encoding)
     - Encoding: See http://hermes.wings.cs.wisc.edu/files/Thumb-2SupplementReferenceManual.pdf
       - Page 71 (3-31) has the chart
-      - It appears that it mistakenly references the I1 and I2 bits as J1 and J2 in the chart
-          (see the notes at the bottom of the page -- the ranges don't make sense)
-      - However, the J1/J2 bits are XORed with !S bit in this case
-          (see vex implementation:
-           https://github.com/angr/vex/blob/6d1252c7ce8fe8376318b8f8bb8034058454c841/priv/guest_arm_toIR.c#L19219 )
+      - It appears that it mistakenly references the I1 and I2 bits as J1 and J2 in the chart (see the notes at the bottom of the page -- the ranges don't make sense)
+      - However, the J1/J2 bits are XORed with !S bit in this case (see vex implementation: https://github.com/angr/vex/blob/6d1252c7ce8fe8376318b8f8bb8034058454c841/priv/guest_arm_toIR.c#L19219 )
       - Implementation appears correct with the bits placed into offset[23:22]
     """
 

--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -299,11 +299,10 @@ class R_ARM_THM_CALL(ELFReloc):
         # Ensure jump is in range
 
         if x & 0xff800000 != 0 and x & 0xff800000 != 0xff800000:
-            l.error("Jump target out of range for reloc R_ARM_THM_CALL (+- 2^23). "
-                    "This may be due to simprocedures being allocated outside the jump range."
-                    "If you believe this is the case, set 'rebase_granularity'=0x1000 in the "
-                    "load options.")
-            raise CLEOperationError("R_ARM_THM_CALL relocation out of bounds")
+            raise CLEOperationError("Jump target out of range for reloc R_ARM_THM_CALL (+- 2^23). "
+                                    "This may be due to SimProcedures being allocated outside the jump range. "
+                                    "If you believe this is the case, set 'rebase_granularity'=0x1000 in the "
+                                    "load options.")
 
         # Rebuild the instruction, first clearing out any previously set offset bits
 

--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -232,7 +232,7 @@ class R_ARM_THM_CALL(ELFReloc):
       - A is the addend
       - P is the target location (place being relocated)
       - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
-        - This bit is entirely irrelevant because
+        - This bit is entirely irrelevant because the 1-bit of the address gets shifted off in the encoding
     - Encoding: See http://hermes.wings.cs.wisc.edu/files/Thumb-2SupplementReferenceManual.pdf
       - Page 71 (3-31) has the chart
       - It appears that it mistakenly references the I1 and I2 bits as J1 and J2 in the chart
@@ -295,6 +295,8 @@ class R_ARM_THM_CALL(ELFReloc):
         #  the thumb flag, T, and PC, P.
 
         x = (((S + A) | T) - P) & 0xffffffff                          # Also mask to 32 bits
+
+        # Ensure jump is in range
 
         if x & 0xff800000 != 0 and x & 0xff800000 != 0xff800000:
             l.error("Jump target out of range for reloc R_ARM_THM_CALL (+- 2^23). "

--- a/cle/backends/externs.py
+++ b/cle/backends/externs.py
@@ -21,13 +21,13 @@ class ExternObject(Backend):
         self.segments.append(ExternSegment('externs', 0, 0, self.map_size))
 
 
-    def make_extern(self, name, alignment=8):
+    def make_extern(self, name, alignment=8, thumb=False):
         try:
             return self._symbol_cache[name]
         except KeyError:
             pass
 
-        addr = self.allocate(1, alignment=alignment)
+        addr = self.allocate(1, alignment=alignment, thumb=thumb)
 
         if hasattr(self.loader.main_object, 'is_ppc64_abiv1') and self.loader.main_object.is_ppc64_abiv1:
             func_symbol = Symbol(self, name + '#func', AT.from_mva(addr, self).to_rva(), 1, Symbol.TYPE_FUNCTION)
@@ -49,8 +49,8 @@ class ExternObject(Backend):
     def get_pseudo_addr(self, name):
         return self.make_extern(name).rebased_addr
 
-    def allocate(self, size=1, alignment=8):
-        addr = ALIGN_UP(self.next_addr, alignment)
+    def allocate(self, size=1, alignment=8, thumb=False):
+        addr = ALIGN_UP(self.next_addr, alignment) | thumb
         self.next_addr = addr + size
         if self.next_addr > self.map_size:
             raise CLEOperationError("Ran out of room in the extern object...! Report this as a bug.")

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -29,7 +29,7 @@ class Relocation(object):
         if self.symbol is not None and self.symbol.is_import:
             self.owner_obj.imports[self.symbol.name] = self
 
-    def resolve_symbol(self, solist, bypass_compatibility=False): # pylint: disable=unused-argument
+    def resolve_symbol(self, solist, bypass_compatibility=False, thumb=False): # pylint: disable=unused-argument
         if self.resolved:
             return True
 
@@ -63,7 +63,7 @@ class Relocation(object):
         if self.symbol.is_weak:
             return False
 
-        new_symbol = self.owner_obj.loader.extern_object.make_extern(self.symbol.name)
+        new_symbol = self.owner_obj.loader.extern_object.make_extern(self.symbol.name, thumb=thumb)
         self.resolve(new_symbol)
         return True
 


### PR DESCRIPTION
### Rationale
Typically, ARM Thumb calls are PC-relative, requiring no relocations at runtime. However, gcc outputs object files with functions in individual sections that can be individually rebased to arbitrary locations in memory, necessitating a relocation method for the inter-section references. In the case of `BL` and `BLX` thumb instructions, this process is implemented with the relocation `R_ARM_THM_CALL`. This pull request implements this relocation in cle.

### Description
There are two main issues that this request tackles:

1. The decoding and encoding of the `R_ARM_THM_CALL` relocation. This implementation supports both encoding and decoding of `BL` and `BLX` instructions so that the initial addend can be read out (in the case of REL relocations) and the relocated value can be encoded back in. The code for this is heavily commented and should be fairly self explanatory when combined with reference to the spec (link provided in comments).

2. Support for allocation of extern symbols at thumb-compatible addresses. More specifically, a `thumb` flag was added at symbol creation time to force allocation at the next available address `| 1`.

This request has a companion branch in archinfo also named `fix/r_arm_thm_call`. This is required in order to register the `R_ARM_THM_CALL` name with relocation type 0xa.