### PR TITLE
Allow arch lookup failure if already specified

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -77,9 +77,12 @@ class ELF(MetaELF):
         if self.arch is None:
             self.set_arch(self.extract_arch(self._reader))
         else:
-            other_arch = self.extract_arch(self._reader)
-            if other_arch != self.arch:
-                l.warning("User specified %s but autodetected %s. Proceed with caution.", self.arch, other_arch)
+            try:
+                other_arch = self.extract_arch(self._reader)
+                if other_arch != self.arch:
+                    l.warning("User specified %s but autodetected %s. Proceed with caution.", self.arch, other_arch)
+            except archinfo.ArchNotFound:
+                pass
 
         self._addend = addend
 


### PR DESCRIPTION
Usually registered architectures will match against a defined regex. However, for additional architectures which do not match, we should not fail to load an object just because we couldn't detect and report what we would have automatically detected 