### PR TITLE
Symbol: Break cyclic reference that breaks pickling.

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -488,6 +488,14 @@ class Backend:
             self.md5 = hashlib.md5(data).digest()
             self.sha256 = hashlib.sha256(data).digest()
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        for sym in self.symbols:
+            sym.owner = self
+
 ALL_BACKENDS = dict()
 
 

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -129,3 +129,9 @@ class Symbol:
             Symbol._complained_owner = True
             l.critical("Deprecation warning: use symbol.owner instead of symbol.owner_obj")
         return self.owner
+
+    def __getstate__(self):
+        return dict((k, v) for k, v in self.__dict__.items() if k != 'owner')
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)


### PR DESCRIPTION
A Symbol might be referenced by one or more objects, one of which is its
owner. Sometimes if the symbol is referenced by more objects besides its
backend, during pickle.load(), pickle will decide to unpickle it after
all everything that references it are unpickled, which leads to the
following exception being raised:

```
Traceback (most recent call last):
  File "/__w/1/s/build/src/angr/tests/test_serialization.py", line 74, in test_analyses
    assert len(pickle.loads(pickle.dumps(p.kb, -1)).functions) > 0
  File "/__w/1/s/build/virtualenv/lib/python3.6/site-packages/sortedcontainers/sortedlist.py", line 1749, in __init__
    self._update(iterable)
  File "/__w/1/s/build/virtualenv/lib/python3.6/site-packages/sortedcontainers/sortedlist.py", line 1877, in update
    values = sorted(iterable, key=self._key)
  File "/__w/1/s/build/src/cle/cle/backends/__init__.py", line 478, in _get_symbol_relative_addr
    return symbol.relative_addr
AttributeError: 'Symbol' object has no attribute 'relative_addr'
```

This is because at the time the Backend is being unpickled, one of its owned
symbols has not been fully unpickled and stays as a stub. Not pickling .owner
when pickling the Symbol objects solves this issue.