### PR TITLE
Improve ELF import identification

### DIFF
--- a/cle/backends/elf/symbol.py
+++ b/cle/backends/elf/symbol.py
@@ -51,5 +51,5 @@ class ELFSymbol(Symbol):
         # these do not appear to be 100% correct, but they work so far...
         # e.g. the "stdout" import symbol will be marked as an export symbol by this
         # there does not seem to be a good way to reliably isolate import symbols
-        self.is_import = self.section is None and self.binding in ('STB_GLOBAL', 'STB_WEAK')
+        self.is_import = self.section is None and self.binding in ('STB_GLOBAL', 'STB_WEAK') and sec_ndx is 'SHN_UNDEF'
         self.is_export = self.section is not None and self.binding in ('STB_GLOBAL', 'STB_WEAK')

--- a/tests/test_preload.py
+++ b/tests/test_preload.py
@@ -1,11 +1,17 @@
+import os
 import cle
 import nose
 import logging
 
+TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                          os.path.join('..', '..', 'binaries', 'tests', 'i386'))
+
 def test_preload():
-	l = cle.Loader('./test_preload', auto_load_libs=True, preload_libs=['./strcpy_lib.so'])
+	l = cle.Loader(os.path.join(TESTS_BASE,'test_preload'), auto_load_libs=True, preload_libs=[os.path.join(TESTS_BASE,'test_preload_strcpy_lib.so')])
 	s = l.find_symbol('strcpy')
-	nose.tools.assert_in('strcpy_lib.so', s.owner.binary)
+	nose.tools.assert_in('test_preload_strcpy_lib.so', s.owner.binary)
+	d = l.find_symbol('do_work')
+	nose.tools.assert_false(d.resolved)
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
Building on #167. Don't set `symbol.is_import` unless the symbol has an `SHN_UNDEF` index. AFAICT that's a slightly better way to isolate imports. I think `is_export` should probably just be `not is_import` but I'm unsure so I left it alone.

Either way, this prevents undefined symbols from being arbitrarily resolved to externs. Updated test binaries incoming.