### PR TITLE
Change to IDA Link class name after library refactor

### DIFF
--- a/cle/backends/idabin.py
+++ b/cle/backends/idabin.py
@@ -8,7 +8,7 @@ from ..errors import CLEError, CLEFileNotFoundError
 l = logging.getLogger("cle.idabin")
 
 try:
-    idalink = __import__('idalink').idalink
+    idalink = __import__('idalink').IDALink
 except ImportError:
     idalink = None
 


### PR DESCRIPTION
Class name was changed in idalink with this commit https://github.com/zardus/idalink/commit/056a07710b1f481897703b38b241008ddd86de4a. Updating the class name fixes an 'AttributeError' which was occuring.