### PR TITLE
Add support for "named regions"

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -347,3 +347,4 @@ from .macho import MachO
 from .java.jar import Jar
 from .java.apk import Apk
 from .binja import BinjaBin
+from .named_region import NamedRegion

--- a/cle/backends/named_region.py
+++ b/cle/backends/named_region.py
@@ -1,5 +1,4 @@
 from . import Backend, register_backend
-from ..errors import CLEError
 from .region import Segment
 import logging
 l = logging.getLogger("cle.named_region")
@@ -15,6 +14,7 @@ class NamedRegion(Backend):
     """
     is_default = False
     has_memory = False
+
     def __init__(self, name, start, end, **kwargs):
         """
         """
@@ -29,7 +29,6 @@ class NamedRegion(Backend):
         self.has_memory = False
         s = Segment(0, start, 0, end - start)
         self.segments.append(s)
-
     
     def __repr__(self):
          return '<NamedRegion %s, maps [%#x:%#x]>' % (self.name, self.min_addr, self.max_addr)

--- a/cle/backends/named_region.py
+++ b/cle/backends/named_region.py
@@ -1,0 +1,61 @@
+from . import Backend, register_backend
+from ..errors import CLEError
+from ..patched_stream import PatchedStream
+from .region import Segment
+import logging
+l = logging.getLogger("cle.blob")
+
+__all__ = ('Blob',)
+
+class NamedRegion(Backend):
+    """
+    A NamedRegion represent a region of memory that has a name, a location, but no static content.
+
+    This can be used as a placeholder for memory that should exist in CLE's view, but for which it does not need data,
+    like RAM, MMIO, etc
+    """
+    is_default = False
+
+    def __init__(self, name, start, end, **kwargs):
+        """
+        """
+
+        self._max_addr = start
+        self._min_addr = end
+
+        s = Segment(0, start, 0, end - start)
+        self.segments.append(s)
+
+    @staticmethod
+    def is_compatible(stream):
+        return stream == 0  # I hate pylint
+
+    @property
+    def min_addr(self):
+        return self._min_addr
+
+    @property
+    def max_addr(self):
+        return self._max_addr
+
+    def function_name(self, addr): #pylint: disable=unused-argument,no-self-use
+        """
+        Blobs don't support function names.
+        """
+        return None
+
+    def contains_addr(self, addr):
+        return self.min_addr <= addr < self.max_addr
+
+    def in_which_segment(self, addr): #pylint: disable=unused-argument,no-self-use
+        """
+        Blobs don't support segments.
+        """
+        return None
+
+    @classmethod
+    def check_compatibility(cls, spec, obj): # pylint: disable=unused-argument
+        return True
+
+
+register_backend("blob", Blob)

--- a/cle/backends/named_region.py
+++ b/cle/backends/named_region.py
@@ -5,6 +5,7 @@ l = logging.getLogger("cle.named_region")
 
 __all__ = ('NamedRegion',)
 
+
 class NamedRegion(Backend):
     """
     A NamedRegion represent a region of memory that has a name, a location, but no static content.
@@ -29,9 +30,9 @@ class NamedRegion(Backend):
         self.has_memory = False
         s = Segment(0, start, 0, end - start)
         self.segments.append(s)
-    
+        
     def __repr__(self):
-         return '<NamedRegion %s, maps [%#x:%#x]>' % (self.name, self.min_addr, self.max_addr)
+        return '<NamedRegion %s, maps [%#x:%#x]>' % (self.name, self.min_addr, self.max_addr)
 
     @staticmethod
     def is_compatible(stream):

--- a/cle/backends/named_region.py
+++ b/cle/backends/named_region.py
@@ -30,7 +30,7 @@ class NamedRegion(Backend):
         self.has_memory = False
         s = Segment(0, start, 0, end - start)
         self.segments.append(s)
-        
+
     def __repr__(self):
         return '<NamedRegion %s, maps [%#x:%#x]>' % (self.name, self.min_addr, self.max_addr)
 

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -363,6 +363,8 @@ class Loader:
             return None
         if not membership_check:
             return obj
+        if not obj.has_memory:
+            return obj
         return _check_object_memory(obj)
 
     def find_segment_containing(self, addr, skip_pseudo_objects=True):
@@ -781,7 +783,7 @@ class Loader:
         if obj.has_memory:
             l.info("Mapping %s at %#x", obj.binary, base_addr)
             self.memory.add_backer(base_addr, obj.memory)
-            key_bisect_insort_left(self.all_objects, obj, keyfunc=lambda o: o.min_addr)
+        key_bisect_insort_left(self.all_objects, obj, keyfunc=lambda o: o.min_addr)
         obj._is_mapped = True
 
     def _relocate_object(self, obj):

--- a/tests/test_namedregion.py
+++ b/tests/test_namedregion.py
@@ -1,0 +1,32 @@
+
+import os
+
+import nose.tools
+from cle import Loader
+from cle.backends import NamedRegion
+
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests')
+
+
+def test_basic_named_region():
+    bin_path = os.path.join(test_location, "armel", "lwip_udpecho_bm.elf")
+    l = Loader(bin_path)
+    # Standard CortexM regions
+    mmio = NamedRegion("mmio", 0x40000000, 0x50000000)
+    sys = NamedRegion("sys", 0xe000e000, 0xe0010000)
+    l.add_object(mmio)
+    l.add_object(sys)
+
+    # In order to ensure static analysis works, we must be able to ask
+    # CLE what owns these addresses and get a valid answer.
+    obj1 = l.find_object_containing(0x4000023c)
+    obj2 = l.find_object_containing(0xe000ed08)
+    nose.tools.assert_not_equal(obj1, None)
+    nose.tools.assert_not_equal(obj2, None)
+    nose.tools.assert_equal(obj1.name, 'mmio')
+    nose.tools.assert_equal(obj2.name, 'sys')
+
+
+
+if __name__ == "__main__":
+    test_basic_named_region()


### PR DESCRIPTION
Add a Backend called NamedRegion, which is... a region, with a name.  Nothing more, nothing less.

This serves the purpose of reserving, from the perspective of the loader, some memory which has no static content, but can be considered "mapped", like MMIO, other weird hardware stuff, misc RAM in embedded systems, and so on.  I bet there are many uses for this we haven't thought of yet.

Should probably pair with some arch-specific loading hook somewhere that is TBD.