### PR TITLE
Add all_symbols support in elf backend

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -93,6 +93,7 @@ class ELF(MetaELF):
 
         self._symbol_cache = {}
         self._symbols_by_name = {}
+        self.all_symbols = []
         self.demangled_names = {}
         self.imports = {}
         self.resolved_imports = []
@@ -478,7 +479,7 @@ class ELF(MetaELF):
                 runpath = maybedecode(tag.runpath)
             elif tagstr == 'DT_RPATH':
                 rpath = maybedecode(tag.rpath)
-       
+
         self.extra_load_path = self.__parse_rpath(runpath, rpath)
 
         self.strtab = seg_readelf._get_stringtable()
@@ -720,7 +721,7 @@ class ELF(MetaELF):
 
     def __register_section_symbols(self, sec_re):
         for sym_re in sec_re.iter_symbols():
-            self.get_symbol(sym_re)
+            self.all_symbols.append(self.get_symbol(sym_re))
 
     def __relocate_mips(self):
         if 'DT_MIPS_BASE_ADDRESS' not in self._dynamic:


### PR DESCRIPTION
When multiple symbols lie at the same address, the existing API (`.symbols_by_addr`) breaks down due to its dictionary nature. This addition, `.all_symbols`, provides a simple list of all symbols that were found in the symbol section. This allows for true enumeration of _all_ symbols in a binary, which is especially useful for analyzing object files with large numbers of symbols.