### PR TITLE
Update pyelftools requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     python_requires='>=3.6',
     packages=packages,
     install_requires=[
-        'pyelftools>=0.25',
+        'pyelftools>=0.27',
         'cffi',
         'pyvex==9.0.gitrolling',
         'pefile',


### PR DESCRIPTION
cle requires pyelftools 0.27 - versions 0.25 and 0.26 fail

Fixes #291 