### PR TITLE
Load constituent binaries while loading coredumps

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -200,12 +200,8 @@ class Backend:
         del self._binary_stream
 
     def __repr__(self):
-        if self.binary is not None:
-            return '<%s Object %s, maps [%#x:%#x]>' % \
-                   (self.__class__.__name__, os.path.basename(self.binary), self.min_addr, self.max_addr)
-        else:
-            return '<%s Object from stream, maps [%#x:%#x]>' % \
-                   (self.__class__.__name__, self.min_addr, self.max_addr)
+        return '<%s Object %s, maps [%#x:%#x]>' % \
+               (self.__class__.__name__, self.binary_basename, self.min_addr, self.max_addr)
 
     def set_arch(self, arch):
         self.arch = arch

--- a/cle/backends/blob.py
+++ b/cle/backends/blob.py
@@ -104,5 +104,8 @@ class Blob(Backend):
     def check_compatibility(cls, spec, obj): # pylint: disable=unused-argument
         return True
 
+    def _checksum(self):
+        return
+
 
 register_backend("blob", Blob)

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -378,17 +378,8 @@ class ELF(MetaELF):
         self._inits_extracted = True
 
     def _load_segment(self, seg):
-        self._load_segment_metadata(seg)
-        self._load_segment_memory(seg)
-
-    def _load_segment_metadata(self, seg):
-        """
-        Loads a segment based on a LOAD directive in the program header table.
-        """
         loaded_segment = ELFSegment(seg)
         self.segments.append(loaded_segment)
-
-    def _load_segment_memory(self, seg):
 
         # see https://code.woboq.org/userspace/glibc/elf/dl-load.c.html#1066
         ph = seg.header
@@ -409,11 +400,14 @@ class ELF(MetaELF):
 
         mapoff = ALIGN_DOWN(ph.p_offset, self.loader.page_size)
 
+        # patch modified addresses into ELFSegment
+        loaded_segment.vaddr = mapstart
+        loaded_segment.memsize = mapend - mapstart
+        loaded_segment.filesize = mapend - mapstart
+        loaded_segment.offset = mapoff
+
         # see https://code.woboq.org/userspace/glibc/elf/dl-map-segments.h.html#88
         data = get_mmaped_data(seg.stream, mapoff, mapend - mapstart, self.loader.page_size)
-        if not data:
-            l.warning("Segment %s is empty at %#08x!", seg.header.p_type, mapstart)
-            return
         if allocend > dataend:
             zero = dataend
             zeropage = (zero + self.loader.page_size - 1) & ~(self.loader.page_size - 1)
@@ -424,6 +418,10 @@ class ELF(MetaELF):
             zeroend = ALIGN_UP(allocend, self.loader.page_size) # mmap maps to the next page boundary
             if zeroend > zeropage:
                 data = data.ljust(zeroend - mapstart, b'\0')
+            loaded_segment.memsize = zeroend - mapstart
+        elif not data:
+            l.warning("Segment %s is empty at %#08x!", seg.header.p_type, mapstart)
+            return
 
         self.memory.add_backer(AT.from_lva(mapstart, self).to_rva(), data)
 
@@ -708,6 +706,14 @@ class ELF(MetaELF):
 
     def __register_relro(self, segment_relro):
         segment_relro = ELFSegment(segment_relro, relro=True)
+        vaddr = ALIGN_DOWN(segment_relro.vaddr, self.loader.page_size)
+        vaddr_end = ALIGN_UP(vaddr + segment_relro.memsize, self.loader.page_size)
+        vaddr_endfile = ALIGN_UP(vaddr + segment_relro.filesize, self.loader.page_size)
+
+        segment_relro.offset = ALIGN_DOWN(segment_relro.offset, self.loader.page_size)
+        segment_relro.vaddr = vaddr
+        segment_relro.memsize = vaddr_end - vaddr
+        segment_relro.filesize = vaddr_endfile - vaddr
 
         def ___segments_overlap(seg1, seg2):
             # Re-arrange so seg1 starts first

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -301,7 +301,6 @@ class ELFCore(ELF):
                     base_addr = patches[0][0]
 
             if base_addr is None:
-                import ipdb; ipdb.set_trace()
                 l.warning("Could not load %s (could not determine base); core may be incomplete", filename)
                 if self.loader.main_object is self:
                     self.loader.main_object = None

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -659,7 +659,7 @@ class Loader:
                 self.main_object = obj
                 self.memory = Clemory(obj.arch, root=True)
 
-                chk_obj = self.main_object if not self.main_object.child_objects else self.main_object.child_objects[0]
+                chk_obj = self.main_object if isinstance(self.main_object, ELFCore) or not self.main_object.child_objects else self.main_object.child_objects[0]
                 if isinstance(chk_obj, ELFCore):
                     self.tls = ELFCoreThreadManager(self, obj.arch)
                 elif isinstance(obj, Minidump):

--- a/cle/memory.py
+++ b/cle/memory.py
@@ -166,7 +166,7 @@ class Clemory(ClemoryBase):
         if not data:
             raise ValueError("Backer is empty!")
 
-        if not isinstance(data, (bytes, list, Clemory)):
+        if not isinstance(data, (bytes, bytearray, list, Clemory)):
             raise TypeError("Data must be a bytes, list, or Clemory object.")
         if start in self:
             raise ValueError("Address %#x is already backed!" % start)

--- a/cle/patched_stream.py
+++ b/cle/patched_stream.py
@@ -1,4 +1,4 @@
-class PatchedStream(object):
+class PatchedStream:
     """
     An object that wraps a readable stream, performing passthroughs on seek and read operations,
     except to make it seem like the data has actually been patched by the given patches.


### PR DESCRIPTION
This change adds a step to coredump loading where it attempts to "invert" itself and reload all constituent executables and libraries as child binaries, then update the children with any modified data from the core, then exposes any leftover mapped regions as Blob children. If this fails, it _should_ fall back to the previous behavior, which just loads the core verbatim (which may be missing segments as documented in various issues).

Closes #244 
Ref #233 