### PR TITLE
Fix for weird empty segments in ARM ELves

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -372,7 +372,9 @@ class ELF(MetaELF):
 
         # see https://code.woboq.org/userspace/glibc/elf/dl-map-segments.h.html#88
         data = get_mmaped_data(seg.stream, mapoff, mapend - mapstart, self.loader.page_size)
-
+        if not data:
+            l.warning("Segment %s is empty at %#08x!", seg.header.p_type, mapstart)
+            return
         if allocend > dataend:
             zero = dataend
             zeropage = (zero + self.loader.page_size - 1) & ~(self.loader.page_size - 1)

--- a/tests/test_arm_firmware.py
+++ b/tests/test_arm_firmware.py
@@ -7,6 +7,17 @@ from nose.tools import assert_true
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
 
 
+def test_empty_segements():
+    """
+    Test for bizarre ELves #1: Energy Micro's compiler makes empty segments
+
+    :return:
+    """
+    path = os.path.join(test_location, "armel", "efm32gg.elf")
+    cle.Loader(path, rebase_granularity=0x1000)
+    # If we survive this, we're doing OK!
+
+
 def test_thumb_object():
     """
     Test for an object file I ripped out of an ARM firmware HAL.
@@ -26,5 +37,7 @@ def test_thumb_object():
         # We missed it
         assert_true(r.value == 0xbff7f000)
 
+
 if __name__ == "__main__":
     test_thumb_object()
+    test_empty_segements()


### PR DESCRIPTION
Some ARM vendors have weird toolchains that generate poorly-formed ELves.
Here's yet another instance.
Don't try to load a segment with nothing in it :)