### PR TITLE
Discover more .plt entires

### DIFF
--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -222,14 +222,14 @@ class MetaELF(Backend):
 
         # if func_jmprel.keys()[0] not in self._plt:
         if not set(func_jmprel.keys()).intersection(self._plt.keys()):
-            # LAST TRY: check if we have a .plt section
+            # Check if we have a .plt section
             if plt_sec is None:
                 # WAHP WAHP
                 return
 
-            # try to find a block that references ANY GOT slot
-            tick.bailout_timer = 5
-            scan_forward(plt_sec.vaddr, list(func_jmprel.keys()), push=True)
+        # Last try: Find the first block to references ANY GOT slot
+        tick.bailout_timer = 5
+        scan_forward(plt_sec.vaddr, list(func_jmprel.keys()), push=True)
 
         if not self._plt:
             # \(_^^)/

--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -227,7 +227,7 @@ class MetaELF(Backend):
                 # WAHP WAHP
                 return
 
-        # Last try: Find the first block to references ANY GOT slot
+        # LAST TRY: Find the first block to references ANY GOT slot
         tick.bailout_timer = 5
         scan_forward(plt_sec.vaddr, list(func_jmprel.keys()), push=True)
 

--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -173,8 +173,14 @@ class MetaELF(Backend):
                     if block_is_good.name is None:
                         raise ValueError('block_is_good.name cannot be None.')
                     old_name = block_is_good.name
-                    while block_is_good(self._block(addr + instruction_alignment)) and block_is_good.name == old_name:
-                        addr += instruction_alignment
+                    block = self._block(addr)
+                    if len(block.instruction_addresses) > 1:
+                        for instruction in block.instruction_addresses[1:]:
+                            candidate_block = self._block(instruction)
+                            if block_is_good(candidate_block) and block_is_good.name == old_name:
+                                addr = candidate_block.addr
+                            else:
+                                break
                     block_is_good.name = old_name
                 else:
                     cont = True


### PR DESCRIPTION
Sometimes, just to scan forward from the beginning of the .plt section improves the amount of the discovered .plt entries. Some flow changes were made to assure the forward scan will happen every time. 