### PR TITLE
Use Enums for Symbol Types

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -5,7 +5,7 @@ import sortedcontainers
 import archinfo
 from .region import Region, Segment, Section
 from .regions import Regions
-from .symbol import Symbol
+from .symbol import Symbol, SymbolType
 from ..address_translator import AT
 from ..memory import Clemory
 from ..errors import CLEOperationError, CLEError

--- a/cle/backends/binja.py
+++ b/cle/backends/binja.py
@@ -1,7 +1,7 @@
 
 import logging
 
-from . import Backend, register_backend, Symbol
+from . import Backend, register_backend, Symbol, SymbolType
 from .relocation import Relocation
 from ..errors import CLEError
 from ..address_translator import AT
@@ -35,11 +35,11 @@ class BinjaSymbol(Symbol):
             raise CLEError(BINJA_NOT_INSTALLED_STR)
 
         if sym.type in self.BINJA_FUNC_SYM_TYPES:
-            symtype = Symbol.TYPE_FUNCTION
+            symtype = SymbolType.TYPE_FUNCTION
         elif sym.type in self.BINJA_DATA_SYM_TYPES:
-            symtype = Symbol.TYPE_OBJECT
+            symtype = SymbolType.TYPE_OBJECT
         else:
-            symtype = Symbol.TYPE_OTHER
+            symtype = SymbolType.TYPE_OTHER
 
         super(BinjaSymbol, self).__init__(owner,
                                           sym.raw_name,

--- a/cle/backends/elf/__init__.py
+++ b/cle/backends/elf/__init__.py
@@ -1,4 +1,3 @@
 from .elf import ELF
 from .metaelf import MetaELF
 from .elfcore import ELFCore
-from .symbol import ElfSymbolType

--- a/cle/backends/elf/__init__.py
+++ b/cle/backends/elf/__init__.py
@@ -1,3 +1,4 @@
 from .elf import ELF
 from .metaelf import MetaELF
 from .elfcore import ELFCore
+from .symbol import ElfSymbolType

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -7,7 +7,7 @@ import elftools
 from elftools.elf import elffile, sections
 from collections import OrderedDict, defaultdict
 
-from .symbol import ELFSymbol, Symbol
+from .symbol import ELFSymbol, Symbol, SymbolType
 from .regions import ELFSection, ELFSegment
 from .hashtable import ELFHashTable, GNUHashTable
 from .metaelf import MetaELF, maybedecode
@@ -79,7 +79,7 @@ class ELF(MetaELF):
         self._init_arr = []
         self._fini_func = None
         self._fini_arr = []
-        self._nullsymbol = Symbol(self, '', 0, 0, Symbol.TYPE_NONE)
+        self._nullsymbol = Symbol(self, '', 0, 0, SymbolType.TYPE_NONE)
         self._nullsymbol.is_static = True
 
         self._symbol_cache = {}

--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -3,7 +3,7 @@ import elftools
 import os
 
 from .. import Backend
-from ..symbol import Symbol
+from ..symbol import SymbolType
 from ...address_translator import AT
 from ...utils import stream_or_path
 from elftools.elf.descriptions import describe_ei_osabi
@@ -68,7 +68,7 @@ class MetaELF(Backend):
             plt_sec = self.sections_map['.MIPS.stubs']
 
         self.jmprel = OrderedDict(sorted(self.jmprel.items(), key=lambda x: x[1].linked_addr))
-        func_jmprel = OrderedDict((k, v) for k, v in self.jmprel.items() if v.symbol.type not in (Symbol.TYPE_OBJECT, Symbol.TYPE_SECTION, Symbol.TYPE_OTHER))
+        func_jmprel = OrderedDict((k, v) for k, v in self.jmprel.items() if v.symbol.type not in (SymbolType.TYPE_OBJECT, SymbolType.TYPE_SECTION, SymbolType.TYPE_OTHER))
 
         # ATTEMPT 1: some arches will just leave the plt stub addr in the import symbol
         if self.arch.name in ('ARM', 'ARMEL', 'ARMHF', 'ARMCortexM', 'AARCH64', 'MIPS32', 'MIPS64'):

--- a/cle/backends/elf/relocation/generic.py
+++ b/cle/backends/elf/relocation/generic.py
@@ -3,7 +3,7 @@ import logging
 
 from ....address_translator import AT
 from ....errors import CLEOperationError
-from ... import Symbol
+from ... import SymbolType
 from .elfreloc import ELFReloc
 
 l = logging.getLogger('cle.backends.elf.relocation.generic')
@@ -22,7 +22,7 @@ class GenericTLSDoffsetReloc(ELFReloc):
 class GenericTLSOffsetReloc(ELFReloc):
     def relocate(self, solist, bypass_compatibility=False):  #pylint: disable=unused-argument
         hell_offset = self.owner.arch.elf_tls.tp_offset
-        if self.symbol.type == Symbol.TYPE_NONE:
+        if self.symbol.type == SymbolType.TYPE_NONE:
             self.owner.memory.pack_word(
                 self.relative_addr,
                 self.owner.tls_block_offset + self.addend + self.symbol.relative_addr - hell_offset)
@@ -38,7 +38,7 @@ class GenericTLSOffsetReloc(ELFReloc):
 
 class GenericTLSModIdReloc(ELFReloc):
     def relocate(self, solist, bypass_compatibility=False):  #pylint: disable=unused-argument
-        if self.symbol.type == Symbol.TYPE_NONE:
+        if self.symbol.type == SymbolType.TYPE_NONE:
             self.owner.memory.pack_word(self.relative_addr, self.owner.tls_module_id)
             self.resolve(None)
         else:
@@ -50,7 +50,7 @@ class GenericTLSModIdReloc(ELFReloc):
 
 class GenericIRelativeReloc(ELFReloc):
     def relocate(self, solist, bypass_compatibility=False):  #pylint: disable=unused-argument
-        if self.symbol.type == Symbol.TYPE_NONE:
+        if self.symbol.type == SymbolType.TYPE_NONE:
             self.owner.irelatives.append((AT.from_lva(self.addend, self.owner).to_mva(), self.relative_addr))
             self.resolve(None)
             return True
@@ -91,7 +91,7 @@ class GenericRelativeReloc(ELFReloc):
         return self.owner.mapped_base + self.addend
 
     def resolve_symbol(self, solist, bypass_compatibility=False, thumb=False):  #pylint: disable=unused-argument
-        if self.symbol.type == Symbol.TYPE_NONE:
+        if self.symbol.type == SymbolType.TYPE_NONE:
             self.resolve(None)
             return True
         return super(GenericRelativeReloc, self).resolve_symbol(

--- a/cle/backends/elf/symbol.py
+++ b/cle/backends/elf/symbol.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from ..symbol import Symbol, SymbolType, SymbolSubType
 from ...address_translator import AT
 

--- a/cle/backends/elf/symbol.py
+++ b/cle/backends/elf/symbol.py
@@ -10,6 +10,16 @@ class ElfSymbolType(SymbolSubType):
     """
     ELF-specific symbol types
     """
+
+    # Enum classes cannot be inherited. Therefore, additional platform-specific
+    # values should simply be added to this enumeration (e.g., STT_GNU_IFUNC)
+    # with an appropriate conversion in `to_base_type()`.
+    #
+    # Though that could be solved with IntEnum as well, that breaks the
+    # strong typing and is discouraged by Python docs.
+
+
+    # Basic types
     STT_NOTYPE = 0     # Symbol's type is not specified
     STT_OBJECT = 1     # Symbol is a data object (variable, array, etc.)
     STT_FUNC = 2       # Symbol is executable code (function, etc.)
@@ -18,7 +28,7 @@ class ElfSymbolType(SymbolSubType):
     STT_COMMON = 5     # An uninitialized common block
     STT_TLS = 6        # Thread local data object
 
-    STT_GNU_IFUNC = 10 # GNU indirect function
+    # ELF's generic place-holders
     STT_LOOS = 10      # Lowest operating system-specific symbol type
     STT_HIOS = 12      # Highest operating system-specific symbol type
     STT_LOPROC = 13    # Lowest processor-specific symbol type
@@ -27,18 +37,28 @@ class ElfSymbolType(SymbolSubType):
     # AMDGPU symbol types
     STT_AMDGPU_HSA_KERNEL = 10
 
+    # GNU
+    STT_GNU_IFUNC = 10  # GNU indirect function
+
     def to_base_type(self):
         if self is ElfSymbolType.STT_NOTYPE:
             return SymbolType.TYPE_NONE
+
         elif self is ElfSymbolType.STT_FUNC:
             return SymbolType.TYPE_FUNCTION
+
         elif self in [ElfSymbolType.STT_OBJECT, ElfSymbolType.STT_COMMON]:
             return SymbolType.TYPE_OBJECT
+
         elif self is ElfSymbolType.STT_SECTION:
             return SymbolType.TYPE_SECTION
+
         elif self is ElfSymbolType.STT_TLS:
             return SymbolType.TYPE_TLS_OBJECT
-        # TODO: Fill in the rest of these
+
+        elif self is ElfSymbolType.STT_GNU_IFUNC:
+            return SymbolType.TYPE_FUNCTION
+
         else:
             return SymbolType.TYPE_OTHER
 

--- a/cle/backends/elf/symbol.py
+++ b/cle/backends/elf/symbol.py
@@ -73,6 +73,7 @@ class ELFSymbol(Symbol):
     """
     def __init__(self, owner, symb):
         self._subtype = ElfSymbolType[symb.entry.st_info.type]
+        self._type = self._subtype.to_base_type()
 
         sec_ndx, value = symb.entry.st_shndx, symb.entry.st_value
 
@@ -99,10 +100,6 @@ class ELFSymbol(Symbol):
         # there does not seem to be a good way to reliably isolate import symbols
         self.is_import = sec_ndx == 'SHN_UNDEF' and self.binding in ('STB_GLOBAL', 'STB_WEAK')
         self.is_export = self.section is not None and self.binding in ('STB_GLOBAL', 'STB_WEAK')
-
-    @property
-    def type(self):
-        return self._subtype.to_base_type()
 
     @property
     def subtype(self):

--- a/cle/backends/elf/symbol_type.py
+++ b/cle/backends/elf/symbol_type.py
@@ -125,12 +125,20 @@ class ELFSymbolType(SymbolSubType):
             return SymbolType.TYPE_OTHER
 
 
-# courtesy: https://stackoverflow.com/q/24105268/1137728
-def __ElfSymbolTypeArchParser(cls, value):
+def __ELFSymbolTypeArchParser(cls, value):
+    """
+    This is just a nice way to allow for just specifying the `int` for
+    default types: `ELFSymbolType(10)` rather than `ELFSymbolType((10,None))`.
+
+    Idea courtesy: https://stackoverflow.com/q/24105268/1137728.
+
+    We don't need to implement the `str` parsing like the SO link above since
+    `Enum` already has built-in item access: `ELFSymbolType['STT_FUNC']`.
+    """
     if isinstance(value, int):
         return super(ELFSymbolType, cls).__new__(cls, (value, None))
     else:
         return super(ELFSymbolType, cls).__new__(cls, value)
 
 
-setattr(ELFSymbolType, '__new__', __ElfSymbolTypeArchParser)
+setattr(ELFSymbolType, '__new__', __ELFSymbolTypeArchParser)

--- a/cle/backends/elf/symbol_type.py
+++ b/cle/backends/elf/symbol_type.py
@@ -73,34 +73,35 @@ class ELFSymbolType(SymbolSubType):
     # STT_HP_STUB = (STT_LOOS[0] + 2, 'hppa')
     # STT_PARISC_MILLICODE = (STT_LOPROC[0], 'hppa')
 
-    def __init__(self, *args):
+    def __init__(self, *args):  # pylint: disable=unused-argument
         # Essentially a static type check, this will fail on import
         # if someone defines a type that's not a `tuple`
         if not isinstance(self.value, tuple):
             raise ValueError(
-                "Symbol value '{}' for member '{}' is invalid. Values must be tuples.".format(self.value, self.name))
+                "Symbol value '{}' for member '{}' is invalid. Values must be tuples.".format(self.value, self.name))  # pylint: disable=logging-format-interpolation
         try:
             if self.os_proc:  # ignore our defaults
                 arch_from_id(self.os_proc)
         except ArchNotFound:
             _l.warning(
-                "Symbol value '{}' for member '{}' does not have an archinfo type.".format(self.value, self.name))
+                "Symbol value '{}' for member '{}' does not have an archinfo type.".format(self.value, self.name))  # pylint: disable=logging-format-interpolation
 
     def __repr__(self):
         return "ELFSymbolType.{}: (elf_value: {}, os_proc: {})".format(self.name, self.elf_value, self.os_proc)
 
     @property
     def elf_value(self):
-        return self.value[0]
+        return self.value[0]  # pylint: disable=unsubscriptable-object
 
     @property
     def os_proc(self):
-        return self.value[1]
+        return self.value[1]  # pylint: disable=unsubscriptable-object
 
     @property
     def is_custom_os_proc(self):
-        return self.elf_value in range(self.STT_LOOS.elf_value, self.STT_HIPROC.elf_value + 1) and \
-               self.os_proc is not None
+        if self.elf_value in range(self.STT_LOOS.elf_value, self.STT_HIPROC.elf_value + 1):  # pylint: disable=no-member
+            return self.os_proc is not None
+        return False
 
     def to_base_type(self):
         if self is ELFSymbolType.STT_NOTYPE:

--- a/cle/backends/externs/simdata/__init__.py
+++ b/cle/backends/externs/simdata/__init__.py
@@ -14,12 +14,14 @@ class SimData(Symbol):
 
     :cvar name:     The name of the symbol to provide
     :cvar libname:  The name of the library from which the symbol originally comes (currently unused).
-    :cvar _type:     The type of the symbol, usually ``SymbolType.TYPE_OBJECT``.
+    :cvar type:     The type of the symbol, usually ``SymbolType.TYPE_OBJECT``.
 
     Use the below `register` method to register SimData subclasses with CLE.
+
+    NOTE: SimData.type hides the Symbol.type instance property
     """
     name = NotImplemented  # type: str
-    _type = NotImplemented  # type: SymbolType
+    type = NotImplemented  # type: SymbolType
     libname = NotImplemented  # type: str
 
     @classmethod

--- a/cle/backends/externs/simdata/__init__.py
+++ b/cle/backends/externs/simdata/__init__.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import List
 
 from ...relocation import Relocation
-from ...symbol import Symbol
+from ...symbol import Symbol, SymbolType
 
 # pylint: disable=unused-argument,no-self-use
 
@@ -14,12 +14,12 @@ class SimData(Symbol):
 
     :cvar name:     The name of the symbol to provide
     :cvar libname:  The name of the library from which the symbol originally comes (currently unused).
-    :cvar type:     The type of the symbol, usually ``Symbol.TYPE_OBJECT``.
+    :cvar _type:     The type of the symbol, usually ``SymbolType.TYPE_OBJECT``.
 
     Use the below `register` method to register SimData subclasses with CLE.
     """
     name = NotImplemented  # type: str
-    type = NotImplemented  # type: int
+    _type = NotImplemented  # type: SymbolType
     libname = NotImplemented  # type: str
 
     @classmethod

--- a/cle/backends/externs/simdata/common.py
+++ b/cle/backends/externs/simdata/common.py
@@ -2,6 +2,7 @@ import struct
 
 from . import SimData
 from ...relocation import Relocation
+from ...symbol import SymbolType
 
 
 class StaticData(SimData):
@@ -13,7 +14,7 @@ class StaticData(SimData):
     :cvar libname:  The name of the library from which the symbol originally comes (currently unused).
     :cvar data:     The bytes to provide
     """
-    type = SimData.TYPE_OBJECT
+    _type = SymbolType.TYPE_OBJECT
     data = NotImplemented  # type: bytes
 
     @classmethod
@@ -34,7 +35,7 @@ class StaticWord(SimData):
     :cvar word:     The value to provide
     :cvar wordsize: (optional) The size of the value in bytes, default the CPU wordsize
     """
-    type = SimData.TYPE_OBJECT
+    _type = SymbolType.TYPE_OBJECT
     word = NotImplemented  # type: int
     wordsize = None # type: int
 
@@ -54,13 +55,13 @@ class PointTo(SimData):
     :cvar name:         The name of the symbol to provide.
     :cvar libname:      The name of the library from which the symbol originally comes (currently unused).
     :cvar pointto_name: The name of the symbol to point to
-    :cvar pointto_type: The type of the symbol to point to (usually ``Symbol.TYPE_FUNCTION`` or
-                        ``Symbol.TYPE_OBJECT``)
+    :cvar pointto_type: The type of the symbol to point to (usually ``SymbolType.TYPE_FUNCTION`` or
+                        ``SymbolType.TYPE_OBJECT``)
     :cvar addend:       (optional) an integer to be added to the symbol's address before storage
     """
     pointto_name = NotImplemented  # type: str
-    pointto_type = NotImplemented  # type: int
-    type = SimData.TYPE_OBJECT
+    pointto_type = NotImplemented  # type: SymbolType
+    _type = SymbolType.TYPE_OBJECT # type: SymbolType
     addend = 0  # type: int
 
     @classmethod

--- a/cle/backends/externs/simdata/common.py
+++ b/cle/backends/externs/simdata/common.py
@@ -14,7 +14,7 @@ class StaticData(SimData):
     :cvar libname:  The name of the library from which the symbol originally comes (currently unused).
     :cvar data:     The bytes to provide
     """
-    _type = SymbolType.TYPE_OBJECT
+    type = SymbolType.TYPE_OBJECT
     data = NotImplemented  # type: bytes
 
     @classmethod
@@ -35,7 +35,7 @@ class StaticWord(SimData):
     :cvar word:     The value to provide
     :cvar wordsize: (optional) The size of the value in bytes, default the CPU wordsize
     """
-    _type = SymbolType.TYPE_OBJECT
+    type = SymbolType.TYPE_OBJECT
     word = NotImplemented  # type: int
     wordsize = None # type: int
 
@@ -61,7 +61,7 @@ class PointTo(SimData):
     """
     pointto_name = NotImplemented  # type: str
     pointto_type = NotImplemented  # type: SymbolType
-    _type = SymbolType.TYPE_OBJECT # type: SymbolType
+    type = SymbolType.TYPE_OBJECT # type: SymbolType
     addend = 0  # type: int
 
     @classmethod

--- a/cle/backends/externs/simdata/glibc_startup.py
+++ b/cle/backends/externs/simdata/glibc_startup.py
@@ -5,7 +5,7 @@ from ...symbol import SymbolType
 
 class DummyProgname(SimData):
     name = '_dummy_progname'
-    _type = SymbolType.TYPE_OBJECT
+    type = SymbolType.TYPE_OBJECT
     libname = 'libc.so.6'
 
     progname = b'./program\0'
@@ -22,7 +22,7 @@ class Progname(PointTo):
     pointto_type = SymbolType.TYPE_OBJECT
     name = '__progname'
     libname = 'libc.so.6'
-    _type = SymbolType.TYPE_OBJECT
+    type = SymbolType.TYPE_OBJECT
     addend = 2
 
 class PrognameFull(PointTo):
@@ -30,7 +30,7 @@ class PrognameFull(PointTo):
     pointto_type = SymbolType.TYPE_OBJECT
     name = '__progname_full'
     libname = 'libc.so.6'
-    _type = SymbolType.TYPE_OBJECT
+    type = SymbolType.TYPE_OBJECT
     addend = 0
 
 class EnvironmentPointer(StaticWord):

--- a/cle/backends/externs/simdata/glibc_startup.py
+++ b/cle/backends/externs/simdata/glibc_startup.py
@@ -1,9 +1,11 @@
 from . import SimData, register
 from .common import PointTo, StaticWord
+from ...symbol import SymbolType
+
 
 class DummyProgname(SimData):
     name = '_dummy_progname'
-    type = SimData.TYPE_OBJECT
+    _type = SymbolType.TYPE_OBJECT
     libname = 'libc.so.6'
 
     progname = b'./program\0'
@@ -17,18 +19,18 @@ class DummyProgname(SimData):
 
 class Progname(PointTo):
     pointto_name = '_dummy_progname'
-    pointto_type = SimData.TYPE_OBJECT
+    pointto_type = SymbolType.TYPE_OBJECT
     name = '__progname'
     libname = 'libc.so.6'
-    type = SimData.TYPE_OBJECT
+    _type = SymbolType.TYPE_OBJECT
     addend = 2
 
 class PrognameFull(PointTo):
     pointto_name = '_dummy_progname'
-    pointto_type = SimData.TYPE_OBJECT
+    pointto_type = SymbolType.TYPE_OBJECT
     name = '__progname_full'
     libname = 'libc.so.6'
-    type = SimData.TYPE_OBJECT
+    _type = SymbolType.TYPE_OBJECT
     addend = 0
 
 class EnvironmentPointer(StaticWord):

--- a/cle/backends/externs/simdata/io_file.py
+++ b/cle/backends/externs/simdata/io_file.py
@@ -79,7 +79,7 @@ class IoStderrPointer(IoFilePointer):
 
 class IoFile(SimData):
     libname = 'libc.so.6'
-    _type = SymbolType.TYPE_OBJECT
+    type = SymbolType.TYPE_OBJECT
     fd = NotImplemented  # type: int
 
     @classmethod

--- a/cle/backends/externs/simdata/io_file.py
+++ b/cle/backends/externs/simdata/io_file.py
@@ -2,6 +2,7 @@ import struct
 import logging
 
 from . import SimData, register
+from ...symbol import SymbolType
 from .common import PointTo
 
 l = logging.getLogger(name=__name__)
@@ -61,7 +62,7 @@ def io_file_data_for_arch(arch):
 
 class IoFilePointer(PointTo):
     libname = 'libc.so.6'
-    pointto_type = PointTo.TYPE_OBJECT
+    pointto_type = SymbolType.TYPE_OBJECT
 
 class IoStdinPointer(IoFilePointer):
     name = 'stdin'
@@ -78,7 +79,7 @@ class IoStderrPointer(IoFilePointer):
 
 class IoFile(SimData):
     libname = 'libc.so.6'
-    type = SimData.TYPE_OBJECT
+    _type = SymbolType.TYPE_OBJECT
     fd = NotImplemented  # type: int
 
     @classmethod

--- a/cle/backends/macho/symbol.py
+++ b/cle/backends/macho/symbol.py
@@ -3,7 +3,7 @@
 # This file is part of Mach-O Loader for CLE.
 # Contributed December 2016 by Fraunhofer SIT (https://www.sit.fraunhofer.de/en/).
 
-from .. import Symbol
+from .. import Symbol, SymbolType
 
 import logging
 l = logging.getLogger('cle.backends.macho.symbol')
@@ -39,7 +39,7 @@ class MachOSymbol(Symbol):
         # pointing to the symobl.
         # Stub addresses must be obtained through some sort of higher-level analysis
         # Note 3: A symbols name may not be unique!
-        # Note 4: The symbol type of all symbols is Symbol.TYPE_OTHER because without docs I was unable to problerly map Mach-O symbol types to CLE's notion of a symbol type
+        # Note 4: The symbol type of all symbols is SymbolType.TYPE_OTHER because without docs I was unable to proplerly map Mach-O symbol types to CLE's notion of a symbol type
 
         # store the mach-o properties, all these are raw values straight from the binary
         self.symtab_offset = symtab_offset # offset from the start of the symbol table
@@ -61,7 +61,7 @@ class MachOSymbol(Symbol):
                owner.get_string(n_strx).decode() if n_strx != 0 else "",
                 self.value,
                 owner.arch.bytes,
-                Symbol.TYPE_OTHER)
+                SymbolType.TYPE_OTHER)
 
         # set further fields
         self.is_import = self.sym_type == SYMBOL_TYPE_UNDEF and self.is_external and self.library_ordinal != LIBRARY_ORDINAL_SELF

--- a/cle/backends/pe/symbol.py
+++ b/cle/backends/pe/symbol.py
@@ -1,6 +1,6 @@
 import logging
 
-from .. import Symbol
+from ..symbol import Symbol, SymbolType
 
 l = logging.getLogger('cle.backends.pe.symbol')
 
@@ -9,7 +9,7 @@ class WinSymbol(Symbol):
     Represents a symbol for the PE format.
     """
     def __init__(self, owner, name, addr, is_import, is_export, ordinal_number, forwarder):
-        super(WinSymbol, self).__init__(owner, name, addr, owner.arch.bytes, Symbol.TYPE_FUNCTION)
+        super(WinSymbol, self).__init__(owner, name, addr, owner.arch.bytes, SymbolType.TYPE_FUNCTION)
         self.is_import = is_import
         self.is_export = is_export
         self.ordinal_number = ordinal_number

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -65,7 +65,7 @@ class Relocation:
         if self.symbol.is_weak:
             return False
 
-        new_symbol = self.owner.loader.extern_object.make_extern(self.symbol.name, sym_type=self.symbol.type, thumb=thumb)
+        new_symbol = self.owner.loader.extern_object.make_extern(self.symbol.name, sym_type=self.symbol._type, thumb=thumb)
         self.resolve(new_symbol)
         return True
 

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -27,7 +27,6 @@ class SymbolSubType(Enum):
     def to_base_type(self) -> SymbolType:
         """
         A subclass' ABI-specific mapping to :SymbolType:
-        A subclass' ABI-specific mapping to :SymbolType:
         """
         raise ValueError("Abstract base class SymbolSubType has no base_type")
 

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -24,7 +24,7 @@ class SymbolSubType(Enum):
     """
     Abstract base class for ABI-specific symbol types
     """
-    def to_base_type(self) -> SymbolType:
+    def to_base_type(self) -> SymbolType:  # pylint: disable=no-self-use
         """
         A subclass' ABI-specific mapping to :SymbolType:
         """

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from enum import Enum
+from enum import Enum, auto
 import subprocess
 import logging
 
@@ -12,12 +12,12 @@ class SymbolType(Enum):
     """
     ABI-agnostic symbol types
     """
-    TYPE_OTHER = 0
-    TYPE_NONE = 1
-    TYPE_FUNCTION = 2
-    TYPE_OBJECT = 3
-    TYPE_SECTION = 4
-    TYPE_TLS_OBJECT = 5
+    TYPE_OTHER = auto()
+    TYPE_NONE = auto()
+    TYPE_FUNCTION = auto()
+    TYPE_OBJECT = auto()
+    TYPE_SECTION = auto()
+    TYPE_TLS_OBJECT = auto()
 
 
 class SymbolSubType(Enum):

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from enum import Enum, auto
+from enum import Enum
 import subprocess
 import logging
 
@@ -12,12 +12,12 @@ class SymbolType(Enum):
     """
     ABI-agnostic symbol types
     """
-    TYPE_OTHER = auto()
-    TYPE_NONE = auto()
-    TYPE_FUNCTION = auto()
-    TYPE_OBJECT = auto()
-    TYPE_SECTION = auto()
-    TYPE_TLS_OBJECT = auto()
+    TYPE_OTHER = 0
+    TYPE_NONE = 1
+    TYPE_FUNCTION = 2
+    TYPE_OBJECT = 3
+    TYPE_SECTION = 4
+    TYPE_TLS_OBJECT = 5
 
 
 class SymbolSubType(Enum):


### PR DESCRIPTION
Closes #169. 

This provides strongly-typed Enum classes for symbol types. Some differences from my original proposal:
 - I don't store the raw `int` at all and didn't make any setters. If someone gets the bright idea to just jam some unimplemented value into the private `_type` and `_subtype` attributes, they'll have problems. If needed, you can just use `<symbol>.subtype.value` to get an `int`.
 - I didn't realize `Enum` had item access so there was no need for my `name_to_elf_type()` function. Just using the string-name works: `ElfSymbolType['STT_FUNC'] == ElfSymbolType(2)`.
- I added a `SymbolSubType` abstract base class to make it clear that each symbol type should ensure it provides some mapping to the generic `SymbolType`.

Also:
- `SimData.type` as a cvar goes on awkwardly hiding `Symbol.type` since a property can't return a cvar. I wasn't up for refactoring any of that. Since we don't have setters for type/subtype, it shouldn't be an issue unless someone tries relying on a `SimData` instance's `_type`.
- I don't know what Mach-O is doing with its odd `sym_type` attribute so I left it alone. The Mach-O and PE changes are purely import/name-related.


The test failures seem unrelated.
