### PR TITLE
Replace hardcoded logger names with __name__

### DIFF
--- a/cle/__init__.py
+++ b/cle/__init__.py
@@ -11,7 +11,7 @@ if bytes is str:
     raise Exception("This module is designed for python 3 only. Please install an older version to use python 2.")
 
 import logging
-logging.getLogger("cle").addHandler(logging.NullHandler())
+logging.getLogger(name=__name__).addHandler(logging.NullHandler())
 
 # pylint: disable=wildcard-import
 from . import utils

--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -10,7 +10,7 @@ from ..address_translator import AT
 from ..memory import Clemory
 from ..errors import CLEOperationError, CLEError
 
-l = logging.getLogger('cle.backends')
+l = logging.getLogger(name=__name__)
 
 
 class Backend:

--- a/cle/backends/binja.py
+++ b/cle/backends/binja.py
@@ -7,7 +7,7 @@ from ..errors import CLEError
 from ..address_translator import AT
 import archinfo
 
-l = logging.getLogger("cle.binja")
+l = logging.getLogger(name=__name__)
 
 try:
     import binaryninja as bn

--- a/cle/backends/blob.py
+++ b/cle/backends/blob.py
@@ -3,7 +3,7 @@ from ..errors import CLEError
 from ..patched_stream import PatchedStream
 from .region import Segment
 import logging
-l = logging.getLogger("cle.blob")
+l = logging.getLogger(name=__name__)
 
 __all__ = ('Blob',)
 

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -18,7 +18,7 @@ from ...errors import CLEError, CLEInvalidBinaryError, CLECompatibilityError
 from ...utils import ALIGN_DOWN, ALIGN_UP, get_mmaped_data, stream_or_path
 from ...address_translator import AT
 
-l = logging.getLogger('cle.elf')
+l = logging.getLogger(name=__name__)
 
 __all__ = ('ELFSymbol', 'ELF')
 

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -6,7 +6,7 @@ from .elf import ELF
 from .. import register_backend
 from ...errors import CLEError, CLECompatibilityError
 
-l = logging.getLogger('cle.elfcore')
+l = logging.getLogger(name=__name__)
 
 
 class CoreNote(object):

--- a/cle/backends/elf/relocation/__init__.py
+++ b/cle/backends/elf/relocation/__init__.py
@@ -9,7 +9,7 @@ ALL_RELOCATIONS = defaultdict(dict)
 complaint_log = set()
 
 path = os.path.dirname(os.path.abspath(__file__))
-l = logging.getLogger('cle.backends.elf.relocation')
+l = logging.getLogger(name=__name__)
 
 def load_relocations():
     for filename in os.listdir(path):

--- a/cle/backends/elf/relocation/amd64.py
+++ b/cle/backends/elf/relocation/amd64.py
@@ -1,7 +1,7 @@
 import logging
 from . import generic
 
-l = logging.getLogger('cle.backends.elf.relocation.amd64')
+l = logging.getLogger(name=__name__)
 arch = 'AMD64'
 
 class R_X86_64_64(generic.GenericAbsoluteAddendReloc):

--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -4,7 +4,7 @@ from .elfreloc import ELFReloc
 from ....errors import CLEOperationError
 
 
-l = logging.getLogger('cle.backends.elf.relocations.arm')
+l = logging.getLogger(name=__name__)
 arch = 'ARM'
 
 # Reference: "ELF for the ARM Architecture ABI r2.10"

--- a/cle/backends/elf/relocation/arm64.py
+++ b/cle/backends/elf/relocation/arm64.py
@@ -1,7 +1,7 @@
 import logging
 from . import generic
 
-l = logging.getLogger('cle.backends.elf.relocations.aarch64')
+l = logging.getLogger(name=__name__)
 
 # http://infocenter.arm.com/help/topic/com.arm.doc.ihi0056b/IHI0056B_aaelf64.pdf
 arch = 'AARCH64'

--- a/cle/backends/elf/relocation/elfreloc.py
+++ b/cle/backends/elf/relocation/elfreloc.py
@@ -1,7 +1,7 @@
 import logging
 from ...relocation import Relocation
 
-l = logging.getLogger('cle.backends.elf.relocation.elfreloc')
+l = logging.getLogger(name=__name__)
 
 
 class ELFReloc(Relocation):

--- a/cle/backends/elf/relocation/generic.py
+++ b/cle/backends/elf/relocation/generic.py
@@ -6,7 +6,7 @@ from ....errors import CLEOperationError
 from ... import SymbolType
 from .elfreloc import ELFReloc
 
-l = logging.getLogger('cle.backends.elf.relocation.generic')
+l = logging.getLogger(name=__name__)
 
 
 class GenericTLSDoffsetReloc(ELFReloc):

--- a/cle/backends/elf/relocation/i386.py
+++ b/cle/backends/elf/relocation/i386.py
@@ -1,7 +1,7 @@
 import logging
 from . import generic
 
-l = logging.getLogger('cle.backends.elf.relocation.x86')
+l = logging.getLogger(name=__name__)
 arch = 'X86'
 
 class R_386_32(generic.GenericAbsoluteAddendReloc):

--- a/cle/backends/elf/relocation/pcc64.py
+++ b/cle/backends/elf/relocation/pcc64.py
@@ -2,7 +2,7 @@ import logging
 from . import generic
 from .elfreloc import ELFReloc
 
-l = logging.getLogger('cle.backends.elf.relocations.ppc64')
+l = logging.getLogger(name=__name__)
 
 # http://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi-1.9.pdf
 arch = 'PPC64'

--- a/cle/backends/elf/relocation/ppc.py
+++ b/cle/backends/elf/relocation/ppc.py
@@ -1,7 +1,7 @@
 import logging
 from . import generic
 
-l = logging.getLogger('cle.backends.elf.relocations.ppc')
+l = logging.getLogger(name=__name__)
 arch = 'PPC32'
 
 class R_PPC_ADDR32(generic.GenericAbsoluteAddendReloc):

--- a/cle/backends/elf/symbol_type.py
+++ b/cle/backends/elf/symbol_type.py
@@ -2,7 +2,7 @@ import logging
 
 from ..symbol import SymbolType, SymbolSubType
 
-_l = logging.getLogger('cle.backends.elf.symbol')
+_l = logging.getLogger(name=__name__)
 
 
 class ELFSymbolType(SymbolSubType):

--- a/cle/backends/ihex.py
+++ b/cle/backends/ihex.py
@@ -7,7 +7,7 @@ from . import register_backend
 from ..errors import CLEError
 from .blob import Blob
 
-l = logging.getLogger("cle.hex")
+l = logging.getLogger(name=__name__)
 
 __all__ = ('Hex',)
 

--- a/cle/backends/java/apk.py
+++ b/cle/backends/java/apk.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 from .. import register_backend
 from .soot import Soot
 
-l = logging.getLogger("cle.backends.apk")
+l = logging.getLogger(name=__name__)
 
 # Default list of JNI archs (in descending order of preference)
 # => specifies which arch should be used for loading native libs from the APK

--- a/cle/backends/java/jar.py
+++ b/cle/backends/java/jar.py
@@ -4,7 +4,7 @@ from zipfile import ZipFile
 from .. import register_backend
 from .soot import Soot
 
-l = logging.getLogger("cle.backends.jar")
+l = logging.getLogger(name=__name__)
 
 
 class Jar(Soot):

--- a/cle/backends/macho/binding.py
+++ b/cle/backends/macho/binding.py
@@ -10,7 +10,7 @@ from ...errors import CLEInvalidBinaryError
 from ...address_translator import AT
 
 import logging
-l = logging.getLogger('cle.backends.macho.binding')
+l = logging.getLogger(name=__name__)
 
 OPCODE_MASK = 0xF0
 IMM_MASK = 0x0F

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -16,7 +16,7 @@ from .. import Backend, register_backend
 from ...errors import CLEInvalidBinaryError, CLECompatibilityError, CLEOperationError
 
 import logging
-l = logging.getLogger('cle.backends.macho')
+l = logging.getLogger(name=__name__)
 
 __all__ = ('MachO', 'MachOSection', 'MachOSegment')
 

--- a/cle/backends/macho/symbol.py
+++ b/cle/backends/macho/symbol.py
@@ -6,7 +6,7 @@
 from .. import Symbol, SymbolType
 
 import logging
-l = logging.getLogger('cle.backends.macho.symbol')
+l = logging.getLogger(name=__name__)
 
 # some constants:
 SYMBOL_TYPE_UNDEF = 0x0

--- a/cle/backends/named_region.py
+++ b/cle/backends/named_region.py
@@ -1,7 +1,7 @@
 from . import Backend, register_backend
 from .region import EmptySegment
 import logging
-l = logging.getLogger("cle.named_region")
+l = logging.getLogger(name=__name__)
 
 __all__ = ('NamedRegion',)
 

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -12,7 +12,7 @@ from ...address_translator import AT
 from ...patched_stream import PatchedStream
 
 
-l = logging.getLogger('cle.pe')
+l = logging.getLogger(name=__name__)
 
 
 class PE(Backend):

--- a/cle/backends/pe/relocation/__init__.py
+++ b/cle/backends/pe/relocation/__init__.py
@@ -9,7 +9,7 @@ ALL_RELOCATIONS = defaultdict(dict)
 complaint_log = set()
 
 path = os.path.dirname(os.path.abspath(__file__))
-l = logging.getLogger('cle.backends.pe.relocation')
+l = logging.getLogger(name=__name__)
 
 def load_relocations():
     for filename in os.listdir(path):

--- a/cle/backends/pe/relocation/amd64.py
+++ b/cle/backends/pe/relocation/amd64.py
@@ -1,7 +1,7 @@
 import logging
 from . import generic
 
-l = logging.getLogger('cle.backends.pe.relocation.amd64')
+l = logging.getLogger(name=__name__)
 
 arch = 'AMD64'
 

--- a/cle/backends/pe/relocation/arm.py
+++ b/cle/backends/pe/relocation/arm.py
@@ -2,7 +2,7 @@ import logging
 from . import generic
 from .pereloc import PEReloc
 
-l = logging.getLogger('cle.backends.pe.relocation.arm')
+l = logging.getLogger(name=__name__)
 
 arch = 'arm'
 

--- a/cle/backends/pe/relocation/generic.py
+++ b/cle/backends/pe/relocation/generic.py
@@ -3,7 +3,7 @@ import logging
 from .pereloc import PEReloc
 from ....address_translator import AT
 
-l = logging.getLogger('cle.backends.pe.relocation.generic')
+l = logging.getLogger(name=__name__)
 
 class DllImport(PEReloc):
     """

--- a/cle/backends/pe/relocation/i386.py
+++ b/cle/backends/pe/relocation/i386.py
@@ -1,7 +1,7 @@
 import logging
 from . import generic
 
-l = logging.getLogger('cle.backends.pe.relocation.x86')
+l = logging.getLogger(name=__name__)
 
 arch = 'X86'
 

--- a/cle/backends/pe/relocation/mips.py
+++ b/cle/backends/pe/relocation/mips.py
@@ -2,7 +2,7 @@ import logging
 from . import generic
 from .pereloc import PEReloc
 
-l = logging.getLogger('cle.backends.pe.relocation.mips')
+l = logging.getLogger(name=__name__)
 
 arch = 'mips'
 

--- a/cle/backends/pe/relocation/pereloc.py
+++ b/cle/backends/pe/relocation/pereloc.py
@@ -1,7 +1,7 @@
 import logging
 from ...relocation import Relocation
 
-l=logging.getLogger('cle.cle.backends.pe.relocation.pereloc')
+l=logging.getLogger(name=__name__)
 
 # Reference: https://msdn.microsoft.com/en-us/library/ms809762.aspx
 class PEReloc(Relocation):

--- a/cle/backends/pe/relocation/riscv.py
+++ b/cle/backends/pe/relocation/riscv.py
@@ -2,7 +2,7 @@ import logging
 from . import generic
 from .pereloc import PEReloc
 
-l = logging.getLogger('cle.backends.pe.relocation.riscv')
+l = logging.getLogger(name=__name__)
 
 arch = 'RISCV'
 

--- a/cle/backends/pe/symbol.py
+++ b/cle/backends/pe/symbol.py
@@ -2,7 +2,7 @@ import logging
 
 from ..symbol import Symbol, SymbolType
 
-l = logging.getLogger('cle.backends.pe.symbol')
+l = logging.getLogger(name=__name__)
 
 class WinSymbol(Symbol):
     """

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -4,7 +4,7 @@ from . import Backend
 from .symbol import Symbol
 from ..address_translator import AT
 
-l = logging.getLogger('cle.backends.relocation')
+l = logging.getLogger(name=__name__)
 
 
 class Relocation:

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -3,7 +3,7 @@ import logging
 
 from ..address_translator import AT
 
-l = logging.getLogger('cle.backends.symbol')
+l = logging.getLogger(name=__name__)
 
 
 class SymbolType(Enum):

--- a/cle/gdb.py
+++ b/cle/gdb.py
@@ -4,7 +4,7 @@ import logging
 from .backends.elf.metaelf import MetaELF
 from .errors import CLEFileNotFoundError
 
-l = logging.getLogger('cle.gdb')
+l = logging.getLogger(name=__name__)
 
 def convert_info_sharedlibrary(fname):
     """

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -17,7 +17,7 @@ except ImportError:
 
 __all__ = ('Loader',)
 
-l = logging.getLogger("cle.loader")
+l = logging.getLogger(name=__name__)
 
 
 class Loader:


### PR DESCRIPTION
Fixes #219 

I'm not sure why the angr code base adopted the convention of specifying the `name` parameter, but to be consistent I've done the same here.