### PR TITLE
Fix PLT parsing for x86 binaries with full RELRO

### DIFF
--- a/cle/backends/ihex.py
+++ b/cle/backends/ihex.py
@@ -71,6 +71,9 @@ class Hex(Backend):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        if self.arch is None:
+            raise CLEError("To use the Hex binary backend, you need to specify an architecture in the loader options.")
+
         # Do the whole thing in one shot.
         self.os = 'unknown'
         got_base = False

--- a/tests/test_plt.py
+++ b/tests/test_plt.py
@@ -96,6 +96,10 @@ def test_plt():
     for filename in TESTS_ARCHES:
         yield check_plt_entries, filename
 
+def test_plt_full_relro():
+    ld = cle.Loader(os.path.join(TESTS_BASE, 'tests/i386/full-relro.bin'), main_opts={'base_addr': 0x400000})
+    assert ld.main_object.plt == {'__libc_start_main': 0x400390}
+
 if __name__ == '__main__':
     for f, a in test_plt():
         print(a)


### PR DESCRIPTION
gcc appears to merge .got.plt into .got when full RELRO is enabled, which can make _block_references_addr() fail.


