### PR TITLE
DWARF: Do not crash when types do not have names.

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -626,7 +626,9 @@ class ELF(MetaELF):
             # scan the whole die tree for DW_TAG_base_type
             for die in cu.iter_DIEs():
                 if die.tag == "DW_TAG_base_type":
-                    type_list[die.offset] = VariableType.read_from_die(die)
+                    var_type = VariableType.read_from_die(die)
+                    if var_type is not None:
+                        type_list[die.offset] = var_type
 
             top_die = cu.get_top_DIE()
 

--- a/cle/backends/elf/variable_type.py
+++ b/cle/backends/elf/variable_type.py
@@ -11,7 +11,11 @@ class VariableType:
 
     @staticmethod
     def read_from_die(die: DIE):
+        dw_at_name = die.attributes.get("DW_AT_name", None)
+        byte_size = die.attributes.get("DW_AT_byte_size", None)
+        if byte_size is None:
+            return None
         return VariableType(
-            name = die.attributes["DW_AT_name"].value.decode(),
-            byte_size = die.attributes["DW_AT_byte_size"].value
+            name = dw_at_name.value.decode() if dw_at_name is not None else "unknown",
+            byte_size = byte_size.value
         )


### PR DESCRIPTION
This PR fixes [angr/angr-management#618](https://github.com/angr/angr-management/issues/618).