### PR TITLE
CLE refactor February 2020

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -18,6 +18,7 @@ class FunctionHintSource:
     Enums that describe the source of function hints.
     """
     EH_FRAME = 0
+    EXTERNAL_EH_FRAME = 1
 
 
 class FunctionHint:

--- a/cle/backends/binja.py
+++ b/cle/backends/binja.py
@@ -41,7 +41,7 @@ class BinjaSymbol(Symbol):
         else:
             symtype = SymbolType.TYPE_OTHER
 
-        super(BinjaSymbol, self).__init__(owner,
+        super().__init__(owner,
                                           sym.raw_name,
                                           AT.from_rva(sym.address, owner).to_rva(),
                                           owner.bv.address_size,
@@ -79,7 +79,7 @@ class BinjaBin(Backend):
                       "x86_64": archinfo.ArchAMD64()}
 
     def __init__(self, binary, *args, **kwargs):
-        super(BinjaBin, self).__init__(binary, *args, **kwargs)
+        super().__init__(binary, *args, **kwargs)
         if not bn:
             raise CLEError(BINJA_NOT_INSTALLED_STR)
         # get_view_of_file can take a bndb or binary - wait for autoanalysis to complete

--- a/cle/backends/blob.py
+++ b/cle/backends/blob.py
@@ -1,6 +1,5 @@
 from . import Backend, register_backend
 from ..errors import CLEError
-from ..patched_stream import PatchedStream
 from .region import Segment
 import logging
 l = logging.getLogger(name=__name__)
@@ -13,7 +12,7 @@ class Blob(Backend):
     """
     is_default = True # Tell CLE to automatically consider using the Blob backend
 
-    def __init__(self, path, offset=None, segments=None, **kwargs):
+    def __init__(self, *args, offset=None, segments=None, **kwargs):
         """
         :param arch:   (required) an :class:`archinfo.Arch` for the binary blob.
         :param offset: Skip this many bytes from the beginning of the file.
@@ -25,23 +24,22 @@ class Blob(Backend):
         if 'custom_offset' in kwargs:
             offset = kwargs.pop('custom_offset')
             l.critical('Deprecation warning: the custom_offset parameter has been renamed to offset')
-        super(Blob, self).__init__(path, **kwargs)
+        super(Blob, self).__init__(*args, **kwargs)
 
         if self.arch is None:
             raise CLEError("Must specify arch when loading blob!")
 
         if self._custom_entry_point is None:
-            l.warning("No entry_point was specified for blob %s, assuming 0", path)
-            self._custom_entry_point = 0
+            l.warning("No entry_point was specified for blob %s, assuming 0", self.binary_basename)
 
-        self._entry = self._custom_entry_point
+        self._entry = 0
         self._max_addr = 0
         self._min_addr = 2**64
 
         try:
             self.linked_base = kwargs['base_addr']
         except KeyError:
-            l.warning("No base_addr was specified for blob %s, assuming 0", path)
+            l.warning("No base_addr was specified for blob %s, assuming 0", self.binary_basename)
         self.mapped_base = self.linked_base
 
         self.os = 'unknown'
@@ -50,14 +48,14 @@ class Blob(Backend):
             if segments is not None:
                 l.error("You can't specify both offset and segments. Taking only the segments data")
             else:
-                self.binary_stream.seek(0, 2)
-                segments = [(offset, self.linked_base, self.binary_stream.tell() - offset)]
+                self._binary_stream.seek(0, 2)
+                segments = [(offset, self.linked_base, self._binary_stream.tell() - offset)]
         else:
             if segments is not None:
                 pass
             else:
-                self.binary_stream.seek(0, 2)
-                segments = [(0, self.linked_base, self.binary_stream.tell())]
+                self._binary_stream.seek(0, 2)
+                segments = [(0, self.linked_base, self._binary_stream.tell())]
 
         for file_offset, mem_addr, size in segments:
             self._load(file_offset, mem_addr, size)
@@ -79,8 +77,8 @@ class Blob(Backend):
         Load a segment into memory.
         """
 
-        self.binary_stream.seek(file_offset)
-        string = self.binary_stream.read(size)
+        self._binary_stream.seek(file_offset)
+        string = self._binary_stream.read(size)
         self.memory.add_backer(mem_addr - self.linked_base, string)
         seg = Segment(file_offset, mem_addr, size, size)
         self.segments.append(seg)
@@ -105,30 +103,6 @@ class Blob(Backend):
     @classmethod
     def check_compatibility(cls, spec, obj): # pylint: disable=unused-argument
         return True
-
-    def __getstate__(self):
-        if self.binary is None:
-            raise ValueError("Can't pickle an object loaded from a stream")
-
-        # Get a copy of our pickleable self
-        state = dict(self.__dict__)
-
-        # Trash the unpickleable
-        if type(self.binary_stream) is PatchedStream:
-            state['binary_stream'].stream = None
-        else:
-            state['binary_stream'] = None
-
-        return state
-
-    def __setstate__(self, data):
-
-        self.__dict__.update(data)
-
-        if self.binary_stream is None:
-            self.binary_stream = open(self.binary, 'rb')
-        else:
-            self.binary_stream.stream = open(self.binary, 'rb')
 
 
 register_backend("blob", Blob)

--- a/cle/backends/blob.py
+++ b/cle/backends/blob.py
@@ -24,7 +24,7 @@ class Blob(Backend):
         if 'custom_offset' in kwargs:
             offset = kwargs.pop('custom_offset')
             l.critical('Deprecation warning: the custom_offset parameter has been renamed to offset')
-        super(Blob, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         if self.arch is None:
             raise CLEError("Must specify arch when loading blob!")

--- a/cle/backends/cgc/backedcgc.py
+++ b/cle/backends/cgc/backedcgc.py
@@ -5,7 +5,7 @@ from ..region import Segment
 
 class FakeSegment(Segment):
     def __init__(self, start, size):
-        super(FakeSegment, self).__init__(0, start, 0, size)
+        super().__init__(0, start, 0, size)
         self.is_readable = True
         self.is_writable = True
         self.is_executable = False
@@ -29,7 +29,7 @@ class BackedCGC(CGC):
         :param permissions_map:         A dict of memory region to permission flags
         :param current_allocation_base: An integer representing the current address of the top of the CGC heap.
         """
-        super(BackedCGC, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.memory_backer = memory_backer
         self.register_backer = register_backer

--- a/cle/backends/cgc/backedcgc.py
+++ b/cle/backends/cgc/backedcgc.py
@@ -18,8 +18,8 @@ class BackedCGC(CGC):
     """
     is_default = True # Tell CLE to automatically consider using the BackedCGC backend
 
-    def __init__(self, path, memory_backer=None, register_backer=None, writes_backer=None, permissions_map=None,
-                 current_allocation_base=None, *args, **kwargs):
+    def __init__(self, *args, memory_backer=None, register_backer=None, writes_backer=None, permissions_map=None,
+                 current_allocation_base=None, **kwargs):
         """
         :param path:                    File path to CGC executable.
         :param memory_backer:           A dict of memory content, with beginning address of each segment as key and
@@ -29,7 +29,7 @@ class BackedCGC(CGC):
         :param permissions_map:         A dict of memory region to permission flags
         :param current_allocation_base: An integer representing the current address of the top of the CGC heap.
         """
-        super(BackedCGC, self).__init__(path, *args, **kwargs)
+        super(BackedCGC, self).__init__(*args, **kwargs)
 
         self.memory_backer = memory_backer
         self.register_backer = register_backer

--- a/cle/backends/cgc/cgc.py
+++ b/cle/backends/cgc/cgc.py
@@ -1,12 +1,10 @@
-import binascii
-
 from ...address_translator import AT
 from .. import register_backend
 from ..elf import ELF
 from ...patched_stream import PatchedStream
 
-ELF_HEADER = binascii.unhexlify("7f45 4c46 0101 0100 0000 0000 0000 0000".replace(" ", ""))
-CGC_HEADER = binascii.unhexlify("7f43 4743 0101 0143 014d 6572 696e 6f00".replace(" ", ""))
+ELF_HEADER = bytes.fromhex("7f454c46010101000000000000000000")
+CGC_HEADER = bytes.fromhex("7f43474301010143014d6572696e6f00")
 
 
 class CGC(ELF):
@@ -33,7 +31,7 @@ class CGC(ELF):
     @staticmethod
     def is_compatible(stream):
         stream.seek(0)
-        identstring = stream.read(0x1000)
+        identstring = stream.read(4)
         stream.seek(0)
         if identstring.startswith(b'\x7fCGC'):
             return True

--- a/cle/backends/cgc/cgc.py
+++ b/cle/backends/cgc/cgc.py
@@ -15,15 +15,9 @@ class CGC(ELF):
     """
     is_default = True # Tell CLE to automatically consider using the CGC backend
 
-    def __init__(self, binary, *args, **kwargs):
-        if hasattr(binary, 'seek'):
-            filename = None
-            stream = PatchedStream(binary, [(0, ELF_HEADER)])
-        else:
-            filename = binary
-            stream = PatchedStream(open(binary, 'rb'), [(0, ELF_HEADER)])
-        kwargs['filename'] = filename
-        super(CGC, self).__init__(stream, *args, **kwargs)
+    def __init__(self, binary, binary_stream, *args, **kwargs):
+        binary_stream = PatchedStream(binary_stream, [(0, ELF_HEADER)])
+        super(CGC, self).__init__(binary, binary_stream, *args, **kwargs)
         self.memory.store(AT.from_raw(0, self).to_rva(), CGC_HEADER)  # repair the CGC header
         self.os = 'cgc'
         self.execstack = True  # the stack is always executable in CGC

--- a/cle/backends/cgc/cgc.py
+++ b/cle/backends/cgc/cgc.py
@@ -17,7 +17,7 @@ class CGC(ELF):
 
     def __init__(self, binary, binary_stream, *args, **kwargs):
         binary_stream = PatchedStream(binary_stream, [(0, ELF_HEADER)])
-        super(CGC, self).__init__(binary, binary_stream, *args, **kwargs)
+        super().__init__(binary, binary_stream, *args, **kwargs)
         self.memory.store(AT.from_raw(0, self).to_rva(), CGC_HEADER)  # repair the CGC header
         self.os = 'cgc'
         self.execstack = True  # the stack is always executable in CGC
@@ -33,7 +33,7 @@ class CGC(ELF):
 
     def _load_segment(self, seg):
         if seg.header.p_memsz > 0:
-            super(CGC, self)._load_segment(seg)
+            super()._load_segment(seg)
 
     supported_filetypes = ['cgc']
 

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -492,6 +492,7 @@ class ELF(MetaELF):
         self.reader = elffile.ELFFile(self.binary_stream)
         if self._dynamic and 'DT_STRTAB' in self._dynamic:
             self.strtab = next(x for x in self.reader.iter_segments() if x.header.p_type == 'PT_DYNAMIC')._get_stringtable()
+            self.__neuter_streams(self.strtab)
             if 'DT_SYMTAB' in self._dynamic and 'DT_SYMENT' in self._dynamic:
                 fakesymtabheader = {
                     'sh_offset': AT.from_lva(self._dynamic['DT_SYMTAB'], self).to_rva(),
@@ -515,6 +516,8 @@ class ELF(MetaELF):
                             self.memory,
                             AT.from_lva(self._dynamic['DT_HASH'], self).to_rva(),
                             self.arch)
+
+        self.binary_stream.close()
 
     def __register_segments(self):
         self.linking = 'static'

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -32,7 +32,7 @@ class ELF(MetaELF):
     """
     is_default = True  # Tell CLE to automatically consider using the ELF backend
 
-    def __init__(self, binary, addend=None, **kwargs):
+    def __init__(self, binary, addend=None, inhibit_close=False, **kwargs):
         super(ELF, self).__init__(binary, **kwargs)
         patch_undo = []
         try:
@@ -152,7 +152,8 @@ class ELF(MetaELF):
         for offset, patch in patch_undo:
             self.memory.store(AT.from_lva(self.min_addr + offset, self).to_rva(), patch)
 
-        self.binary_stream.close()
+        if not inhibit_close:
+            self.binary_stream.close()
 
 
     #

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -33,7 +33,7 @@ class ELF(MetaELF):
     is_default = True  # Tell CLE to automatically consider using the ELF backend
 
     def __init__(self, *args, addend=None, debug_symbols=None, **kwargs):
-        super(ELF, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         patch_undo = []
         try:
             self._reader = elffile.ELFFile(self._binary_stream)

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -160,7 +160,7 @@ class ELF(MetaELF):
         for offset, patch in patch_undo:
             self.memory.store(AT.from_lva(self.min_addr + offset, self).to_rva(), patch)
 
-        if not inhibit_close:
+        if not inhibit_close and self.binary is not None:
             self.binary_stream.close()
 
 

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -33,7 +33,6 @@ class CoreNote:
             self.n_type = CoreNote.n_type_lookup[n_type]
         self.name = name
         self.desc = desc
-        self.filename_lookup = []
 
     def __repr__(self):
         return "<Note %s %s %#x>" % (self.name, self.n_type, len(self.desc))
@@ -48,7 +47,7 @@ class ELFCore(ELF):
     def __init__(self, binary, inhibit_close=False, **kwargs):
         super(ELFCore, self).__init__(binary, inhibit_close=True, **kwargs)
 
-        self.notes = []
+        self.filename_lookup = []
         self.__current_thread = None
         self._threads = []
         self.auxv = {}
@@ -236,9 +235,8 @@ class ELFCore(ELF):
                     byte = self.__dummy_clemory[pos]
                     if byte == 0:
                         break
-                    else:
-                        value.append(byte)
-                        pos += 1
+                    value.append(byte)
+                    pos += 1
                 value = bytes(value)
 
             self.auxv[code_str] = value

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -18,8 +18,8 @@ class ELFCore(ELF):
     """
     is_default = True # Tell CLE to automatically consider using the ELFCore backend
 
-    def __init__(self, binary, **kwargs):
-        super(ELFCore, self).__init__(binary, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super(ELFCore, self).__init__(*args, **kwargs)
 
         self.filename_lookup = []
         self.__current_thread = None

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -45,8 +45,8 @@ class ELFCore(ELF):
     """
     is_default = True # Tell CLE to automatically consider using the ELFCore backend
 
-    def __init__(self, binary, **kwargs):
-        super(ELFCore, self).__init__(binary, **kwargs)
+    def __init__(self, binary, inhibit_close=False, **kwargs):
+        super(ELFCore, self).__init__(binary, inhibit_close=True, **kwargs)
 
         self.notes = []
         self.__current_thread = None
@@ -54,6 +54,9 @@ class ELFCore(ELF):
         self.auxv = {}
 
         self.__extract_note_info()
+
+        if not inhibit_close:
+            self.binary_stream.close()
 
     @staticmethod
     def is_compatible(stream):

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -5,6 +5,7 @@ import logging
 from .elf import ELF
 from .. import register_backend
 from ...errors import CLEError, CLECompatibilityError
+from ...memory import Clemory
 
 l = logging.getLogger(name=__name__)
 
@@ -32,6 +33,7 @@ class CoreNote:
             self.n_type = CoreNote.n_type_lookup[n_type]
         self.name = name
         self.desc = desc
+        self.filename_lookup = []
 
     def __repr__(self):
         return "<Note %s %s %#x>" % (self.name, self.n_type, len(self.desc))
@@ -47,7 +49,9 @@ class ELFCore(ELF):
         super(ELFCore, self).__init__(binary, **kwargs)
 
         self.notes = []
-        self.prstatuses = []
+        self.__current_thread = None
+        self._threads = []
+        self.auxv = {}
 
         self.__extract_note_info()
 
@@ -62,14 +66,19 @@ class ELFCore(ELF):
             return False
         return False
 
+    def __cycle_thread(self):
+        if self.__current_thread is not None:
+            self._threads.append(self.__current_thread)
+        self.__current_thread = {}
+
     @property
     def threads(self):
-        return list(range(len(self.prstatuses)))
+        return list(range(len(self._threads)))
 
     def thread_registers(self, thread=None):
         if thread is None:
             thread = 0
-        return self.prstatuses[thread]['registers']
+        return self._threads[thread]['registers']
 
     def __extract_note_info(self):
         """
@@ -77,37 +86,36 @@ class ELFCore(ELF):
         """
         for seg_readelf in self.reader.iter_segments():
             if seg_readelf.header.p_type == 'PT_NOTE':
-                self.__parse_notes(seg_readelf)
-                break
-        else:
-            l.warning("Could not find note segment, cannot initialize registers")
+                for note in seg_readelf.iter_notes():
+                    if note.n_type == 'NT_PRSTATUS':
+                        self.__cycle_thread()
+                        self.__parse_prstatus(note.n_desc.encode('latin-1'))  # ???
+                    elif note.n_type == 'NT_FILE':
+                        self.__parse_files(note.n_desc)
+                    elif note.n_type == 'NT_AUXV':
+                        self.__parse_auxv(note.n_desc.encode('latin-1'))
+                    elif note.n_type == 512 and self.arch.name == 'X86':
+                        self.__parse_x86_tls(note.n_desc.encode('latin-1'))
 
-    def __parse_notes(self, seg):
-        """
-        This exists, because note parsing in elftools is not good.
-        """
+        self.__cycle_thread()
+        if not self._threads:
+            l.warning("Could not find thread info, cannot initialize registers")
+        elif self.arch.name == 'X86' and 'segments' not in self._threads[0]:
+            l.warning("This core dump does not contain TLS information. threads will be matched to TLS regions via heuristics")
+            pointer_rand = self.auxv['AT_RANDOM'][4:8]
+            all_locations = [addr - 0x18 for addr in self.__dummy_clemory.find(pointer_rand) if self.__dummy_clemory.unpack_word(addr - 0x18) == addr - 0x18]
+            # the heuristic is that generally threads are allocated with descending tls addresses
+            for thread, loc in zip(self._threads, reversed(all_locations)):
+                thread['segments'] = {thread['registers']['gs'] >> 3: (loc, 0xfffff, 0x51)}
 
-        blob = seg.data()
+    @property
+    def __dummy_clemory(self):
+        dummy_clemory = Clemory(self.arch, root=True)
+        dummy_clemory.add_backer(self.linked_base, self.memory)
+        return dummy_clemory
 
-        note_pos = 0
-        while note_pos < len(blob):
-            name_sz, desc_sz, n_type = struct.unpack("<3I", blob[note_pos:note_pos+12])
-            name_sz_rounded = (((name_sz + (4 - 1)) // 4) * 4)
-            desc_sz_rounded = (((desc_sz + (4 - 1)) // 4) * 4)
-            # description size + the rounded name size + header size
-            n_size = desc_sz_rounded + name_sz_rounded + 12
 
-            # name_sz includes the null byte
-            name = blob[note_pos+12:note_pos+12+name_sz-1]
-            desc = blob[note_pos+12+name_sz_rounded:note_pos+12+name_sz_rounded+desc_sz]
-
-            self.notes.append(CoreNote(n_type, name, desc))
-            note_pos += n_size
-
-        # prstatus
-        self.prstatuses = [self.__parse_prstatus(x) for x in self.notes if x.n_type == 'NT_PRSTATUS']
-
-    def __parse_prstatus(self, prstatus):
+    def __parse_prstatus(self, desc):
         """
         Parse out the prstatus, accumulating the general purpose register values. Supports AMD64, X86, ARM, and AARCH64
         at the moment.
@@ -118,10 +126,10 @@ class ELFCore(ELF):
         # TODO: support all architectures angr supports
 
         result = {}
-        result['si_signo'], result['si_code'], result['si_errno'] = struct.unpack("<3I", prstatus.desc[:12])
+        result['si_signo'], result['si_code'], result['si_errno'] = struct.unpack("<3I", desc[:12])
 
         # this field is a short, but it's padded to an int
-        result['pr_cursig'] = struct.unpack("<I", prstatus.desc[12:16])[0]
+        result['pr_cursig'] = struct.unpack("<I", desc[12:16])[0]
 
         arch_bytes = self.arch.bytes
         if arch_bytes == 4:
@@ -131,27 +139,27 @@ class ELFCore(ELF):
         else:
             raise CLEError("Architecture must have a bitwidth of either 64 or 32")
 
-        result['pr_sigpend'], result['pr_sighold'] = struct.unpack("<" + (fmt * 2), prstatus.desc[16:16+(2*arch_bytes)])
+        result['pr_sigpend'], result['pr_sighold'] = struct.unpack("<" + (fmt * 2), desc[16:16+(2*arch_bytes)])
 
-        attrs = struct.unpack("<IIII", prstatus.desc[16+(2*arch_bytes):16+(2*arch_bytes)+(4*4)])
+        attrs = struct.unpack("<IIII", desc[16+(2*arch_bytes):16+(2*arch_bytes)+(4*4)])
         result['pr_pid'], result['pr_ppid'], result['pr_pgrp'], result['pr_sid'] = attrs
 
         # parse out the 4 timevals
         pos = 16+(2*arch_bytes)+(4*4)
-        usec = struct.unpack("<" + fmt, prstatus.desc[pos:pos+arch_bytes])[0] * 1000
-        result['pr_utime_usec'] = struct.unpack("<" + fmt, prstatus.desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
+        usec = struct.unpack("<" + fmt, desc[pos:pos+arch_bytes])[0] * 1000
+        result['pr_utime_usec'] = struct.unpack("<" + fmt, desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
 
         pos += arch_bytes * 2
-        usec = struct.unpack("<" + fmt, prstatus.desc[pos:pos+arch_bytes])[0] * 1000
-        result['pr_stime_usec'] = struct.unpack("<" + fmt, prstatus.desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
+        usec = struct.unpack("<" + fmt, desc[pos:pos+arch_bytes])[0] * 1000
+        result['pr_stime_usec'] = struct.unpack("<" + fmt, desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
 
         pos += arch_bytes * 2
-        usec = struct.unpack("<" + fmt, prstatus.desc[pos:pos+arch_bytes])[0] * 1000
-        result['pr_cutime_usec'] = struct.unpack("<" + fmt, prstatus.desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
+        usec = struct.unpack("<" + fmt, desc[pos:pos+arch_bytes])[0] * 1000
+        result['pr_cutime_usec'] = struct.unpack("<" + fmt, desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
 
         pos += arch_bytes * 2
-        usec = struct.unpack("<" + fmt, prstatus.desc[pos:pos+arch_bytes])[0] * 1000
-        result['pr_cstime_usec'] = struct.unpack("<" + fmt, prstatus.desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
+        usec = struct.unpack("<" + fmt, desc[pos:pos+arch_bytes])[0] * 1000
+        result['pr_cstime_usec'] = struct.unpack("<" + fmt, desc[pos+arch_bytes:pos+arch_bytes*2])[0] + usec
 
         pos += arch_bytes * 2
 
@@ -159,8 +167,8 @@ class ELFCore(ELF):
         if self.arch.name == 'AMD64':
             # register names as they appear in dump
             rnames = ['r15', 'r14', 'r13', 'r12', 'rbp', 'rbx', 'r11', 'r10', 'r9', 'r8', 'rax', 'rcx',
-                    'rdx', 'rsi', 'rdi', 'xxx', 'rip', 'cs', 'eflags', 'rsp', 'ss', 'xxx', 'xxx', 'ds', 'es',
-                    'fs', 'gs']
+                    'rdx', 'rsi', 'rdi', 'xxx', 'rip', 'cs', 'eflags', 'rsp', 'ss', 'fs_base', 'gs_base', 'ds', 'es',
+                    'xxx', 'xxx']
             nreg = 27
         elif self.arch.name == 'X86':
             rnames = ['ebx', 'ecx', 'edx', 'esi', 'edi', 'ebp', 'eax', 'ds', 'es', 'fs', 'gs', 'xxx', 'eip',
@@ -188,12 +196,89 @@ class ELFCore(ELF):
 
         regvals = []
         for idx in range(pos, pos+nreg*arch_bytes, arch_bytes):
-            regvals.append(struct.unpack("<" + fmt, prstatus.desc[idx:idx+arch_bytes])[0])
+            regvals.append(struct.unpack("<" + fmt, desc[idx:idx+arch_bytes])[0])
         result['registers'] = dict(zip(rnames, regvals))
         del result['registers']['xxx']
 
         pos += nreg * arch_bytes
-        result['pr_fpvalid'] = struct.unpack("<I", prstatus.desc[pos:pos+4])[0]
-        return result
+        result['pr_fpvalid'] = struct.unpack("<I", desc[pos:pos+4])[0]
+        self.__current_thread.update(result)
+
+    def __parse_files(self, desc):
+        self.filename_lookup = [(ent.vm_start, ent.vm_end, ent.page_offset, fn) for ent, fn in zip(desc.Elf_Nt_File_Entry, desc.filename)]
+
+    def __parse_x86_tls(self, desc):
+        self.__current_thread['segments'] = {}
+        for offset in range(0, len(desc), 4*4):
+            index, base, limit, flags = struct.unpack_from('4I', desc, offset)
+            self.__current_thread['segments'][index] = (base, limit, flags)
+
+    def __parse_auxv(self, desc):
+        for offset in range(0, len(desc), self.arch.bytes*2):
+            code = struct.unpack_from(self.arch.struct_fmt(), desc, offset)[0]
+            value = struct.unpack_from(self.arch.struct_fmt(), desc, offset + self.arch.bytes)[0]
+            code_str = auxv_codes.get(code, code)
+
+            if code_str == 'AT_RANDOM':
+                value = self.__dummy_clemory.load(value, 0x10)
+            elif code_str in ('AT_EXECFN', 'AT_PLATFORM'):
+                pos = value
+                value = bytearray()
+                while True:
+                    byte = self.__dummy_clemory[pos]
+                    if byte == 0:
+                        break
+                    else:
+                        value.append(byte)
+                        pos += 1
+                value = bytes(value)
+
+            self.auxv[code_str] = value
+
+auxv_codes = {
+ 0x0: 'AT_NULL',
+ 0x1: 'AT_IGNORE',
+ 0x2: 'AT_EXECFD',
+ 0x3: 'AT_PHDR',
+ 0x4: 'AT_PHENT',
+ 0x5: 'AT_PHNUM',
+ 0x6: 'AT_PAGESZ',
+ 0x7: 'AT_BASE',
+ 0x8: 'AT_FLAGS',
+ 0x9: 'AT_ENTRY',
+ 0xa: 'AT_NOTELF',
+ 0xb: 'AT_UID',
+ 0xc: 'AT_EUID',
+ 0xd: 'AT_GID',
+ 0xe: 'AT_EGID',
+ 0x11: 'AT_CLKTCK',
+ 0xf: 'AT_PLATFORM',
+ 0x10: 'AT_HWCAP',
+ 0x12: 'AT_FPUCW',
+ 0x13: 'AT_DCACHEBSIZE',
+ 0x14: 'AT_ICACHEBSIZE',
+ 0x15: 'AT_UCACHEBSIZE',
+ 0x16: 'AT_IGNOREPPC',
+ 0x17: 'AT_SECURE',
+ 0x18: 'AT_BASE_PLATFORM',
+ 0x19: 'AT_RANDOM',
+ 0x1a: 'AT_HWCAP2',
+ 0x1f: 'AT_EXECFN',
+ 0x20: 'AT_SYSINFO',
+ 0x21: 'AT_SYSINFO_EHDR',
+ 0x22: 'AT_L1I_CACHESHAPE',
+ 0x23: 'AT_L1D_CACHESHAPE',
+ 0x24: 'AT_L2_CACHESHAPE',
+ 0x25: 'AT_L3_CACHESHAPE',
+ 0x28: 'AT_L1I_CACHESIZE',
+ 0x29: 'AT_L1I_CACHEGEOMETRY',
+ 0x2a: 'AT_L1D_CACHESIZE',
+ 0x2b: 'AT_L1D_CACHEGEOMETRY',
+ 0x2c: 'AT_L2_CACHESIZE',
+ 0x2d: 'AT_L2_CACHEGEOMETRY',
+ 0x2e: 'AT_L3_CACHESIZE',
+ 0x2f: 'AT_L3_CACHEGEOMETRY'}
+
+
 
 register_backend('elfcore', ELFCore)

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -55,7 +55,7 @@ class ELFCore(ELF):
 
         self.__extract_note_info()
 
-        if not inhibit_close:
+        if not inhibit_close and self.binary is not None:
             self.binary_stream.close()
 
     @staticmethod

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -194,5 +194,6 @@ class ELFCore(ELF):
 
         pos += nreg * arch_bytes
         result['pr_fpvalid'] = struct.unpack("<I", prstatus.desc[pos:pos+4])[0]
+        return result
 
 register_backend('elfcore', ELFCore)

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -19,7 +19,7 @@ class ELFCore(ELF):
     is_default = True # Tell CLE to automatically consider using the ELFCore backend
 
     def __init__(self, *args, **kwargs):
-        super(ELFCore, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.filename_lookup = []
         self.__current_thread = None
@@ -255,7 +255,5 @@ auxv_codes = {
  0x2d: 'AT_L2_CACHEGEOMETRY',
  0x2e: 'AT_L3_CACHESIZE',
  0x2f: 'AT_L3_CACHEGEOMETRY'}
-
-
 
 register_backend('elfcore', ELFCore)

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -11,7 +11,7 @@ l = logging.getLogger(name=__name__)
 # TODO: yall know struct.unpack_from exists, right? maybe even bitstream?
 
 
-class CoreNote(object):
+class CoreNote:
     """
     This class is used when parsing the NOTES section of a core file.
     """

--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -24,7 +24,7 @@ class MetaELF(Backend):
     A base class that implements functions used by all backends that can load an ELF.
     """
     def __init__(self, *args, **kwargs):
-        super(MetaELF, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         tmp_reader = elftools.elf.elffile.ELFFile(self._binary_stream)
         self.os = describe_ei_osabi(tmp_reader.header.e_ident.EI_OSABI)
         self.elfflags = tmp_reader.header.e_flags

--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -25,7 +25,7 @@ class MetaELF(Backend):
     """
     def __init__(self, *args, **kwargs):
         super(MetaELF, self).__init__(*args, **kwargs)
-        tmp_reader = elftools.elf.elffile.ELFFile(self.binary_stream)
+        tmp_reader = elftools.elf.elffile.ELFFile(self._binary_stream)
         self.os = describe_ei_osabi(tmp_reader.header.e_ident.EI_OSABI)
         self.elfflags = tmp_reader.header.e_flags
         self._plt = {}

--- a/cle/backends/elf/regions.py
+++ b/cle/backends/elf/regions.py
@@ -11,7 +11,7 @@ class ELFSegment(Segment):
     def __init__(self, readelf_seg, relro=False):
         self.flags = readelf_seg.header.p_flags
         self.relro = relro
-        super(ELFSegment, self).__init__(readelf_seg.header.p_offset,
+        super().__init__(readelf_seg.header.p_offset,
                                          readelf_seg.header.p_vaddr,
                                          readelf_seg.header.p_filesz,
                                          readelf_seg.header.p_memsz)
@@ -40,7 +40,7 @@ class ELFSection(Section):
     SHT_NULL = 'SHT_NULL'
 
     def __init__(self, readelf_sec, remap_offset=0):
-        super(ELFSection, self).__init__(
+        super().__init__(
             maybedecode(readelf_sec.name),
             readelf_sec.header.sh_offset,
             readelf_sec.header.sh_addr + remap_offset,

--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -240,7 +240,7 @@ class R_ARM_THM_CALL(ELFReloc):
       - Implementation appears correct with the bits placed into offset[23:22]
     """
     def __init__(self, *args, **kwargs):
-        super(R_ARM_THM_CALL, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._insn_bytes = None
 
     def resolve_symbol(self, solist, **kwargs):

--- a/cle/backends/elf/relocation/elfreloc.py
+++ b/cle/backends/elf/relocation/elfreloc.py
@@ -6,7 +6,7 @@ l = logging.getLogger(name=__name__)
 
 class ELFReloc(Relocation):
     def __init__(self, owner, symbol, relative_addr, addend=None):
-        super(ELFReloc, self).__init__(owner, symbol, relative_addr)
+        super().__init__(owner, symbol, relative_addr)
 
         if addend is not None:
             self.is_rela = True

--- a/cle/backends/elf/symbol.py
+++ b/cle/backends/elf/symbol.py
@@ -40,11 +40,11 @@ class ELFSymbol(Symbol):
         if owner.is_relocatable and isinstance(sec_ndx, int):
             value += owner.sections[sec_ndx].remap_offset
 
-        super(ELFSymbol, self).__init__(owner,
-                                        maybedecode(symb.name),
-                                        AT.from_lva(value, owner).to_rva(),
-                                        symb.entry.st_size,
-                                        self.type)
+        super().__init__(owner,
+                         maybedecode(symb.name),
+                         AT.from_lva(value, owner).to_rva(),
+                         symb.entry.st_size,
+                         self.type)
 
         self.binding = symb.entry.st_info.bind
         self.is_hidden = symb.entry['st_other']['visibility'] == 'STV_HIDDEN'

--- a/cle/backends/externs/__init__.py
+++ b/cle/backends/externs/__init__.py
@@ -34,7 +34,7 @@ class TOCRelocation(Relocation):
 
 class ExternObject(Backend):
     def __init__(self, loader, map_size=0, tls_size=0):
-        super(ExternObject, self).__init__('cle##externs', None, loader=loader)
+        super().__init__('cle##externs', None, loader=loader)
         self._next_object = None
         self._delayed_writes = []
 
@@ -235,7 +235,7 @@ class ExternObject(Backend):
 
 class KernelObject(Backend):
     def __init__(self, loader, map_size=0x8000):
-        super(KernelObject, self).__init__('cle##kernel', None, loader=loader)
+        super().__init__('cle##kernel', None, loader=loader)
         self.map_size = map_size
         self.set_arch(loader.main_object.arch)
         self.memory.add_backer(0, bytes(map_size))

--- a/cle/backends/externs/__init__.py
+++ b/cle/backends/externs/__init__.py
@@ -34,7 +34,7 @@ class TOCRelocation(Relocation):
 
 class ExternObject(Backend):
     def __init__(self, loader, map_size=0, tls_size=0):
-        super(ExternObject, self).__init__('cle##externs', loader=loader)
+        super(ExternObject, self).__init__('cle##externs', None, loader=loader)
         self._next_object = None
         self._delayed_writes = []
 
@@ -235,7 +235,7 @@ class ExternObject(Backend):
 
 class KernelObject(Backend):
     def __init__(self, loader, map_size=0x8000):
-        super(KernelObject, self).__init__('cle##kernel', loader=loader)
+        super(KernelObject, self).__init__('cle##kernel', None, loader=loader)
         self.map_size = map_size
         self.set_arch(loader.main_object.arch)
         self.memory.add_backer(0, bytes(map_size))

--- a/cle/backends/externs/simdata/common.py
+++ b/cle/backends/externs/simdata/common.py
@@ -85,7 +85,7 @@ class SimDataSimpleRelocation(Relocation):
     A relocation used to implement PointTo. Pretty simple.
     """
     def __init__(self, owner, symbol, addr, addend):
-        super(SimDataSimpleRelocation, self).__init__(owner, symbol, addr)
+        super().__init__(owner, symbol, addr)
         self.addend = addend
 
     @property

--- a/cle/backends/ihex.py
+++ b/cle/backends/ihex.py
@@ -102,7 +102,7 @@ class Hex(Backend):
                 # "Extended Mode" Segment address, take this value, multiply by 16, make the base
                 self._base_address = struct.unpack('>H', data)[0] * 16
                 got_base = True
-                l.debug("Loading a segment at " + hex(self._base_address))
+                l.debug("Loading a segment at %#x", self._base_address)
             elif rectype == HEX_TYPE_STARTSEGADDR:
                 # Four bytes, the segment and the initial IP
                 got_base = True
@@ -110,17 +110,17 @@ class Hex(Backend):
                 self._initial_cs, self._initial_ip = struct.unpack('>HH', data)
                 # The whole thing is the entry, as far as angr is concerned.
                 self._entry = struct.unpack('>I', data)[0]
-                l.debug("Got entry point at " + hex(self._entry))
+                l.debug("Got entry point at %#x", self._entry)
             elif rectype == HEX_TYPE_EXTLINEARADDR:
                 got_base = True
                 # Specifies the base for all future data bytes.
                 self._base_address = struct.unpack('>H', data)[0] << 16
-                l.debug("Loading a segment at " + hex(self._base_address))
+                l.debug("Loading a segment at %#x", self._base_address)
             elif rectype == HEX_TYPE_STARTLINEARADDR:
                 got_entry = True
                 # The 32-bit EIP, really the same as STARTSEGADDR, but some compilers pick one over the other.
                 self._entry = struct.unpack('>I', data)[0]
-                l.debug("Found entry point at " + hex(self._entry))
+                l.debug("Found entry point at %#x", self._entry)
                 self._initial_eip = self._entry
             else:
                 raise CLEError("This HEX Object type is not implemented: " + hex(rectype))

--- a/cle/backends/java/apk.py
+++ b/cle/backends/java/apk.py
@@ -64,7 +64,7 @@ class Apk(Soot):
                 l.error("Install pyaxmlparser to identify APK entry point.")
 
         # the actual lifting is done by the Soot superclass
-        super(Apk, self).__init__(apk_path, binary_stream,
+        super().__init__(apk_path, binary_stream,
                                   input_format='apk',
                                   android_sdk=android_sdk,
                                   entry_point=entry_point,

--- a/cle/backends/java/apk.py
+++ b/cle/backends/java/apk.py
@@ -20,7 +20,7 @@ class Apk(Soot):
 
     is_default = True  # let CLE automatically use this backend
 
-    def __init__(self, apk_path, entry_point=None, entry_point_params=(), android_sdk=None,
+    def __init__(self, apk_path, binary_stream, entry_point=None, entry_point_params=(), android_sdk=None,
                  supported_jni_archs=None, jni_libs=None, jni_libs_ld_path=None, **options):
         """
         :param apk_path:                Path to APK.
@@ -64,7 +64,7 @@ class Apk(Soot):
                 l.error("Install pyaxmlparser to identify APK entry point.")
 
         # the actual lifting is done by the Soot superclass
-        super(Apk, self).__init__(apk_path,
+        super(Apk, self).__init__(apk_path, binary_stream,
                                   input_format='apk',
                                   android_sdk=android_sdk,
                                   entry_point=entry_point,

--- a/cle/backends/java/jar.py
+++ b/cle/backends/java/jar.py
@@ -14,7 +14,7 @@ class Jar(Soot):
 
     is_default = True  # let CLE automatically use this backend
 
-    def __init__(self, jar_path, entry_point=None, entry_point_params=('java.lang.String[]',), jni_libs=None, jni_libs_ld_path=None, **options):
+    def __init__(self, jar_path, binary_stream, entry_point=None, entry_point_params=('java.lang.String[]',), jni_libs=None, jni_libs_ld_path=None, **kwargs):
         """
         :param jar_path:                Path to JAR.
 
@@ -39,13 +39,13 @@ class Jar(Soot):
                 entry_point = main_class + "." + "main"
 
         # the actual lifting is done by the Soot superclass
-        super(Jar, self).__init__(jar_path,
+        super(Jar, self).__init__(jar_path, binary_stream,
                                   input_format='jar',
                                   entry_point=entry_point,
                                   entry_point_params=entry_point_params,
                                   jni_libs=jni_libs,
                                   jni_libs_ld_path=jni_libs_ld_path,
-                                  **options)
+                                  **kwargs)
 
     @staticmethod
     def is_compatible(stream):

--- a/cle/backends/java/jar.py
+++ b/cle/backends/java/jar.py
@@ -39,7 +39,7 @@ class Jar(Soot):
                 entry_point = main_class + "." + "main"
 
         # the actual lifting is done by the Soot superclass
-        super(Jar, self).__init__(jar_path, binary_stream,
+        super().__init__(jar_path, binary_stream,
                                   input_format='jar',
                                   entry_point=entry_point,
                                   entry_point_params=entry_point_params,

--- a/cle/backends/java/soot.py
+++ b/cle/backends/java/soot.py
@@ -13,6 +13,7 @@ try:
     from pysoot.lifter import Lifter
 except ImportError:
     pysoot = None
+    Lifter = None
 
 l = logging.getLogger(name=__name__)
 
@@ -25,7 +26,7 @@ class Soot(Backend):
     0.
     """
 
-    def __init__(self, path, entry_point=None, entry_point_params=(), input_format=None,
+    def __init__(self, *args, entry_point=None, entry_point_params=(), input_format=None,
                  additional_jars=None, additional_jar_roots=None,
                  jni_libs_ld_path=None, jni_libs=None,
                  android_sdk=None, **kwargs):
@@ -36,12 +37,14 @@ class Soot(Backend):
         if kwargs.get('has_memory', False):
             raise CLEError('The parameter "has_memory" must be False for Soot backend.')
 
-        super(Soot, self).__init__(path, has_memory=False, **kwargs)
+        super(Soot, self).__init__(*args, has_memory=False, **kwargs)
+        if self.binary is None:
+            raise ValueError("Cannot use the Soot backend loading from a stream")
 
         # load the classes
         l.debug("Lifting to Soot IR ...")
         start_time = time.time()
-        pysoot_lifter = Lifter(path,
+        pysoot_lifter = Lifter(self.binary,
                                input_format=input_format,
                                android_sdk=android_sdk,
                                additional_jars=additional_jars,

--- a/cle/backends/java/soot.py
+++ b/cle/backends/java/soot.py
@@ -37,7 +37,7 @@ class Soot(Backend):
         if kwargs.get('has_memory', False):
             raise CLEError('The parameter "has_memory" must be False for Soot backend.')
 
-        super(Soot, self).__init__(*args, has_memory=False, **kwargs)
+        super().__init__(*args, has_memory=False, **kwargs)
         if self.binary is None:
             raise ValueError("Cannot use the Soot backend loading from a stream")
 

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -40,10 +40,10 @@ class MachO(Backend):
     MH_CIGAM = 0xcefaedfe
 
 
-    def __init__(self, binary, **kwargs):
+    def __init__(self, *args, **kwargs):
         l.warning('The Mach-O backend is not well-supported. Good luck!')
 
-        super(MachO, self).__init__(binary, **kwargs)
+        super(MachO, self).__init__(*args, **kwargs)
 
         self.struct_byteorder = None  # holds byteorder for struct.unpack(...)
         self._mapped_base = None # temporary holder für mapped base derived via loading
@@ -79,7 +79,7 @@ class MachO(Backend):
         # Begin parsing the file
         try:
 
-            binary_file = self.binary_stream
+            binary_file = self._binary_stream
             # get magic value and determine endianness
             self.struct_byteorder = self._detect_byteorder(struct.unpack("=I", binary_file.read(4))[0])
 

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -43,7 +43,7 @@ class MachO(Backend):
     def __init__(self, *args, **kwargs):
         l.warning('The Mach-O backend is not well-supported. Good luck!')
 
-        super(MachO, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.struct_byteorder = None  # holds byteorder for struct.unpack(...)
         self._mapped_base = None # temporary holder für mapped base derived via loading

--- a/cle/backends/macho/section.py
+++ b/cle/backends/macho/section.py
@@ -26,7 +26,7 @@ class MachOSection(Region):
     """
 
     def __init__(self, offset, vaddr, size, vsize, segname, sectname, align, reloff, nreloc, flags, r1, r2):
-        super(MachOSection, self).__init__(offset, vaddr, size, vsize)
+        super().__init__(offset, vaddr, size, vsize)
 
         self.segname = segname.decode()
         self.sectname = sectname.decode()

--- a/cle/backends/macho/segment.py
+++ b/cle/backends/macho/segment.py
@@ -21,7 +21,7 @@ class MachOSegment(Region):
     """
 
     def __init__(self, offset, vaddr, size, vsize, segname, nsect, sections, flags, initprot, maxprot):
-        super(MachOSegment, self).__init__(offset, vaddr, size, vsize)
+        super().__init__(offset, vaddr, size, vsize)
 
         self.segname = segname.decode()
         self.nsect = nsect

--- a/cle/backends/macho/symbol.py
+++ b/cle/backends/macho/symbol.py
@@ -28,7 +28,7 @@ class AbstractMachOSymbol(Symbol):
     """
 
     def __init__(self, owner, name, relative_addr, size, sym_type):
-        super(AbstractMachOSymbol,self).__init__(owner,name,relative_addr,size,sym_type)
+        super().__init__(owner,name,relative_addr,size,sym_type)
 
         # additional properties
         self.bind_xrefs = []  # XREFs discovered during binding of the symbol
@@ -76,7 +76,7 @@ class SymbolTableSymbol(AbstractMachOSymbol):
         # now we may call super
         # however we cannot access any properties yet that would touch superclass-initialized attributes
         # so we have to repeat some work
-        super(SymbolTableSymbol, self).__init__(owner,
+        super().__init__(owner,
                owner.get_string(n_strx).decode('utf-8') if n_strx != 0 else "",
                 self.value,
                 owner.arch.bytes,
@@ -243,7 +243,7 @@ class BindingSymbol(AbstractMachOSymbol):
         # now we may call super
         # however we cannot access any properties yet that would touch superclass-initialized attributes
         # so we have to repeat some work
-        super(BindingSymbol, self).__init__(owner,
+        super().__init__(owner,
                                                 name,
                                                 0,
                                                 owner.arch.bytes,

--- a/cle/backends/minidump/__init__.py
+++ b/cle/backends/minidump/__init__.py
@@ -11,12 +11,11 @@ except ImportError:
 
 from .. import register_backend, Backend
 from ..region import Section
-from ... memory import Clemory
 from ...errors import CLEError, CLEInvalidBinaryError
 
 class MinidumpMissingStreamError(Exception):
     def __init__(self, stream, message=None):
-        super(MinidumpMissingStreamError, self).__init__()
+        super().__init__()
         self.message = message
         self.stream = stream
 
@@ -25,7 +24,7 @@ class Minidump(Backend):
     def __init__(self, *args, **kwargs):
         if minidumpfile is None:
             raise CLEError("Run `pip install minidump==0.0.10` to support loading minidump files")
-        super(Minidump, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.os = 'windows'
         self.supports_nx = True
         if self.binary is None:

--- a/cle/backends/named_region.py
+++ b/cle/backends/named_region.py
@@ -32,7 +32,7 @@ class NamedRegion(Backend):
         :param kwargs:
         """
         self.name = name
-        super(NamedRegion, self).__init__(name, None, **kwargs)
+        super().__init__(name, None, **kwargs)
         self._min_addr = start
         self.linked_base = start
         self._max_addr = end

--- a/cle/backends/named_region.py
+++ b/cle/backends/named_region.py
@@ -32,7 +32,7 @@ class NamedRegion(Backend):
         :param kwargs:
         """
         self.name = name
-        super(NamedRegion, self).__init__(name, **kwargs)
+        super(NamedRegion, self).__init__(name, None, **kwargs)
         self._min_addr = start
         self.linked_base = start
         self._max_addr = end

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -9,7 +9,6 @@ from .relocation.generic import DllImport, IMAGE_REL_BASED_HIGHADJ, IMAGE_REL_BA
 from .relocation import get_relocation
 from .. import register_backend, Backend
 from ...address_translator import AT
-from ...patched_stream import PatchedStream
 
 
 l = logging.getLogger(name=__name__)
@@ -60,7 +59,7 @@ class PE(Backend):
         self.supports_nx = self._pe.OPTIONAL_HEADER.DllCharacteristics & 0x100 != 0
         self.pic = self.pic or self._pe.OPTIONAL_HEADER.DllCharacteristics & 0x40 != 0
         if hasattr(self._pe, 'DIRECTORY_ENTRY_LOAD_CONFIG'):
-            self.load_config = {name: value['Value'] for name, value in self._pe.DIRECTORY_ENTRY_LOAD_CONFIG.struct.dump_dict().items() if name is not 'Structure'}
+            self.load_config = {name: value['Value'] for name, value in self._pe.DIRECTORY_ENTRY_LOAD_CONFIG.struct.dump_dict().items() if name != 'Structure'}
         else:
             self.load_config = {}
 

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -21,7 +21,7 @@ class PE(Backend):
     is_default = True # Tell CLE to automatically consider using the PE backend
 
     def __init__(self, *args, **kwargs):
-        super(PE, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.segments = self.sections # in a PE, sections and segments have the same meaning
         self.os = 'windows'
         if self.binary is None:

--- a/cle/backends/pe/regions.py
+++ b/cle/backends/pe/regions.py
@@ -5,7 +5,7 @@ class PESection(Section):
     Represents a section for the PE format.
     """
     def __init__(self, pe_section, remap_offset=0):
-        super(PESection, self).__init__(
+        super().__init__(
             pe_section.Name.decode(),
             pe_section.Misc_PhysicalAddress,
             pe_section.VirtualAddress + remap_offset,

--- a/cle/backends/pe/relocation/generic.py
+++ b/cle/backends/pe/relocation/generic.py
@@ -18,7 +18,7 @@ class IMAGE_REL_BASED_ABSOLUTE(PEReloc):
 
 class IMAGE_REL_BASED_HIGHADJ(PEReloc):
     def __init__(self, owner, addr, next_rva):
-        super(IMAGE_REL_BASED_HIGHADJ, self).__init__(owner, None, addr)
+        super().__init__(owner, None, addr)
         self.next_rva = next_rva
     @property
     def value(self):

--- a/cle/backends/pe/relocation/pereloc.py
+++ b/cle/backends/pe/relocation/pereloc.py
@@ -8,7 +8,7 @@ class PEReloc(Relocation):
     AUTO_HANDLE_NONE = True
 
     def __init__(self, owner, symbol, addr, resolvewith=None):   # pylint: disable=unused-argument
-        super(PEReloc, self).__init__(owner, symbol, addr)
+        super().__init__(owner, symbol, addr)
 
         self.resolvewith = resolvewith
         if self.resolvewith is not None:
@@ -17,7 +17,7 @@ class PEReloc(Relocation):
     def resolve_symbol(self, solist, bypass_compatibility=False, extern_object=None, **kwargs):
         if not bypass_compatibility:
             solist = [x for x in solist if self.resolvewith == x.provides]
-        super(PEReloc, self).resolve_symbol(solist, bypass_compatibility=bypass_compatibility, extern_object=extern_object, **kwargs)
+        super().resolve_symbol(solist, bypass_compatibility=bypass_compatibility, extern_object=extern_object, **kwargs)
 
         if self.resolvedby is None:
             return

--- a/cle/backends/pe/symbol.py
+++ b/cle/backends/pe/symbol.py
@@ -9,7 +9,7 @@ class WinSymbol(Symbol):
     Represents a symbol for the PE format.
     """
     def __init__(self, owner, name, addr, is_import, is_export, ordinal_number, forwarder):
-        super(WinSymbol, self).__init__(owner, name, addr, owner.arch.bytes, SymbolType.TYPE_FUNCTION)
+        super().__init__(owner, name, addr, owner.arch.bytes, SymbolType.TYPE_FUNCTION)
         self.is_import = is_import
         self.is_export = is_export
         self.ordinal_number = ordinal_number

--- a/cle/backends/region.py
+++ b/cle/backends/region.py
@@ -112,7 +112,7 @@ class EmptySegment(Segment):
     """
 
     def __init__(self, vaddr, memsize, is_readable=True, is_writable=True, is_executable=False):
-        super(EmptySegment, self).__init__(0, vaddr, 0, memsize)
+        super().__init__(0, vaddr, 0, memsize)
         self._is_readable = is_readable
         self._is_writable = is_writable
         self._is_executable = is_executable
@@ -150,7 +150,7 @@ class Section(Region):
         :param int vaddr:   The address in virtual memory this section begins
         :param int size:    How large this section is
         """
-        super(Section, self).__init__(offset, vaddr, size, size)
+        super().__init__(offset, vaddr, size, size)
         self.name = name
 
     @property

--- a/cle/backends/tls/__init__.py
+++ b/cle/backends/tls/__init__.py
@@ -56,4 +56,5 @@ class TLSObject(Backend):
     pass
 
 from .elf_tls import ELFThreadManager
+from .elfcore_tls import ELFCoreThreadManager
 from .pe_tls import PEThreadManager

--- a/cle/backends/tls/__init__.py
+++ b/cle/backends/tls/__init__.py
@@ -53,7 +53,8 @@ class InternalTLSRelocation(Relocation):
         return self.val + self.owner.mapped_base
 
 class TLSObject(Backend):
-    pass
+    def __init__(self, loader, arch):
+        super().__init__('cle##tls', None, loader=loader, arch=arch)
 
 from .elf_tls import ELFThreadManager
 from .elfcore_tls import ELFCoreThreadManager

--- a/cle/backends/tls/elf_tls.py
+++ b/cle/backends/tls/elf_tls.py
@@ -51,7 +51,7 @@ class ELFThreadManager(ThreadManager):
 
 class ELFTLSObject(TLSObject):
     def __init__(self, thread_manager: ELFThreadManager):
-        super().__init__('cle##tls', loader=thread_manager.loader, arch=thread_manager.arch)
+        super().__init__(loader=thread_manager.loader, arch=thread_manager.arch)
         self.tcb_offset: int = None
         self.dtv_offset: int = None
         self.tp_offset: int = None

--- a/cle/backends/tls/elfcore_tls.py
+++ b/cle/backends/tls/elfcore_tls.py
@@ -1,0 +1,47 @@
+import archinfo
+import logging
+
+l = logging.getLogger(__name__)
+
+class ELFCoreThreadManager:
+    def __init__(self, loader, arch, **kwargs):
+        self.loader = loader
+        self.arch = arch
+        self.threads = [ELFCoreThread(loader, arch, threadinfo) for threadinfo in loader.main_object._threads]
+        if arch.name not in ('AMD64', 'X86'):
+            l.warning("TLS for coredumps won't be right for this arch - idk how to do it")
+        self.modules = []  # ???
+
+    def new_thread(self, insert=False):
+        raise TypeError("Cannot create new threads from a core file... for now")
+
+    def register_object(self, obj):
+        pass
+
+class ELFCoreThread:
+    def __init__(self, loader, arch: archinfo.Arch, threadinfo):
+        self.loader = loader
+        self.arch = arch
+        self._threadinfo = threadinfo
+        if arch.name == 'AMD64':
+            self.thread_pointer = threadinfo['registers']['fs_base']
+        elif arch.name == 'X86':
+            gs = threadinfo['registers']['gs']
+            if gs == 0:
+                # I have no idea why this happens
+                gs = next(iter(threadinfo['segments'].keys())) << 3
+            self.thread_pointer = threadinfo['segments'][gs >> 3][0]
+        else:
+            self.thread_pointer = 0
+
+        self.user_thread_pointer = self.thread_pointer + arch.elf_tls.tp_offset
+
+    @property
+    def dtv(self):
+        return self.loader.memory.unpack_word(self.thread_pointer + self.arch.elf_tls.dtv_offsets[0])
+
+    def get_addr(self, module_id, offset):
+        """
+        basically ``__tls_get_addr``.
+        """
+        return self.loader.memory.unpack_word(self.dtv + module_id * self.arch.bytes) + offset

--- a/cle/backends/tls/elfcore_tls.py
+++ b/cle/backends/tls/elfcore_tls.py
@@ -4,7 +4,7 @@ import logging
 l = logging.getLogger(__name__)
 
 class ELFCoreThreadManager:
-    def __init__(self, loader, arch, **kwargs):
+    def __init__(self, loader, arch, **kwargs):  # pylint: disable=unused-argument
         self.loader = loader
         self.arch = arch
         self.threads = [ELFCoreThread(loader, arch, threadinfo) for threadinfo in loader.main_object._threads]
@@ -12,7 +12,7 @@ class ELFCoreThreadManager:
             l.warning("TLS for coredumps won't be right for this arch - idk how to do it")
         self.modules = []  # ???
 
-    def new_thread(self, insert=False):
+    def new_thread(self, insert=False): # pylint: disable=no-self-use
         raise TypeError("Cannot create new threads from a core file... for now")
 
     def register_object(self, obj):

--- a/cle/backends/tls/pe_tls.py
+++ b/cle/backends/tls/pe_tls.py
@@ -67,7 +67,7 @@ class PETLSObject(TLSObject):
     """
 
     def __init__(self, thread_manager: PEThreadManager):
-        super(PETLSObject, self).__init__('cle##tls', loader=thread_manager.loader, arch=thread_manager.arch)
+        super(PETLSObject, self).__init__(loader=thread_manager.loader, arch=thread_manager.arch)
 
         self.used_modules = len(thread_manager.modules)
         self.data_start = self.arch.bytes*thread_manager.max_modules

--- a/cle/backends/tls/pe_tls.py
+++ b/cle/backends/tls/pe_tls.py
@@ -67,7 +67,7 @@ class PETLSObject(TLSObject):
     """
 
     def __init__(self, thread_manager: PEThreadManager):
-        super(PETLSObject, self).__init__(loader=thread_manager.loader, arch=thread_manager.arch)
+        super().__init__(loader=thread_manager.loader, arch=thread_manager.arch)
 
         self.used_modules = len(thread_manager.modules)
         self.data_start = self.arch.bytes*thread_manager.max_modules

--- a/cle/backends/xbe.py
+++ b/cle/backends/xbe.py
@@ -7,7 +7,6 @@ except ImportError:
 
 import archinfo
 
-from ..patched_stream import PatchedStream
 from ..errors import CLEError
 from . import Backend, register_backend
 from .region import Segment, Section
@@ -16,12 +15,6 @@ l = logging.getLogger(name=__name__)
 
 class XBESection(Section):
     def __init__(self, name, file_offset, file_size, virtual_addr, virtual_size, xbe_sec):
-        """
-        :param str name:    The name of the section
-        :param int offset:  The offset into the binary file this section begins
-        :param int vaddr:   The address in virtual memory this section begins
-        :param int size:    How large this section is
-        """
         super(XBESection, self).__init__(name, file_offset, virtual_addr, virtual_size)
         self.filesize = file_size
         self._xbe_sec = xbe_sec

--- a/cle/backends/xbe.py
+++ b/cle/backends/xbe.py
@@ -15,7 +15,7 @@ l = logging.getLogger(name=__name__)
 
 class XBESection(Section):
     def __init__(self, name, file_offset, file_size, virtual_addr, virtual_size, xbe_sec):
-        super(XBESection, self).__init__(name, file_offset, virtual_addr, virtual_size)
+        super().__init__(name, file_offset, virtual_addr, virtual_size)
         self.filesize = file_size
         self._xbe_sec = xbe_sec
 

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -688,8 +688,7 @@ class Loader:
                 cached_failures.add(spec)
                 if self._except_missing_libs:
                     raise
-                else:
-                    continue
+                continue
 
             objects.append(obj)
             dependencies.extend(obj.deps)

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -657,7 +657,9 @@ class Loader:
                 # this is technically the first place we can start to initialize things based on platform
                 self.main_object = obj
                 self.memory = Clemory(obj.arch, root=True)
-                if isinstance(obj, MetaELF):
+                if isinstance(obj, ELFCore):
+                    self.tls = ELFCoreThreadManager(self, obj.arch)
+                elif isinstance(obj, MetaELF):
                     self.tls = ELFThreadManager(self, obj.arch)
                 elif isinstance(obj, PE):
                     self.tls = PEThreadManager(self, obj.arch)
@@ -1096,7 +1098,7 @@ class Loader:
 
 from .errors import CLEError, CLEFileNotFoundError, CLECompatibilityError, CLEOperationError
 from .memory import Clemory
-from .backends import MetaELF, ELF, PE, Soot, Blob, ALL_BACKENDS, Backend
-from .backends.tls import ThreadManager, ELFThreadManager, PEThreadManager, TLSObject
+from .backends import MetaELF, ELF, PE, ELFCore, Blob, ALL_BACKENDS, Backend
+from .backends.tls import ThreadManager, ELFThreadManager, PEThreadManager, ELFCoreThreadManager, TLSObject
 from .backends.externs import ExternObject, KernelObject
 from .utils import stream_or_path

--- a/cle/memory.py
+++ b/cle/memory.py
@@ -28,7 +28,7 @@ class ClemoryBase:
     def backers(self, addr=0):
         raise NotImplementedError
 
-    def find(self, data, start=None, end=None):
+    def find(self, data, search_min=None, search_max=None):
         raise NotImplementedError
 
     def unpack(self, addr, fmt):
@@ -468,8 +468,8 @@ class ClemoryView(ClemoryBase):
         return k + self._rebase in self._backer
 
     def backers(self, addr=0):
-        for addr, backer in self._backer.backers(addr + self._rebase):
-            taddr = addr - self._rebase
+        for oaddr, backer in self._backer.backers(addr=addr + self._rebase):
+            taddr = oaddr - self._rebase
             if self._offset <= taddr < self._endoffset and self._offset <= taddr + len(backer) - 1 < self._endoffset:
                 yield taddr, backer
             elif taddr >= self._endoffset or taddr + len(backer) - 1 < self._offset:
@@ -505,12 +505,11 @@ class ClemoryView(ClemoryBase):
             raise KeyError(addr)
         if not self._offset <= addr + len(data) - 1 < self._endoffset:
             raise KeyError(addr + len(data) - 1)
-        return self._backer.store(addr + self._rebase, data)
+        self._backer.store(addr + self._rebase, data)
 
-    def find(self, data, start=None, end=None):
-        if start is None or start < self._start:
-            start = self._start
-        if end is None or end > self._end:
-            end = self._end
-        return self._backer.find(data, start=start + self._rebase, end=end + self._rebase)
-
+    def find(self, data, search_min=None, search_max=None):
+        if search_min is None or search_min < self._start:
+            search_min = self._start
+        if search_max is None or search_max > self._end:
+            search_max = self._end
+        return self._backer.find(data, search_min=search_min + self._rebase, search_max=search_max + self._rebase)

--- a/tests/test_address_translator.py
+++ b/tests/test_address_translator.py
@@ -6,7 +6,7 @@ from cle.address_translator import AT
 
 class MockBackend(cle.Backend):
     def __init__(self, linked_base, mapped_base, *nargs, **kwargs):
-        super(MockBackend, self).__init__("/dev/zero", None, *nargs, **kwargs)
+        super().__init__("/dev/zero", None, *nargs, **kwargs)
         regions = [
             cle.Region(0x000000, 0x8048000, 0x1b2d30, 0x1b2d30),
             cle.Region(0x1b3260, 0x81fc260, 0x002c74, 0x0057bc)

--- a/tests/test_address_translator.py
+++ b/tests/test_address_translator.py
@@ -6,7 +6,7 @@ from cle.address_translator import AT
 
 class MockBackend(cle.Backend):
     def __init__(self, linked_base, mapped_base, *nargs, **kwargs):
-        super(MockBackend, self).__init__("/dev/zero", *nargs, **kwargs)
+        super(MockBackend, self).__init__("/dev/zero", None, *nargs, **kwargs)
         regions = [
             cle.Region(0x000000, 0x8048000, 0x1b2d30, 0x1b2d30),
             cle.Region(0x1b3260, 0x81fc260, 0x002c74, 0x0057bc)

--- a/tests/test_hex.py
+++ b/tests/test_hex.py
@@ -13,8 +13,8 @@ def test_hex():
     machofile = os.path.join(TEST_BASE, 'tests', 'armel', 'i2c_master_read-arduino_mzero.hex')
     ld = cle.Loader(machofile, auto_load_libs=False, main_opts={'arch':"ARMEL"})
     nose.tools.assert_true(isinstance(ld.main_object,cle.Hex))
-    nose.tools.assert_equals(ld.main_object.os, 'unknown')
-    nose.tools.assert_equals(ld.main_object.entry,0x44cd)
+    nose.tools.assert_equal(ld.main_object.os, 'unknown')
+    nose.tools.assert_equal(ld.main_object.entry,0x44cd)
 
 
 if __name__ == '__main__':

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -5,7 +5,7 @@ import os
 
 class MockBackend(cle.backends.Backend):
     def __init__(self, linked_base, size, **kwargs):
-        super(MockBackend, self).__init__('/dev/zero', None, **kwargs)
+        super().__init__('/dev/zero', None, **kwargs)
         self.mapped_base = self.linked_base = linked_base
         self.size = size
         self.pic = True

--- a/tests/test_overlap.py
+++ b/tests/test_overlap.py
@@ -5,7 +5,7 @@ import os
 
 class MockBackend(cle.backends.Backend):
     def __init__(self, linked_base, size, **kwargs):
-        super(MockBackend, self).__init__('/dev/zero', **kwargs)
+        super(MockBackend, self).__init__('/dev/zero', None, **kwargs)
         self.mapped_base = self.linked_base = linked_base
         self.size = size
         self.pic = True

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -13,8 +13,8 @@ def test_exe():
     exe = os.path.join(TEST_BASE, 'tests', 'x86', 'windows', 'TLS.exe')
     ld = cle.Loader(exe, auto_load_libs=False)
     nose.tools.assert_true(isinstance(ld.main_object,cle.PE))
-    nose.tools.assert_equals(ld.main_object.os, 'windows')
-    nose.tools.assert_equals(sorted([sec.name for sec in ld.main_object.sections]),
+    nose.tools.assert_equal(ld.main_object.os, 'windows')
+    nose.tools.assert_equal(sorted([sec.name for sec in ld.main_object.sections]),
                              sorted(['.textbss',
                                      '.text\x00\x00\x00',
                                      '.rdata\x00\x00',
@@ -25,11 +25,11 @@ def test_exe():
                                      '.00cfg\x00\x00',
                                      '.rsrc\x00\x00\x00']))
     nose.tools.assert_is(ld.main_object.segments, ld.main_object.sections)
-    nose.tools.assert_equals(sorted(ld.main_object.deps),
+    nose.tools.assert_equal(sorted(ld.main_object.deps),
                              sorted(['kernel32.dll',
                                      'vcruntime140d.dll',
                                      'ucrtbased.dll']))
-    nose.tools.assert_equals(sorted(ld.main_object.imports),
+    nose.tools.assert_equal(sorted(ld.main_object.imports),
                              sorted(['_configure_narrow_argv',
                                      'GetLastError',
                                      'HeapFree',
@@ -107,15 +107,15 @@ def test_tls():
     tls = ld.tls.new_thread()
 
     nose.tools.assert_true(ld.main_object.tls_used)
-    nose.tools.assert_equals(ld.main_object.tls_data_start, 0x1b000)
-    nose.tools.assert_equals(ld.main_object.tls_data_size, 520)
-    nose.tools.assert_equals(ld.main_object.tls_index_address, 0x41913C)
-    nose.tools.assert_equals(ld.main_object.tls_callbacks, [0x411302])
-    nose.tools.assert_equals(ld.main_object.tls_block_size, ld.main_object.tls_data_size)
+    nose.tools.assert_equal(ld.main_object.tls_data_start, 0x1b000)
+    nose.tools.assert_equal(ld.main_object.tls_data_size, 520)
+    nose.tools.assert_equal(ld.main_object.tls_index_address, 0x41913C)
+    nose.tools.assert_equal(ld.main_object.tls_callbacks, [0x411302])
+    nose.tools.assert_equal(ld.main_object.tls_block_size, ld.main_object.tls_data_size)
 
     nose.tools.assert_is_not_none(tls)
-    nose.tools.assert_equals(len(ld.tls.modules), 1)
-    nose.tools.assert_equals(tls.get_tls_data_addr(0), tls.memory.unpack_word(0))
+    nose.tools.assert_equal(len(ld.tls.modules), 1)
+    nose.tools.assert_equal(tls.get_tls_data_addr(0), tls.memory.unpack_word(0))
     nose.tools.assert_raises(IndexError, tls.get_tls_data_addr, 1)
 
 if __name__ == '__main__':

--- a/tests/test_plt.py
+++ b/tests/test_plt.py
@@ -93,8 +93,9 @@ def check_plt_entries(filename):
     ideal_plt = PLT_CACHE[filename.replace('\\', '/')]
     nose.tools.assert_equal(ideal_plt, ld.main_object.plt)
 
-PLT_CACHE = {}
-PLT_CACHE = pickle.load(open(os.path.join(TESTS_BASE, 'tests_data', 'objdump-grep-plt.p'), 'rb'))
+#PLT_CACHE = {}
+with open(os.path.join(TESTS_BASE, 'tests_data', 'objdump-grep-plt.p'), 'rb') as fp:
+    PLT_CACHE = pickle.load(fp)
 
 def test_plt():
     for filename in TESTS_ARCHES:

--- a/tests/test_relocated.py
+++ b/tests/test_relocated.py
@@ -68,9 +68,9 @@ def test_local_symbol_reloc():
             reloc_abs = r
 
     nose.tools.assert_is_not_none(reloc_abs_nc)
-    nose.tools.assert_equals(data_vaddr, reloc_abs_nc.resolvedby.rebased_addr)
+    nose.tools.assert_equal(data_vaddr, reloc_abs_nc.resolvedby.rebased_addr)
     nose.tools.assert_is_not_none(reloc_abs)
-    nose.tools.assert_equals(data_vaddr, reloc_abs.resolvedby.rebased_addr)
+    nose.tools.assert_equal(data_vaddr, reloc_abs.resolvedby.rebased_addr)
 
 if __name__ == '__main__':
     test_relocated()

--- a/tests/test_runpath.py
+++ b/tests/test_runpath.py
@@ -10,7 +10,6 @@ TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 
 def test_runpath():
     tempdir = tempfile.mkdtemp()
-    loader = None
     try:
         runpath_file = os.path.join(TEST_BASE, 'tests', 'x86_64', 'runpath')
         relocated_file = os.path.join(tempdir, 'runpath')
@@ -29,8 +28,6 @@ def test_runpath():
         nose.tools.assert_in(loader.all_objects[1].binary, expected_libs)
         nose.tools.assert_in(loader.all_objects[2].binary, expected_libs)
     finally:
-        if loader is not None:
-            loader.close()
         shutil.rmtree(tempdir)
 
 if __name__ == '__main__':

--- a/tests/test_xbe.py
+++ b/tests/test_xbe.py
@@ -13,9 +13,9 @@ def test_xbe():
     xbe = os.path.join(TEST_BASE, 'tests', 'x86', 'xbox', 'triangle.xbe')
     ld = cle.Loader(xbe, auto_load_libs=False)
     nose.tools.assert_true(isinstance(ld.main_object,cle.XBE))
-    nose.tools.assert_equals(ld.main_object.os, 'xbox')
-    nose.tools.assert_equals(ld.main_object.mapped_base, 0x10000)
-    nose.tools.assert_equals(sorted([sec.name for sec in ld.main_object.sections]),
+    nose.tools.assert_equal(ld.main_object.os, 'xbox')
+    nose.tools.assert_equal(ld.main_object.mapped_base, 0x10000)
+    nose.tools.assert_equal(sorted([sec.name for sec in ld.main_object.sections]),
                              sorted(['.rdata',
                                      '.bss',
                                      '.data',


### PR DESCRIPTION
I kind of went off the rails and did a bunch of refactors I've always wanted to do.

- coredumps can export multiple threads of context
- there's an elf core tls manager which attempts to recover the tls regions for each thread
- new kinds of clemory which are views over other clemories (unused atm but will be necessary for future introspection into coredumps, like symbol loading)
- A ton of new coredump features, like parsing the auxv and file mappings
- automatically look in the OS for the debug symbols for ELFs if load_debug_info is on, or you can manually specify the file to load debug symbols from
- add a PE file API for examining the load config directory (this was the only extrajudicial use of the pefile object)
- rework the backend contract so there's less magic around the binary and its stream. the stream is now explicitly provided from above, and the backend must relinquish all references to it upon calling close().
- Remove all the magic around pickling now that things are simple

closes #233 
closes #215 
closes #207 
closes #184 (probably)

depends on https://github.com/eliben/pyelftools/pull/287
sync angr/angr#1973
sync angr/angr-doc#304
sync angr/angr-platforms#32