### PR TITLE
Fix APK loading

### DIFF
--- a/cle/backends/java/apk.py
+++ b/cle/backends/java/apk.py
@@ -124,12 +124,13 @@ class Apk(Soot):
 
     @staticmethod
     def is_compatible(stream):
-        # check if stream is an archive
-        if not Soot.is_zip_archive(stream):
-            return False
         # get filelist
-        with ZipFile(stream) as apk:
-            filelist = apk.namelist()
+        try:
+            with ZipFile(stream) as apk:
+                filelist = apk.namelist()
+        except:
+            # stream is not unzippable
+            return False
         # check for manifest and the .dex bytecode file
         if 'AndroidManifest.xml' not in filelist:
             return False

--- a/cle/backends/java/apk.py
+++ b/cle/backends/java/apk.py
@@ -124,13 +124,12 @@ class Apk(Soot):
 
     @staticmethod
     def is_compatible(stream):
-        # get filelist
-        try:
-            with ZipFile(stream) as apk:
-                filelist = apk.namelist()
-        except:
-            # stream is not unzippable
+        # check if stream is an archive
+        if not Soot.is_zip_archive(stream):
             return False
+        # get filelist
+        with ZipFile(stream) as apk:
+            filelist = apk.namelist()
         # check for manifest and the .dex bytecode file
         if 'AndroidManifest.xml' not in filelist:
             return False

--- a/cle/backends/java/soot.py
+++ b/cle/backends/java/soot.py
@@ -189,6 +189,7 @@ class Soot(Backend):
 
     @staticmethod
     def is_zip_archive(stream):
+        stream.seek(0)
         identstring = stream.read(4)
         stream.seek(0)
         return identstring.startswith(b'\x50\x4b\x03\x04')


### PR DESCRIPTION
`Soot.is_zip_archive(stream)` produces non-deterministic results, making (sometimes) the APK loading fail.

Using try/except works reliably.