### PR TITLE
bytes and string comparison bug fix

### DIFF
--- a/cle/backends/binja.py
+++ b/cle/backends/binja.py
@@ -167,7 +167,7 @@ class BinjaBin(Backend):
         magic = stream.read(100)
         stream.seek(0)
         # bndb files are SQlite 3
-        if magic.startswith("SQLite format 3".encode()) and stream.name.endswith("bndb"):
+        if magic.startswith(b"SQLite format 3") and stream.name.endswith("bndb"):
             return True
 
         return False

--- a/cle/backends/binja.py
+++ b/cle/backends/binja.py
@@ -167,7 +167,7 @@ class BinjaBin(Backend):
         magic = stream.read(100)
         stream.seek(0)
         # bndb files are SQlite 3
-        if magic.startswith("SQLite format 3") and stream.name.endswith("bndb"):
+        if magic.startswith("SQLite format 3".encode()) and stream.name.endswith("bndb"):
             return True
 
         return False


### PR DESCRIPTION
Error 
```python
in is_compatible(stream)
    168         stream.seek(0)
    169         # bndb files are SQlite 3
--> 170         if magic.startswith("SQLite format 3") and stream.name.endswith("bndb"):
    171             return True
    172 

TypeError: startswith first arg must be bytes or a tuple of bytes, not str
```
Solution:
encode comparison string 