### PR TITLE
Two small features

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -188,6 +188,10 @@ class ELF(MetaELF):
         self._ppc64_abiv1_entry_fix()
         self._load_plt()
 
+        # hack: set guess_simprocs = True for object files
+        if self.is_relocatable and self.imports and not self._dynamic:
+            self.guess_simprocs = True
+
         for offset, patch in patch_undo:
             self.memory.store(AT.from_lva(self.min_addr + offset, self).to_rva(), patch)
 

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -427,6 +427,27 @@ class Loader:
 
         return obj.find_section_containing(addr)
 
+    def find_loadable_containing(self, addr, skip_pseudo_objects=True):
+        """
+        Find the section or segment object the address belongs to. Sections will only be used if the corresponding
+        object does not have segments.
+
+        :param addr: The address to test
+        :param skip_pseudo_objects: Skip objects that CLE adds during loading.
+        :return:  The section or segment that the address belongs to, or None if the address does not belong to any
+                    section or segment.
+        """
+        obj = self.find_object_containing(addr, membership_check=False)
+
+        if obj is None:
+            return None
+
+        if skip_pseudo_objects and isinstance(obj, (ExternObject, KernelObject, TLSObject)):
+            # the address is from a special CLE section
+            return None
+
+        return obj.find_loadable_containing(addr)
+
     def find_section_next_to(self, addr, skip_pseudo_objects=True):
         """
         Find the next section after the given address.


### PR DESCRIPTION
- Add find_loadable_containing to Loader
- Set guess_simprocs = True for elf object files. This flag was created for binary ninja, which doesn't say what an object's dependencies are, but elf objects (.o files) also don't provide this information.