### PR TITLE
Add symbol versioning info to elf symbols; use this to detect newer versions of glibc

### DIFF
--- a/cle/backends/elf/symbol.py
+++ b/cle/backends/elf/symbol.py
@@ -46,6 +46,7 @@ class ELFSymbol(Symbol):
                          symb.entry.st_size,
                          self.type)
 
+        self.version = None
         self.binding = symb.entry.st_info.bind
         self.is_hidden = symb.entry['st_other']['visibility'] == 'STV_HIDDEN'
         self.section = sec_ndx if type(sec_ndx) is not str else None


### PR DESCRIPTION
For angr/angr#3254, though it doesn't fix it

Also includes other misc fixes