### PR TITLE
Refactor CLE to separate linking from mapping and relocation

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -146,16 +146,17 @@ class Backend:
         self.pic = force_rebase
         self.execstack = False
 
-        # tls info
+        # tls info set by backend to communicate with thread manager
         self.tls_used = False
-        self.tls_module_id = None
-        self.tls_block_offset = None
         self.tls_block_size = None
-        self.tls_data_start = None
         self.tls_data_size = None
+        self.tls_data_start = None
+        # tls info set by thread manager
+        self.tls_module_id = None
+        #self.tls_block_offset = None  # this is an ELF-only attribute
 
         # Hints
-        self.function_hints = [ ]  # they should be rebased when .rebase() is called
+        self.function_hints = []  # they should be rebased when .rebase() is called
 
         # Custom options
         self._custom_entry_point = entry_point
@@ -169,6 +170,8 @@ class Backend:
         # cached max_addr
         self._max_addr = None
 
+        if arch is None and loader is not None and loader.main_object is not None:
+            arch = loader.main_object.arch
         if arch is None:
             self.arch = None
         elif isinstance(arch, str):

--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -170,8 +170,6 @@ class Backend:
         # cached max_addr
         self._max_addr = None
 
-        if arch is None and loader is not None and loader.main_object is not None:
-            arch = loader.main_object.arch
         if arch is None:
             self.arch = None
         elif isinstance(arch, str):
@@ -241,12 +239,15 @@ class Backend:
         l.critical("Deprecation warning: symbols_by_addr is deprecated - use loader.find_symbol() for lookup and .symbols for enumeration")
         return {s.rebased_addr: s for s in self.symbols}
 
-    def rebase(self):
+    def rebase(self, new_base):
         """
         Rebase backend's regions to the new base where they were mapped by the loader
         """
         if self._is_mapped:
+            # we could rebase an object twice if we really wanted... no need though, right?
             raise CLEOperationError("Image already rebased from %#x to %#x" % (self.linked_base, self.mapped_base))
+
+        self.mapped_base = new_base
 
         if self.sections:
             self.sections._rebase(self.image_base_delta)
@@ -255,6 +256,18 @@ class Backend:
 
         for hint in self.function_hints:
             hint.addr = hint.addr + self.image_base_delta
+
+    def relocate(self):
+        """
+        Apply all resolved relocations to memory.
+
+        The meaning of "resolved relocations" is somewhat subtle - there is a linking step which attempts to resolve
+        each relocation, currently only present in the main internal loading function since the calculation of which
+        objects should be available
+        """
+        for reloc in self.relocs:
+            if reloc.resolved:
+                reloc.relocate()
 
     def contains_addr(self, addr):
         """
@@ -410,6 +423,7 @@ from .macho import MachO
 from .named_region import NamedRegion
 from .java.jar import Jar
 from .java.apk import Apk
+from .java.soot import Soot
 from .xbe import XBE
 
 try:

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -313,8 +313,8 @@ class ELF(MetaELF):
         else:
             raise CLEError("Bad symbol identifier: %r" % (symid,))
 
-    def rebase(self):
-        super().rebase()
+    def rebase(self, new_base):
+        super().rebase(new_base)
 
         # rebase frame description entries
         for fde in self.fdes:

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -93,6 +93,7 @@ class ELF(MetaELF):
         self._desperate_for_symbols = False
         self.imports = {}
         self.resolved_imports = []
+        self.tls_block_offset = None  # this is an ELF-only attribute
 
         self.relocs = []
         self.jmprel = OrderedDict()

--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -243,10 +243,9 @@ class R_ARM_THM_CALL(ELFReloc):
         super(R_ARM_THM_CALL, self).__init__(*args, **kwargs)
         self._insn_bytes = None
 
-    def resolve_symbol(self, solist, bypass_compatibility=False, thumb=False):
-        return super(R_ARM_THM_CALL, self).resolve_symbol(solist,
-                                                          bypass_compatibility=bypass_compatibility,
-                                                          thumb=True)
+    def resolve_symbol(self, solist, **kwargs):
+        kwargs['thumb'] = True
+        super().resolve_symbol(solist, **kwargs)
 
     @property
     def value(self):

--- a/cle/backends/elf/relocation/generic.py
+++ b/cle/backends/elf/relocation/generic.py
@@ -1,8 +1,7 @@
-
 import logging
 
 from ....address_translator import AT
-from ....errors import CLEOperationError
+from ....errors import CLEOperationError, CLEInvalidBinaryError
 from ... import SymbolType
 from .elfreloc import ELFReloc
 
@@ -29,6 +28,9 @@ class GenericTLSOffsetReloc(ELFReloc):
             obj = self.owner
         else:
             obj = self.resolvedby.owner
+
+        if obj.tls_block_offset is None:
+            raise CLEInvalidBinaryError("Illegal relocation - dynamically loaded object using static TLS")
 
         self.owner.memory.pack_word(
             self.relative_addr,

--- a/cle/backends/elf/relocation/generic.py
+++ b/cle/backends/elf/relocation/generic.py
@@ -14,52 +14,47 @@ class GenericTLSDoffsetReloc(ELFReloc):
     def value(self):
         return self.addend + self.symbol.relative_addr
 
-    def resolve_symbol(self, solist, bypass_compatibility=False, thumb=False):  #pylint: disable=unused-argument
+    def resolve_symbol(self, solist, **kwargs):  #pylint: disable=unused-argument
         self.resolve(None)
         return True
 
 
 class GenericTLSOffsetReloc(ELFReloc):
-    def relocate(self, solist, bypass_compatibility=False):  #pylint: disable=unused-argument
+    AUTO_HANDLE_NONE = True
+
+    def relocate(self):
         hell_offset = self.owner.arch.elf_tls.tp_offset
-        if self.symbol.type == SymbolType.TYPE_NONE:
-            self.owner.memory.pack_word(
-                self.relative_addr,
-                self.owner.tls_block_offset + self.addend + self.symbol.relative_addr - hell_offset)
-            self.resolve(None)
+
+        if self.resolvedby is None:
+            obj = self.owner
         else:
-            if not self.resolve_symbol(solist, bypass_compatibility):
-                return False
-            self.owner.memory.pack_word(
-                self.relative_addr,
-                self.resolvedby.owner.tls_block_offset + self.addend + self.symbol.relative_addr - hell_offset)
-        return True
+            obj = self.resolvedby.owner
+
+        self.owner.memory.pack_word(
+            self.relative_addr,
+            obj.tls_block_offset + self.addend + self.symbol.relative_addr - hell_offset)
 
 
 class GenericTLSModIdReloc(ELFReloc):
-    def relocate(self, solist, bypass_compatibility=False):  #pylint: disable=unused-argument
+    AUTO_HANDLE_NONE = True
+
+    def relocate(self):
         if self.symbol.type == SymbolType.TYPE_NONE:
-            self.owner.memory.pack_word(self.relative_addr, self.owner.tls_module_id)
-            self.resolve(None)
+            obj = self.owner
         else:
-            if not self.resolve_symbol(solist):
-                return False
-            self.owner.memory.pack_word(self.relative_addr, self.resolvedby.owner.tls_module_id)
-        return True
+            obj = self.resolvedby.owner
+
+        self.owner.memory.pack_word(self.relative_addr, obj.tls_module_id)
 
 
 class GenericIRelativeReloc(ELFReloc):
-    def relocate(self, solist, bypass_compatibility=False):  #pylint: disable=unused-argument
+    AUTO_HANDLE_NONE = True
+
+    def relocate(self):
         if self.symbol.type == SymbolType.TYPE_NONE:
             self.owner.irelatives.append((AT.from_lva(self.addend, self.owner).to_mva(), self.relative_addr))
-            self.resolve(None)
-            return True
-
-        if not self.resolve_symbol(solist, bypass_compatibility):
-            return False
-
-        self.owner.irelatives.append((self.resolvedby.rebased_addr, self.relative_addr))
-        return True
+        else:
+            self.owner.irelatives.append((self.resolvedby.rebased_addr, self.relative_addr))
 
 
 class GenericAbsoluteAddendReloc(ELFReloc):
@@ -84,21 +79,13 @@ class GenericJumpslotReloc(ELFReloc):
 
 
 class GenericRelativeReloc(ELFReloc):
+    AUTO_HANDLE_NONE = True
+
     @property
     def value(self):
         if self.resolvedby is not None:
             return self.resolvedby.rebased_addr
         return self.owner.mapped_base + self.addend
-
-    def resolve_symbol(self, solist, bypass_compatibility=False, thumb=False):  #pylint: disable=unused-argument
-        if self.symbol.type == SymbolType.TYPE_NONE:
-            self.resolve(None)
-            return True
-        return super(GenericRelativeReloc, self).resolve_symbol(
-            solist,
-            bypass_compatibility=bypass_compatibility,
-            thumb=thumb
-        )
 
 
 class GenericAbsoluteReloc(ELFReloc):
@@ -108,15 +95,11 @@ class GenericAbsoluteReloc(ELFReloc):
 
 
 class GenericCopyReloc(ELFReloc):
-    def relocate(self, solist, bypass_compatibility=False):
-        try:
-            solist.remove(self.owner)
-        except ValueError:
-            pass
+    def resolve_symbol(self, solist, **kwargs):
+        new_solist = [x for x in solist if x is not self.owner]
+        super().resolve_symbol(new_solist, **kwargs)
 
-        if not self.resolve_symbol(solist, bypass_compatibility):
-            return False
-
+    def relocate(self):
         if self.resolvedby.size != self.symbol.size and (self.resolvedby.size != 0 or not self.resolvedby.is_extern):
             l.error("Export symbol is different size than import symbol for copy relocation: %s", self.symbol.name)
         else:
@@ -129,19 +112,22 @@ class MipsGlobalReloc(GenericAbsoluteReloc):
 
 
 class MipsLocalReloc(ELFReloc):
-    def relocate(self, solist, bypass_compatibility=False): # pylint: disable=unused-argument
+    AUTO_HANDLE_NONE = True
+
+    def resolve_symbol(self, solist, **kwargs):
+        self.resolve(None)
+
+    def relocate(self):
         if self.owner.mapped_base == 0:
-            self.resolve(None)
-            return True                     # don't touch local relocations on the main bin
+            return   # don't touch local relocations on the main bin
+
         delta = self.owner.mapped_base - self.owner._dynamic['DT_MIPS_BASE_ADDRESS']
         if delta == 0:
-            self.resolve(None)
-            return True
+            return
+
         val = self.owner.memory.unpack_word(self.relative_addr)
         newval = val + delta
         self.owner.memory.pack_word(self.relative_addr, newval)
-        self.resolve(None)
-        return True
 
 
 class RelocTruncate32Mixin:
@@ -155,10 +141,7 @@ class RelocTruncate32Mixin:
     # If True, 32-bit truncated value must equal to its original when sign-extended
     check_sign_extend = False
 
-    def relocate(self, solist, bypass_compatibility=False): # pylint: disable=unused-argument
-        if not self.resolve_symbol(solist):
-            return False
-
+    def relocate(self):
         arch_bits = self.owner.arch.bits
         assert arch_bits >= 32            # 16-bit makes no sense here
 

--- a/cle/backends/elf/relocation/pcc64.py
+++ b/cle/backends/elf/relocation/pcc64.py
@@ -8,10 +8,7 @@ l = logging.getLogger(name=__name__)
 arch = 'PPC64'
 
 class R_PPC64_JMP_SLOT(ELFReloc):
-    def relocate(self, solist, bypass_compatibility=False):
-        if not self.resolve_symbol(solist, bypass_compatibility):
-            return False
-
+    def relocate(self):
         if self.owner.is_ppc64_abiv1:
             # R_PPC64_JMP_SLOT
             # http://osxr.org/glibc/source/sysdeps/powerpc/powerpc64/dl-machine.h?v=glibc-2.15#0405

--- a/cle/backends/elf/relocation/ppc.py
+++ b/cle/backends/elf/relocation/ppc.py
@@ -236,10 +236,10 @@ class R_PPC_GLOB_DAT(generic.GenericJumpslotReloc):
 
 
 class R_PPC_JMP_SLOT(generic.GenericJumpslotReloc):
-    def relocate(self, solist, bypass_compatibility=False):
+    def relocate(self):
         if 'DT_PPC_GOT' not in self.owner._dynamic and 'DT_LOPROC' not in self.owner._dynamic:
             l.error("This binary is relocated incorrectly. See https://github.com/angr/cle/issues/142 for details.")
-        return super(R_PPC_JMP_SLOT, self).relocate(solist, bypass_compatibility=bypass_compatibility)
+        super().relocate()
 
 
 class R_PPC_RELATIVE(generic.GenericRelativeReloc):

--- a/cle/backends/externs/__init__.py
+++ b/cle/backends/externs/__init__.py
@@ -51,7 +51,7 @@ class ExternObject(Backend):
         self.tls_next_addr = 0
         self._tls_mapped = False
 
-    def rebase(self):
+    def rebase(self, new_base):
         if self._is_mapped:
             return
 
@@ -63,7 +63,7 @@ class ExternObject(Backend):
 
         self.memory.add_backer(0, bytes(backer))
         self.segments.append(ExternSegment(self.map_size))
-        super().rebase()
+        super().rebase(new_base)
 
     def make_extern(self, name, size=0, alignment=None, thumb=False, sym_type=SymbolType.TYPE_FUNCTION, libname=None) -> Symbol:
         try:

--- a/cle/backends/externs/__init__.py
+++ b/cle/backends/externs/__init__.py
@@ -94,6 +94,11 @@ class ExternObject(Backend):
             toc_symbol = self.make_extern(name, size=0x18, alignment=8, sym_type=SymbolType.TYPE_OBJECT)
             name += '#func'
 
+        if size == 0 and sym_type in (SymbolType.TYPE_NONE, SymbolType.TYPE_OBJECT, SymbolType.TYPE_TLS_OBJECT):
+            l.warning("Symbol was allocated without a known size; emulation may fail if it is used non-opaquely: %s", name)
+            self._warned_data_import = True
+            real_size = 8
+
         local_addr = self._allocate(real_size, alignment=alignment, thumb=thumb, tls=tls)
         if local_addr is None:
             if self._next_object is None:
@@ -210,10 +215,6 @@ class ExternObject(Backend):
                 self._delayed_writes.append(symbol)
                 for reloc in relocs:
                     reloc.relocate()
-
-        if symbol.size == 0 and symbol.type in (SymbolType.TYPE_OBJECT, SymbolType.TYPE_TLS_OBJECT):
-            l.warning("Symbol was allocated without a known size; emulation will fail if it is used non-opaquely: %s", symbol.name)
-            self._warned_data_import = True
 
 
 class KernelObject(Backend):

--- a/cle/backends/externs/__init__.py
+++ b/cle/backends/externs/__init__.py
@@ -1,8 +1,9 @@
 import logging
 
 from cle.backends import Backend, Symbol, Segment, SymbolType
+from cle.backends.relocation import Relocation
 from cle.utils import ALIGN_UP
-from cle.errors import CLEOperationError
+from cle.errors import CLEOperationError, CLEError
 from cle.address_translator import AT
 
 l = logging.getLogger(name=__name__)
@@ -25,13 +26,21 @@ class ExternSegment(Segment):
     is_executable = True
 
 
+class TOCRelocation(Relocation):
+    @property
+    def value(self):
+        return self.resolvedby.rebased_addr
+
+
 class ExternObject(Backend):
-    def __init__(self, loader, map_size=0x8000, tls_size=0x1000):
+    def __init__(self, loader, map_size=0, tls_size=0):
         super(ExternObject, self).__init__('cle##externs', loader=loader)
+        self._next_object = None
+        self._delayed_writes = []
+
         self.next_addr = 0
         self.map_size = map_size
         self.set_arch(loader.main_object.arch)
-        self.memory.add_backer(0, bytes(map_size))
         self.provides = 'extern-address space'
         self.pic = True
         self._import_symbols = {}
@@ -42,64 +51,109 @@ class ExternObject(Backend):
         self.tls_next_addr = 0
         self._tls_mapped = False
 
+    def rebase(self):
+        if self._is_mapped:
+            return
+
+        backer = bytearray(self.map_size)
+        for simdata in self._delayed_writes:
+            value = simdata.value()
+            # TODO: is this right for tls?
+            backer[simdata.relative_addr:simdata.relative_addr+len(value)] = value
+
+        self.memory.add_backer(0, bytes(backer))
         self.segments.append(ExternSegment(self.map_size))
+        super().rebase()
 
-
-    def make_extern(self, name, size=0, alignment=None, thumb=False, sym_type=SymbolType.TYPE_FUNCTION, libname=None):
+    def make_extern(self, name, size=0, alignment=None, thumb=False, sym_type=SymbolType.TYPE_FUNCTION, libname=None) -> Symbol:
         try:
             return self._symbol_cache[name]
         except KeyError:
             pass
 
-        l.info("Creating extern symbol for %s", name)
-
-        if alignment is None:
-            alignment = self.arch.bytes
-
+        tls = sym_type == SymbolType.TYPE_TLS_OBJECT
         SymbolCls = Symbol
         simdata = lookup(name, libname)
-        tls = sym_type == SymbolType.TYPE_TLS_OBJECT
         if simdata is not None:
             SymbolCls = simdata
             size = simdata.static_size(self)
             if sym_type != simdata.type:
                 l.warning("Symbol type mismatch between export request and response for %s. What's going on?", name)
 
-        addr = self.allocate(max(size, 1), alignment=alignment, thumb=thumb, tls=tls)
+        real_size = max(size, 1)
 
-        if hasattr(self.loader.main_object, 'is_ppc64_abiv1') and self.loader.main_object.is_ppc64_abiv1 and sym_type == SymbolType.TYPE_FUNCTION:
-            func_symbol = SymbolCls(self, name + '#func', AT.from_mva(addr, self).to_rva(), size, sym_type)
-            func_symbol.is_export = True
-            func_symbol.is_extern = True
-            self._symbol_cache[name + '#func'] = func_symbol
-            self.symbols.add(func_symbol)
-            self._init_symbol(func_symbol)
+        if alignment is None:
+            alignment = self.arch.bytes
 
-            toc = self.allocate(0x18, alignment=8)
-            size = 0x18
-            self.memory.pack_word(AT.from_mva(toc, self).to_rva(), addr)
-            addr = toc
-            sym_type = SymbolType.TYPE_OBJECT
-            SymbolCls = Symbol
+        make_toc = getattr(self.loader.main_object, 'is_ppc64_abiv1', False) and sym_type == SymbolType.TYPE_FUNCTION
+        toc_symbol = None
+        if make_toc:
+            # we make two symbols, one for the func and one for the toc
+            # the one for the func ends up named with the #func suffix, the toc gets the normal name
+            # we return the one for the toc
+            toc_symbol = self.make_extern(name, size=0x18, alignment=8, sym_type=SymbolType.TYPE_OBJECT)
+            name += '#func'
 
-        new_symbol = SymbolCls(self, name, addr if tls else AT.from_mva(addr, self).to_rva(), size, sym_type)
+        local_addr = self._allocate(real_size, alignment=alignment, thumb=thumb, tls=tls)
+        if local_addr is None:
+            if self._next_object is None:
+                # we're at the end of the line. make a new extern object
+                # this should only be hit if we're doing this outside a loading pass
+                self._make_new_externs(real_size, alignment, tls)
+            return self._next_object.make_extern(name, size=size, alignment=alignment, sym_type=sym_type, libname=libname)
+
+        l.info("Created extern symbol for %s", name)
+
+        new_symbol = SymbolCls(self, name, local_addr, size, sym_type)
         new_symbol.is_export = True
         new_symbol.is_extern = True
 
         self._symbol_cache[name] = new_symbol
         self.symbols.add(new_symbol)
         self._init_symbol(new_symbol)
+
+        if make_toc:
+            # write the pointer to the func into the toc
+            # i.e. make a relocation for it
+            # then if we're already mapped, apply the relocation manually
+            reloc = TOCRelocation(self, toc_symbol, toc_symbol.relative_addr)
+            reloc.resolve(new_symbol)
+            self.relocs.append(reloc)
+            if self._is_mapped:
+                reloc.relocate()
+
+            return toc_symbol
         return new_symbol
 
-    def get_pseudo_addr(self, name):
+    def get_pseudo_addr(self, name) -> int:
+        if not self._is_mapped:
+            raise CLEError("Can't allocate with extern object before it is mapped")
+
         return self.make_extern(name).rebased_addr
 
-    def allocate(self, size=1, alignment=8, thumb=False, tls=False):
+    def allocate(self, size=1, alignment=8, thumb=False, tls=False) -> int:
+        if not self._is_mapped:
+            raise CLEError("Can't allocate with extern object before it is mapped")
+
+        result = self._allocate(size=size, alignment=alignment, thumb=thumb, tls=tls) + (0 if tls else self.mapped_base)
+        if result is not None:
+            return result
+
+        if self._next_object is None:
+            # we're at the end of the line. make a new extern object
+            # this should only be hit if we're doing this outside a loading pass
+            self._make_new_externs(size, alignment, tls)
+        return self._next_object.allocate(size=size, alignment=alignment, thumb=thumb, tls=tls)
+
+    def _make_new_externs(self, size, alignment, tls):
+        self._next_object = ExternObject(self.loader, map_size=max(size + alignment, 0x8000) if not tls else 0x8000, tls_size=max(size + alignment, 0x1000) if tls else 0x1000)
+        self.loader._internal_load(self._next_object)
+
+    def _allocate(self, size=1, alignment=8, thumb=False, tls=False):
         if tls:
             if not self.tls_used:
                 self.tls_data_start = self.allocate(self.tls_data_size) - self.mapped_base
                 self.tls_used = True
-                self.loader.tls_object.register_object(self)
             start = self.tls_next_addr
             limit = self.tls_data_size
         else:
@@ -109,14 +163,20 @@ class ExternObject(Backend):
         addr = ALIGN_UP(start, alignment) | thumb
         next_start = addr + size
         if next_start >= limit:
-            raise CLEOperationError("Ran out of room in the extern object...! Report this as a bug.")
+            if self._is_mapped:
+                return None
+            else:
+                if tls:
+                    self.tls_data_size += next_start - limit
+                else:
+                    self.map_size += next_start - limit
 
         if tls:
             self.tls_next_addr = next_start
             return addr
         else:
             self.next_addr = next_start
-            return addr + self.mapped_base
+            return addr
 
     @property
     def max_addr(self):
@@ -128,8 +188,9 @@ class ExternObject(Backend):
             sym.is_import = True
             sym.is_extern = True
             # this is kind of tricky... normally if you have an import and an export of the same name in the binary
-            # the two symbols are *the same symbol*. but we don't know ahead of time whether we will have the symbol
-            # here in externs, so we will not expose the import symbol to the rest of the world.
+            # the two symbols are *the same symbol*, usually with a copy relocation. but we don't know ahead of time
+            # whether we will have the symbol here in externs, so we will not expose the import symbol to the rest of
+            # the world.
             self._import_symbols[name] = sym
             return sym
         else:
@@ -140,15 +201,16 @@ class ExternObject(Backend):
 
     def _init_symbol(self, symbol):
         if isinstance(symbol, SimData):
-            self.memory.store(symbol.relative_addr, symbol.value())
-            # the unfortunate fact of the matter is that if we are being polled for a relocation we need its contents to
-            # be resolved, like, yesterday. so recurse here, lord help us.
-            # if we want extern relocations to be able to depend on other objects we are in for a serious refactor
-            # perhaps split resolution and relocation into two different phases?
             relocs = symbol.relocations()
             self.relocs.extend(relocs)
-            for reloc in relocs:
-                reloc.relocate([self])
+
+            if self._is_mapped:
+                # TODO: is this right for tls?
+                self.memory.store(symbol.relative_addr, symbol.value())
+            else:
+                self._delayed_writes.append(symbol)
+                for reloc in relocs:
+                    reloc.relocate()
 
         if symbol.size == 0 and symbol.type in (SymbolType.TYPE_OBJECT, SymbolType.TYPE_TLS_OBJECT):
             l.warning("Symbol was allocated without a known size; emulation will fail if it is used non-opaquely: %s", symbol.name)

--- a/cle/backends/pe/relocation/generic.py
+++ b/cle/backends/pe/relocation/generic.py
@@ -13,7 +13,8 @@ class DllImport(PEReloc):
     pass
 
 class IMAGE_REL_BASED_ABSOLUTE(PEReloc):
-    pass
+    def relocate(self):
+        pass
 
 class IMAGE_REL_BASED_HIGHADJ(PEReloc):
     def __init__(self, owner, addr, next_rva):

--- a/cle/backends/pe/relocation/pereloc.py
+++ b/cle/backends/pe/relocation/pereloc.py
@@ -5,6 +5,8 @@ l=logging.getLogger(name=__name__)
 
 # Reference: https://msdn.microsoft.com/en-us/library/ms809762.aspx
 class PEReloc(Relocation):
+    AUTO_HANDLE_NONE = True
+
     def __init__(self, owner, symbol, addr, resolvewith=None):   # pylint: disable=unused-argument
         super(PEReloc, self).__init__(owner, symbol, addr)
 

--- a/cle/backends/tls/__init__.py
+++ b/cle/backends/tls/__init__.py
@@ -18,6 +18,7 @@ class TLSObject(Backend):
         self.next_module_id = 0
         self.tp_offset = 0
         self.max_modules = max_modules
+        self._finalized_modules = None
 
     def register_object(self, obj):
         """
@@ -30,6 +31,17 @@ class TLSObject(Backend):
 
         self.modules.append(obj)
 
+    def finalize_layout(self):
+        """
+        Will Be called when all objects have been registered and none have been mapped. Do the heavy
+        lifting in a subclass.
+        """
+        if self._finalized_modules == len(self.modules):
+            return
+        elif self._finalized_modules is not None:
+            raise CLEError("Trying to refinalize the TLS layout with more data. Are you trying to do dynamic loading with TLS? Report this as a bug")
+
+        self._finalized_modules = len(self.modules)
     def map_object(self, obj):
         # Grab the init images and map them into memory
         data = obj.memory.load(obj.tls_data_start, obj.tls_data_size).ljust(obj.tls_block_size, b'\0')

--- a/cle/backends/tls/__init__.py
+++ b/cle/backends/tls/__init__.py
@@ -53,9 +53,7 @@ class InternalTLSRelocation(Relocation):
         return self.val + self.owner.mapped_base
 
 class TLSObject(Backend):
-    def __init__(self, *args, loader=None, **kwargs):
-        kwargs['arch'] = loader.all_elf_objects[0].arch  # gdi soot
-        super().__init__(*args, loader=loader, **kwargs)
+    pass
 
 from .elf_tls import ELFThreadManager
 from .pe_tls import PEThreadManager

--- a/cle/backends/tls/__init__.py
+++ b/cle/backends/tls/__init__.py
@@ -8,9 +8,9 @@ class ThreadManager:
 
     Most of the heavy lifting will be handled in a subclass
     """
-    def __init__(self, loader, max_modules=256):
+    def __init__(self, loader, arch, max_modules=256):
         self.loader = loader
-        self.arch = self.loader.main_object.arch
+        self.arch = arch
         self.max_modules = max_modules
         self.modules = []
         self.threads = []
@@ -53,7 +53,9 @@ class InternalTLSRelocation(Relocation):
         return self.val + self.owner.mapped_base
 
 class TLSObject(Backend):
-    pass
+    def __init__(self, *args, loader=None, **kwargs):
+        kwargs['arch'] = loader.all_elf_objects[0].arch  # gdi soot
+        super().__init__(*args, loader=loader, **kwargs)
 
 from .elf_tls import ELFThreadManager
 from .pe_tls import PEThreadManager

--- a/cle/backends/tls/__init__.py
+++ b/cle/backends/tls/__init__.py
@@ -1,64 +1,59 @@
-from .. import Backend
-from ...memory import Clemory
+from ..relocation import Relocation
 from ...errors import CLEError
+from .. import Backend
 
-class TLSObject(Backend):
+class ThreadManager:
     """
-    CLE implements thread-local storage by treating the TLS region as another object to be loaded. Because of the
-    complex interactions between TLS and all the other objects that can be loaded into memory, each TLS object will
-    perform some basic initialization when instantiated, and then once all other objects have been loaded,
-    ``map_object()`` is called to actually put each object's image into memory.
+    This class tracks what data is thread-local and can generate thread initialization images
+
+    Most of the heavy lifting will be handled in a subclass
     """
     def __init__(self, loader, max_modules=256):
-        super(TLSObject, self).__init__('cle##tls', loader=loader)
+        self.loader = loader
         self.arch = self.loader.main_object.arch
-        self.memory = Clemory(self.arch)
-        self.modules = []
-        self.pic = True
-        self.next_module_id = 0
-        self.tp_offset = 0
         self.max_modules = max_modules
-        self._finalized_modules = None
+        self.modules = []
+        self.threads = []
 
     def register_object(self, obj):
-        """
-        Assign some thread-local identifiers to the module (object). Do the heavy lifting in a subclass.
-        """
+        if not obj.tls_used:
+            return False
         if len(self.modules) >= self.max_modules:
             raise CLEError("Too many loaded modules for TLS to handle... file this as a bug")
-        obj.tls_module_id = self.next_module_id
-        self.next_module_id += 1
+        obj.tls_module_id = len(self.modules)
 
         self.modules.append(obj)
+        return True
 
-    def finalize_layout(self):
-        """
-        Will Be called when all objects have been registered and none have been mapped. Do the heavy
-        lifting in a subclass.
-        """
-        if self._finalized_modules == len(self.modules):
-            return
-        elif self._finalized_modules is not None:
-            raise CLEError("Trying to refinalize the TLS layout with more data. Are you trying to do dynamic loading with TLS? Report this as a bug")
+    @staticmethod
+    def initialization_image(obj):
+        return obj.memory.load(obj.tls_data_start, obj.tls_data_size).ljust(obj.tls_block_size, b'\0')
 
-        self._finalized_modules = len(self.modules)
+    def new_thread(self, insert=True):
+        thread = self._thread_cls(self)
+        if insert:
+            self.loader._internal_load(thread)
+            self.threads.append(thread)
+        return thread
 
-    def map_modules(self):
-        # Grab the init images and map them into memory
-        for obj in self.modules:
-            data = obj.memory.load(obj.tls_data_start, obj.tls_data_size).ljust(obj.tls_block_size, b'\0')
-            self.memory.add_backer(self.tp_offset + obj.tls_block_offset, data)
+    @property
+    def _thread_cls(self):
+        raise NotImplementedError("This platform doesn't have an implementation of thread-local storage")
 
-class InternalTLSRelocation(object):
+
+class InternalTLSRelocation(Relocation):
+    AUTO_HANDLE_NONE = True
+
     def __init__(self, val, offset, owner):
+        super().__init__(owner, None, offset)
         self.val = val
-        self.offset = offset
-        self.owner = owner
-        self.symbol = None
-        self.resolved = True
 
-    def relocate(self):
-        self.owner.memory.pack_word(self.offset, self.val + self.owner.mapped_base)
+    @property
+    def value(self):
+        return self.val + self.owner.mapped_base
 
-from .elf_tls import ELFTLSObject
-from .pe_tls import PETLSObject
+class TLSObject(Backend):
+    pass
+
+from .elf_tls import ELFThreadManager
+from .pe_tls import PEThreadManager

--- a/cle/backends/tls/elf_tls.py
+++ b/cle/backends/tls/elf_tls.py
@@ -51,7 +51,7 @@ class ELFThreadManager(ThreadManager):
 
 class ELFTLSObject(TLSObject):
     def __init__(self, thread_manager: ELFThreadManager):
-        super().__init__('cle##tls', loader=thread_manager.loader)
+        super().__init__('cle##tls', loader=thread_manager.loader, arch=thread_manager.arch)
         self.tcb_offset: int = None
         self.dtv_offset: int = None
         self.tp_offset: int = None

--- a/cle/backends/tls/elf_tls.py
+++ b/cle/backends/tls/elf_tls.py
@@ -1,6 +1,16 @@
-import struct
+"""
+This module is used when parsing the Thread Local Storage of an ELF binary. It heavily uses the TLSArchInfo
+namedtuple from archinfo.
 
-from . import TLSObject, InternalTLSRelocation
+ELF TLS is implemented based on the following documents:
+
+    - https://www.uclibc.org/docs/tls.pdf
+    - https://www.uclibc.org/docs/tls-ppc.txt
+    - https://www.uclibc.org/docs/tls-ppc64.txt
+    - https://www.linux-mips.org/wiki/NPTL
+"""
+
+from . import InternalTLSRelocation, ThreadManager, TLSObject
 
 TLS_BLOCK_ALIGN = 0x10
 TLS_TOTAL_HEAD_SIZE = 0x4000
@@ -9,100 +19,86 @@ TLS_HEAD_ALIGN = 0x10000
 def roundup(val, to=TLS_BLOCK_ALIGN):
     return val - 1 + (to - ((val - 1) % to))
 
+class ELFThreadManager(ThreadManager):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.used_data = 0
+
+    def register_object(self, obj):
+        if not super().register_object(obj):
+            return False
+
+        # only track tls_block_offset for modules registered before the first thread
+        # ??? is this right
+        if not self.threads:
+            # tls_block_offset has these semantics: the thread pointer plus the block offset equals the address of the
+            # module's TLS data in memory
+            if self.arch.elf_tls.variant == 1:
+                obj.tls_block_offset = self.used_data
+            else:
+                obj.tls_block_offset = -self.used_data - roundup(obj.tls_block_size)
+
+            self.used_data += roundup(obj.tls_block_size)
+        return True
+
+    @property
+    def _thread_cls(self):
+        if self.arch.elf_tls.variant == 1:
+            return ELFTLSObjectV1
+        else:
+            return ELFTLSObjectV2
+
 
 class ELFTLSObject(TLSObject):
-    """
-    This class is used when parsing the Thread Local Storage of an ELF binary. It heavily uses the TLSArchInfo
-    namedtuple from archinfo.
+    def __init__(self, thread_manager: ELFThreadManager):
+        super().__init__('cle##tls', loader=thread_manager.loader)
+        self.tcb_offset: int = None
+        self.dtv_offset: int = None
+        self.tp_offset: int = None
+        self.head_offset: int = None
+        self._max_addr: int = None
+        self.tlsoffsets = [obj.tls_block_offset for obj in thread_manager.modules]
+        self.pic = True
 
-    ELF TLS is implemented based on the following documents:
+        self._calculate_pointers(thread_manager.used_data, thread_manager.max_modules)
 
-        - https://www.uclibc.org/docs/tls.pdf
-        - https://www.uclibc.org/docs/tls-ppc.txt
-        - https://www.uclibc.org/docs/tls-ppc64.txt
-        - https://www.linux-mips.org/wiki/NPTL
-    """
-    def __init__(self, loader, max_modules=256):
-        super(ELFTLSObject, self).__init__(loader, max_modules=max_modules)
-        self.next_module_id = 1
-        self.used_data = 0
-        self._max_addr = 0
-        self._finalized_modules = None
+        # add backer for header
+        self.memory.add_backer(self.head_offset, bytes(TLS_TOTAL_HEAD_SIZE))
 
-        self.tcb_offset = None
-        self.dtv_offset = None
-
-    def finalize_layout(self):
-        if self._finalized_modules == len(self.modules):
-            return
-
-        super().finalize_layout()  # sets self._finalized_modules
-
-        if self.arch.elf_tls.variant == 1:
-            # variant 1: memory is laid out like so:
-            # [header][module data][dtv]
-            #         ^ thread pointer
-            self.tcb_offset = TLS_TOTAL_HEAD_SIZE - self.arch.elf_tls.tcbhead_size
-            self.tp_offset = TLS_TOTAL_HEAD_SIZE    # CRITICAL DIFFERENCE FROM THE DOC - variant 1 seems to expect the thread pointer points to the end of the TCB
-            self.dtv_offset = TLS_TOTAL_HEAD_SIZE + self.used_data + 2 * self.arch.bytes
-            self._max_addr = self.dtv_offset + 2*self.arch.bytes*self.max_modules
-            self.memory.add_backer(0, bytes(TLS_TOTAL_HEAD_SIZE))
-        else:
-            # variant 2: memory is laid out like so:
-            # [module data][header][dtv]
-            #              ^ thread pointer
-            self.tcb_offset = roundup(self.used_data, TLS_HEAD_ALIGN)
-            self.tp_offset = roundup(self.used_data, TLS_HEAD_ALIGN)
-            self.dtv_offset = self.tp_offset + TLS_TOTAL_HEAD_SIZE + 2*self.arch.bytes
-            self._max_addr = self.dtv_offset + 2*self.arch.bytes*self.max_modules
-            self.memory.add_backer(self.tp_offset, bytes(TLS_TOTAL_HEAD_SIZE))
-
-        self.memory.add_backer(self.dtv_offset - 2*self.arch.bytes, bytes(2*self.arch.bytes*self.max_modules + 2*self.arch.bytes))
+        # add backer for dtv
+        self.memory.add_backer(self.dtv_offset - 2*self.arch.bytes, bytes(2*self.arch.bytes*thread_manager.max_modules + 2*self.arch.bytes))
 
         # Set the appropriate pointers in the tcbhead
         for off in self.arch.elf_tls.head_offsets:
-            self.drop_int(self.tp_offset, off + self.tcb_offset, True)
+            self._drop_int(off + self.tcb_offset, self.tp_offset, True)
         for off in self.arch.elf_tls.dtv_offsets:
-            self.drop_int(self.dtv_offset, off + self.tcb_offset, True)
+            self._drop_int(off + self.tcb_offset, self.dtv_offset, True)
         for off in self.arch.elf_tls.pthread_offsets:
-            self.drop_int(self.tp_offset, off + self.tcb_offset, True)     # ?????
+            self._drop_int(off + self.tcb_offset, self.tp_offset, True)  # ?????
 
         # Set up the DTV
         # at dtv[-1] there's capacity, at dtv[0] there's count (technically generation number?)
-        self.drop_int(self.max_modules-1, self.dtv_offset - 2*self.arch.bytes)
-        self.drop_int(len(self.modules), self.dtv_offset)
+        self._drop_int(self.dtv_offset - 2 * self.arch.bytes, thread_manager.max_modules - 1)
+        self._drop_int(self.dtv_offset, len(thread_manager.modules))
 
-        for obj in self.modules:
+        # set up each module
+        for obj in thread_manager.modules:
+            # dtv entry
             dtv_entry_offset = self.dtv_offset + 2*self.arch.bytes*obj.tls_module_id
-            self.drop_int(self.tp_offset + obj.tls_block_offset + self.arch.elf_tls.dtv_entry_offset, dtv_entry_offset, True)
-            self.drop_int(1, dtv_entry_offset + self.arch.bytes)
+            self._drop_int(dtv_entry_offset, self.tp_offset + obj.tls_block_offset + self.arch.elf_tls.dtv_entry_offset, True)
+            self._drop_int(dtv_entry_offset + self.arch.bytes, 1)
 
+            # initialization image
+            image = thread_manager.initialization_image(obj)
+            self.memory.add_backer(self.tp_offset + obj.tls_block_offset, image)
 
-    def drop(self, string, offset):
-        for i, c in enumerate(string):
-            self.memory[i + offset] = c
+    def _calculate_pointers(self, used_data, max_modules):
+        raise NotImplementedError
 
-    def drop_int(self, num, offset, needs_relocation=False):
+    def _drop_int(self, offset, num, needs_relocation=False):
         if needs_relocation:
             self.relocs.append(InternalTLSRelocation(num, offset, self))
-            num += self.mapped_base
-
-        self.drop(struct.pack(self.arch.struct_fmt(), num), offset)
-
-    def register_object(self, obj):
-        if not obj.tls_used:
-            return
-
-        super(ELFTLSObject, self).register_object(obj)
-
-        # tls_block_offset has these semantics: the thread pointer plus the block offset equals the address of the
-        # module's TLS data in memory
-        if self.arch.elf_tls.variant == 1:
-            obj.tls_block_offset = self.used_data
-        else:
-            obj.tls_block_offset = -self.used_data - roundup(obj.tls_block_size)
-
-        self.used_data += roundup(obj.tls_block_size)
+        self.memory.pack_word(offset, num)
 
     @property
     def thread_pointer(self):
@@ -126,4 +122,26 @@ class ELFTLSObject(TLSObject):
         """
         basically ``__tls_get_addr``.
         """
-        return self.user_thread_pointer + self.modules[module_id-1].tls_block_offset + offset
+        return self.memory.unpack_word(self.dtv_offset + module_id * self.arch.bytes) + offset
+
+class ELFTLSObjectV1(ELFTLSObject):
+    # variant 1: memory is laid out like so:
+    # [header][module data]
+    #         ^ thread pointer
+    def _calculate_pointers(self, used_data, max_modules):
+        self.tcb_offset = TLS_TOTAL_HEAD_SIZE - self.arch.elf_tls.tcbhead_size
+        self.tp_offset = TLS_TOTAL_HEAD_SIZE    # CRITICAL DIFFERENCE FROM THE DOC - variant 1 seems to expect the thread pointer points to the end of the TCB
+        self.dtv_offset = TLS_TOTAL_HEAD_SIZE + used_data + 2 * self.arch.bytes
+        self.head_offset = 0                    # ^^ that's the point of this field
+        self._max_addr = self.dtv_offset + 2*self.arch.bytes*max_modules
+
+class ELFTLSObjectV2(ELFTLSObject):
+    # variant 2: memory is laid out like so:
+    # [module data][header]
+    #              ^ thread pointer
+    def _calculate_pointers(self, used_data, max_modules):
+        self.tcb_offset = roundup(used_data, TLS_HEAD_ALIGN)
+        self.tp_offset = roundup(used_data, TLS_HEAD_ALIGN)
+        self.dtv_offset = self.tp_offset + TLS_TOTAL_HEAD_SIZE + 2*self.arch.bytes
+        self.head_offset = self.tp_offset
+        self._max_addr = self.dtv_offset + 2*self.arch.bytes*max_modules

--- a/cle/backends/tls/pe_tls.py
+++ b/cle/backends/tls/pe_tls.py
@@ -53,10 +53,8 @@ class PETLSObject(TLSObject):
     TLS array to get the start address of the TLS data.
     """
 
-    def __init__(self, loader, max_modules=256, max_data=0x8000):
+    def __init__(self, loader, max_modules=256):
         super(PETLSObject, self).__init__(loader, max_modules=max_modules)
-        self.max_data = max_data
-
         self.used_data = 0
         self.data_start = self.arch.bytes*max_modules
 
@@ -71,8 +69,6 @@ class PETLSObject(TLSObject):
         data_start = self.data_start + self.used_data
         obj.tls_block_offset = data_start
         self.used_data += obj.tls_block_size
-        if self.used_data > self.max_data:
-            raise CLEError("Too much TLS data to handle... file this as a bug")
 
         # The PE TLS header says to write its index into a given address
         obj.memory.pack_word(AT.from_lva(obj.tls_index_address, obj).to_rva(), obj.tls_module_id)

--- a/cle/backends/tls/pe_tls.py
+++ b/cle/backends/tls/pe_tls.py
@@ -66,7 +66,7 @@ class PETLSObject(TLSObject):
     """
 
     def __init__(self, thread_manager: PEThreadManager):
-        super(PETLSObject, self).__init__('cle##tls', loader=thread_manager.loader)
+        super(PETLSObject, self).__init__('cle##tls', loader=thread_manager.loader, arch=thread_manager.arch)
 
         self.used_modules = len(thread_manager.modules)
         self.data_start = self.arch.bytes*thread_manager.max_modules

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -204,12 +204,13 @@ class Loader:
         Accessing this property will load this object into memory if it was not previously present.
 
         proposed model for how multiple extern objects should work:
-        1) extern objects are a linked list. the one in loader._extern_object is the head of the list
-        2) each round of explicit loads generates a new extern object if it has unresolved dependencies. this object
-           has exactly the size necessary to hold all its exports.
-        3) All requests for size are passed down the chain until they reach an object which has the space to service it
-           or an object which has not yet been mapped. If all objects have been mapped and are full, a new extern object
-           is mapped with a fixed size.
+
+            1) extern objects are a linked list. the one in loader._extern_object is the head of the list
+            2) each round of explicit loads generates a new extern object if it has unresolved dependencies. this object
+               has exactly the size necessary to hold all its exports.
+            3) All requests for size are passed down the chain until they reach an object which has the space to service it
+               or an object which has not yet been mapped. If all objects have been mapped and are full, a new extern object
+               is mapped with a fixed size.
         """
         if self._extern_object is None:
             if self._extern_size is None:

--- a/tests/test_arm_firmware.py
+++ b/tests/test_arm_firmware.py
@@ -1,7 +1,8 @@
-
 import os
 import cle
-from nose.tools import assert_true
+import pyvex
+import struct
+from nose.tools import assert_equal
 
 
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'binaries', 'tests'))
@@ -31,12 +32,11 @@ def test_thumb_object():
     for r in l.main_object.relocs:
         if r.__class__ == cle.backends.elf.relocation.arm.R_ARM_THM_JUMP24:
             if r.symbol.name == 'HAL_I2C_ER_IRQHandler':
-                if r.value == 0xbff7f000:
-                    break
+                irsb = pyvex.lift(struct.pack('<I', r.value), r.rebased_addr + 1, l.main_object.arch, bytes_offset=1)
+                assert_equal(irsb.default_exit_target, r.resolvedby.rebased_addr)
+                break
     else:
-        # We missed it
-        assert_true(r.value == 0xbff7f000)
-
+        assert False, "Could not find JUMP24 relocation for HAL_I2C_ER_IRQHandler"
 
 if __name__ == "__main__":
     test_thumb_object()

--- a/tests/test_namedregion.py
+++ b/tests/test_namedregion.py
@@ -14,8 +14,8 @@ def test_basic_named_region():
     # Standard CortexM regions
     mmio = NamedRegion("mmio", 0x40000000, 0x50000000)
     sys = NamedRegion("sys", 0xe000e000, 0xe0010000)
-    l.add_object(mmio)
-    l.add_object(sys)
+    l.dynamic_load(mmio)
+    l.dynamic_load(sys)
 
     # In order to ensure static analysis works, we must be able to ask
     # CLE what owns these addresses and get a valid answer.

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -24,10 +24,8 @@ def test_overlap():
     obj1 = MockBackend(0x8047000, 0x2000, arch=ld.main_object.arch)
     obj2 = MockBackend(0x8047000, 0x1000, arch=ld.main_object.arch)
 
-    ld._register_object(obj1)
-    ld._register_object(obj2)
-    ld._map_object(obj1)
-    ld._map_object(obj2)
+    ld.dynamic_load(obj1)
+    ld.dynamic_load(obj2)
 
     nose.tools.assert_equal(obj2.mapped_base, 0x8047000)
     nose.tools.assert_greater(obj1.mapped_base, 0x8048000)

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -104,6 +104,7 @@ def test_dll():
 def test_tls():
     exe = os.path.join(TEST_BASE, 'tests', 'x86', 'windows', 'TLS.exe')
     ld = cle.Loader(exe, auto_load_libs=False)
+    tls = ld.tls.new_thread()
 
     nose.tools.assert_true(ld.main_object.tls_used)
     nose.tools.assert_equals(ld.main_object.tls_data_start, 0x1b000)
@@ -112,9 +113,8 @@ def test_tls():
     nose.tools.assert_equals(ld.main_object.tls_callbacks, [0x411302])
     nose.tools.assert_equals(ld.main_object.tls_block_size, ld.main_object.tls_data_size)
 
-    tls = ld.tls_objects[0]
     nose.tools.assert_is_not_none(tls)
-    nose.tools.assert_equals(len(tls.modules), 1)
+    nose.tools.assert_equals(len(ld.tls.modules), 1)
     nose.tools.assert_equals(tls.get_tls_data_addr(0), tls.memory.unpack_word(0))
     nose.tools.assert_raises(IndexError, tls.get_tls_data_addr, 1)
 

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -112,7 +112,7 @@ def test_tls():
     nose.tools.assert_equals(ld.main_object.tls_callbacks, [0x411302])
     nose.tools.assert_equals(ld.main_object.tls_block_size, ld.main_object.tls_data_size)
 
-    tls = ld.tls_object
+    tls = ld.tls_objects[0]
     nose.tools.assert_is_not_none(tls)
     nose.tools.assert_equals(len(tls.modules), 1)
     nose.tools.assert_equals(tls.get_tls_data_addr(0), tls.memory.unpack_word(0))


### PR DESCRIPTION
Also changes the way thread local storage is handled, so that multiple thread-local storage regions for multiple threads can be explicitly created.

- There can now be multiple externs objects, and they will be dynamically sized based on how much data is needed by the unsatisfied imports.
- When you ask to manually allocate space in the externs, if all the extern objects are full then another one will be created and mapped.
- `loader.tls_object` has been replaced by `loader.tls`, which is strictly a manager interface for doing bookkeeping about how which objects have thread-local allocations.
- `loader.tls` has the following interface
  - `.modules: List[Backend]` - all objects which have thread-local allocations
  - `.new_thread(insert=True) -> TLSObject` - make a new tls region, conditionally mapping it to global memory
   - `.threads: List[TLSObject]` - all tls regions which have been inserted

Generally, this makes the loading process MUCH clearner, decoupling several parts which were previously weirdly tightly coupled. At this point the only "hacks" we have still have in the code are related to java loading, which I think in the future we should address by having a more explicit division between the native and java objects.

sync angr/angr#1964