### PR TITLE
prevent IndexError in _extract_jni_libs

### DIFF
--- a/cle/backends/java/apk.py
+++ b/cle/backends/java/apk.py
@@ -99,9 +99,9 @@ class Apk(Soot):
 
             # Step 2: parse name of available libs and archs
             #         from lib paths "/lib/<jni_arch>/lib<name>.so"
-            lib_filelist = [f.split('/') for f in filelist if f.startswith('lib')]
+            lib_filelist = [list(filter(None, f.split('/'))) for f in filelist if f.startswith('lib')]
             jni_libs = { lib_path[2] for lib_path in lib_filelist if len(lib_path) > 2}
-            available_jni_archs = { lib_path[1] for lib_path in lib_filelist }
+            available_jni_archs = { lib_path[1] for lib_path in lib_filelist if len(lib_path) > 2 }
 
             if not jni_libs:
                 l.info("No JNI libs found.")

--- a/cle/backends/java/apk.py
+++ b/cle/backends/java/apk.py
@@ -100,7 +100,7 @@ class Apk(Soot):
             # Step 2: parse name of available libs and archs
             #         from lib paths "/lib/<jni_arch>/lib<name>.so"
             lib_filelist = [f.split('/') for f in filelist if f.startswith('lib')]
-            jni_libs = { lib_path[2] for lib_path in lib_filelist }
+            jni_libs = { lib_path[2] for lib_path in lib_filelist if len(lib_path) > 2}
             available_jni_archs = { lib_path[1] for lib_path in lib_filelist }
 
             if not jni_libs:


### PR DESCRIPTION
When using ZipFile, lib_path[2] can occur IndexError in following case.

`lib_filelist =  [['lib', ''], ['lib', 'armeabi', ''], ['lib', 'armeabi', 'libdaemon_api20.so'], ['lib', 'armeabi', 'libdaemon_api21.so'], ['lib', 'armeabi-v7a', ''], ['lib', 'armeabi-v7a', 'libdaemon_api20.so'], ['lib', 'armeabi-v7a', 'libdaemon_api21.so'], ['lib', 'x86', ''], ['lib', 'x86', 'libdaemon_api20.so'], ['lib', 'x86', 'libdaemon_api21.so']] `

It handled empty string in lib_filelist, unmatched lib_path(like ['lib'])