### PR TITLE
Only warn for non TWOLEVEL Mach-O binaries

### DIFF
--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -294,7 +294,7 @@ class MachO(Backend):
         self.pie = bool(self.flags & 0x200000)  # MH_PIE
 
         if not bool(self.flags & 0x80):  # ensure MH_TWOLEVEL
-            raise CLEInvalidBinaryError("Cannot handle non MH_TWOLEVEL binaries")
+            l.error("Binary is not using MH_TWOLEVEL namespacing. This isn't properly implemented yet and will degrade results in unpredictable ways. Please open an issue if you encounter this with a binary you can share")
 
     @staticmethod
     def _detect_byteorder(magic):


### PR DESCRIPTION
Talked about this in the Slack.
In very rare cases a binary is not using the typical namespacing which isn't handled by CLE yet. This is so rare that those binaries tend to be proprietary and can't be shared. If I can actually get a binary that causes issues with this I can probably implement it, but so far I didn't.