### PR TITLE
Remove symbol name demangling.

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -89,7 +89,6 @@ class ELF(MetaELF):
         self._symbol_cache = {}
         self._symbols_by_name = {}
         self._desperate_for_symbols = False
-        self.demangled_names = {}
         self.imports = {}
         self.resolved_imports = []
 
@@ -123,8 +122,6 @@ class ELF(MetaELF):
         # call the methods defined by MetaELF
         self._ppc64_abiv1_entry_fix()
         self._load_plt()
-
-        self._populate_demangled_names()
 
         for offset, patch in patch_undo:
             self.memory.store(AT.from_lva(self.min_addr + offset, self).to_rva(), patch)
@@ -403,29 +400,6 @@ class ELF(MetaELF):
             address += dest_section.remap_offset
 
         return RelocClass(self, symbol, address, addend)
-
-    def _populate_demangled_names(self):
-        """
-        TODO: remove this once a python implementation of a name demangler has
-        been implemented, then update self.demangled_names in Symbol
-        """
-
-        if not self.symbols:
-            return
-
-        names = [s.name for s in self.symbols if s.name.startswith("_Z")]
-        # this monstrosity taken from stackoverflow
-        # http://stackoverflow.com/questions/6526500/c-name-mangling-library-for-python
-        args = ['c++filt']
-        args.extend(n.split('@@')[0] for n in names)
-        try:
-            pipe = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-            stdout, _ = pipe.communicate()
-            demangled = stdout.decode().split("\n")[:-1]
-
-            self.demangled_names = dict(zip(names, demangled))
-        except OSError:
-            pass
 
     #
     # Private Methods... really. Calling these out of context

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1,6 +1,5 @@
 import os
 import struct
-import subprocess
 import logging
 import archinfo
 import elftools
@@ -249,7 +248,7 @@ class ELF(MetaELF):
                 return self._nullsymbol
             try:
                 re_sym = symbol_table.get_symbol(symid)
-            except Exception: # pylint: disable=bare-except
+            except Exception:  # pylint: disable=broad-except
                 l.exception("Error parsing symbol at %#08x", symid)
                 return None
             cache_key = self._symbol_to_tuple(re_sym)

--- a/cle/backends/macho/symbol.py
+++ b/cle/backends/macho/symbol.py
@@ -123,9 +123,6 @@ class MachOSymbol(Symbol):
         # Incompatibility to CLE
         pass  # Mach-O cannot be resolved like this as the whole binary is involved
 
-    def demangled_name(self):
-        return self.name  # it is not THAT easy with Mach-O
-
     # real symbols have properties, mach-o symbols have plenty of them:
     @property
     def is_stab(self):

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -61,11 +61,6 @@ class Symbol:
         self.resolved = False
         self.resolvedby = None
 
-        # would be nice if we could populate demangled_names here...
-        #demangled = self.demangled_name
-        #if demangled is not None:
-        #    self.owner.demangled_names[self.name] = demangled
-
     def __repr__(self):
         if self.is_import:
             return '<Symbol "%s" in %s (import)>' % (self.name, self.owner.provides)
@@ -118,29 +113,6 @@ class Symbol:
     is_weak = False
     is_extern = False
     is_forward = False
-
-    @property
-    def demangled_name(self):
-        """
-        The name of this symbol, run through a C++ demangler
-
-        Warning: this calls out to the external program `c++filt` and will fail loudly if it's not installed
-        """
-        # make sure it's mangled
-        if self.name.startswith("_Z"):
-            name = self.name
-            if '@@' in self.name:
-                name = self.name.split("@@")[0]
-            args = ['c++filt']
-            args.append(name)
-            pipe = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-            stdout, _ = pipe.communicate()
-            demangled = stdout.decode().split("\n")
-
-            if demangled:
-                return demangled[0]
-
-        return self.name
 
     def resolve_forwarder(self):
         """

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -1,5 +1,4 @@
 from enum import Enum
-import subprocess
 import logging
 
 from ..address_translator import AT


### PR DESCRIPTION
See https://github.com/angr/angr/pull/1279 if you need to demangle symbol
names.
This will significantly speed up file loading for C++ binaries.