### PR TITLE
Make the default entry point zero

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -87,7 +87,7 @@ class Backend:
         self.is_main_bin = is_main_bin
         self.has_memory = has_memory
         self.loader = loader
-        self._entry = None
+        self._entry = 0
         self._segments = Regions() # List of segments
         self._sections = Regions() # List of sections
         self.sections_map = {}  # Mapping from section name to section

--- a/cle/backends/ihex.py
+++ b/cle/backends/ihex.py
@@ -34,10 +34,6 @@ class Hex(Blob):
     """
     is_default = True # Tell CLE to automatically consider using the Hex backend
 
-    def __init__(self, path, arch=None, entry_point=0, **kwargs):
-        super(Hex, self).__init__(path, arch=arch, entry_point=entry_point, **kwargs)
-        self._entry = None
-
     @staticmethod
     def parse_record(line):
         m = intel_hex_re.match(line)


### PR DESCRIPTION
closes #174 

This is consistent with what non-executable ELF files have for an entry point field.

Furthermore, removes what I think is a misuse of the `entry_point` parameter in the IHex backend.