### PR TITLE
PE: Speed up loading by enabling fast_load and on-demand parsing.

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -26,11 +26,13 @@ class PE(Backend):
         self.segments = self.sections # in a PE, sections and segments have the same meaning
         self.os = 'windows'
         if self.binary is None:
-            self._pe = pefile.PE(data=self.binary_stream.read())
+            self._pe = pefile.PE(data=self.binary_stream.read(), fast_load=True)
+            self._parse_pe_imports_exports()
         elif self.binary in self._pefile_cache: # these objects are not mutated, so they are reusable within a process
             self._pe = self._pefile_cache[self.binary]
         else:
-            self._pe = pefile.PE(self.binary)
+            self._pe = pefile.PE(self.binary, fast_load=True)
+            self._parse_pe_imports_exports()
             if not self.is_main_bin:
                 # only cache shared libraries, the main binary will not be reused
                 self._pefile_cache[self.binary] = self._pe
@@ -63,8 +65,14 @@ class PE(Backend):
         self._symbol_cache = self._exports # same thing
         self._handle_imports()
         self._handle_exports()
-        self.__register_relocs()
+        if self.loader.perform_relocations:
+            # parse base relocs
+            self._pe.parse_data_directories(directories=(pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_BASERELOC'],))
+            self.__register_relocs()
+        # parse TLS
+        self._pe.parse_data_directories(directories=(pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_TLS'],))
         self._register_tls()
+        # parse sections
         self._register_sections()
 
         self.linking = 'dynamic' if self.deps else 'static'
@@ -116,6 +124,12 @@ class PE(Backend):
     # Private methods
     #
 
+    def _parse_pe_imports_exports(self):
+        # parse imports
+        self._pe.parse_data_directories(directories=(pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_IMPORT'],))
+        # parse exports
+        self._pe.parse_data_directories(directories=(pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_EXPORT'],))
+
     def _get_jmprel(self):
         return self.imports
 
@@ -152,7 +166,6 @@ class PE(Backend):
                     forwardlib = forwarder.split('.', 1)[0].lower() + '.dll'
                     if forwardlib not in self.deps:
                         self.deps.append(forwardlib)
-
 
     def __register_relocs(self):
         if not hasattr(self._pe, 'DIRECTORY_ENTRY_BASERELOC'):

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -65,7 +65,7 @@ class PE(Backend):
         self._symbol_cache = self._exports # same thing
         self._handle_imports()
         self._handle_exports()
-        if self.loader.perform_relocations:
+        if self.loader._perform_relocations:
             # parse base relocs
             self._pe.parse_data_directories(directories=(pefile.DIRECTORY_ENTRY['IMAGE_DIRECTORY_ENTRY_BASERELOC'],))
             self.__register_relocs()

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -108,7 +108,7 @@ class Loader:
         self._extern_size = extern_size
         self._tls_size = tls_size
         self._relocated_objects = set()
-        self._perform_relocations = perform_relocations
+        self.perform_relocations = perform_relocations
 
         # case insensitivity setup
         if sys.platform == 'win32': # TODO: a real check for case insensitive filesystems
@@ -641,7 +641,7 @@ class Loader:
     def _internal_load(self, *args, preloading=False):
         """
         Pass this any number of files or libraries to load. If it can't load any of them for any reason, it will
-        except out. Note that the sematics of ``auto_load_libs`` and ``except_missing_libs`` apply at all times.
+        except out. Note that the semantics of ``auto_load_libs`` and ``except_missing_libs`` apply at all times.
 
         It will return a list of all the objects successfully loaded, which may be smaller than the list you provided
         if any of them were previously loaded.
@@ -701,7 +701,7 @@ class Loader:
         for obj in objects:
             if isinstance(obj, (MetaELF, PE)) and obj.tls_used:
                 self.tls_object.register_object(obj)
-        if self._perform_relocations:
+        if self.perform_relocations:
             for obj in objects:
                 self._relocate_object(obj)
 

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -108,7 +108,7 @@ class Loader:
         self._extern_size = extern_size
         self._tls_size = tls_size
         self._relocated_objects = set()
-        self.perform_relocations = perform_relocations
+        self._perform_relocations = perform_relocations
 
         # case insensitivity setup
         if sys.platform == 'win32': # TODO: a real check for case insensitive filesystems
@@ -701,7 +701,7 @@ class Loader:
         for obj in objects:
             if isinstance(obj, (MetaELF, PE)) and obj.tls_used:
                 self.tls_object.register_object(obj)
-        if self.perform_relocations:
+        if self._perform_relocations:
             for obj in objects:
                 self._relocate_object(obj)
 


### PR DESCRIPTION
Also, relocation directories will not be parsed if
loader.perform_relocation is False. This greatly speeds up angr
management's Load Binary dialog for PE binaries since loading PE
relocation directories takes ~75% of the total loading time.