### PR TITLE
bugfix: Segment has no 'length' attribute

### DIFF
--- a/cle/backends/binja.py
+++ b/cle/backends/binja.py
@@ -98,7 +98,7 @@ class BinjaBin(Backend):
             l.info("Adding memory for segment at %x.", seg.start)
             br = bn.BinaryReader(self.bv)
             br.seek(seg.start)
-            data = br.read(seg.length)
+            data = br.read(len(seg))
             self.memory.add_backer(seg.start, data)
 
         self._find_got()


### PR DESCRIPTION
According to binja documentation, `length` is not a valid attribute name:
https://api.binary.ninja/binaryninja.binaryview.Segment.html

Note that `data_length` is the actual length in the file, but we need the mapped length of the segment, which is usually page aligned. It equals to `seg.end - seg.start`.