### PR TITLE
Better caching for find_xxx_containing() methods.

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -178,6 +178,10 @@ class Backend:
         self._is_mapped = False
         # cached max_addr
         self._max_addr = None
+        # cached last section
+        self._last_section = None
+        # cached last segment
+        self._last_segment = None
 
         if arch is None:
             self.arch = None
@@ -292,13 +296,25 @@ class Backend:
         """
         Returns the segment that contains `addr`, or ``None``.
         """
-        return self.segments.find_region_containing(addr)
+        if self._last_segment is not None and self._last_segment.contains_addr(addr):
+            return self._last_segment
+
+        r = self.segments.find_region_containing(addr)
+        if r is not None:
+            self._last_segment = r
+        return r
 
     def find_section_containing(self, addr):
         """
         Returns the section that contains `addr` or ``None``.
         """
-        return self.sections.find_region_containing(addr)
+        if self._last_section is not None and self._last_section.contains_addr(addr):
+            return self._last_section
+
+        r = self.sections.find_region_containing(addr)
+        if r is not None:
+            self._last_section = r
+        return r
 
     def addr_to_offset(self, addr):
         loadable = self.find_loadable_containing(addr)

--- a/cle/backends/regions.py
+++ b/cle/backends/regions.py
@@ -4,7 +4,7 @@ if str is not bytes:
     long = int
 
 
-class Regions(object):
+class Regions:
     """
     A container class acting as a list of regions (sections or segments). Additionally, it keeps an sorted list of
     all regions that are mapped into memory to allow fast lookups.

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -365,8 +365,10 @@ class Loader:
         if not obj.min_addr <= addr <= obj.max_addr:
             return None
         if not membership_check:
+            self._last_object = obj
             return obj
         if not obj.has_memory:
+            self._last_object = obj
             return obj
         return _check_object_memory(obj)
 


### PR DESCRIPTION
The change in `cle/loader.py` alone reduces the cache miss rate from ~1.9% to 0.4% during a CFG run. When generating CFG of a big binary (around 60k blocks), the introduction of caching `find_section_containing()` in `Backend` reduces the time spent on this method from 13 seconds down to 2.1 seconds.