### PR TITLE
ELF: Attempt last-resort ArchPcode generation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ ar =
     arpy==1.1.1
 minidump =
     minidump>=0.0.10
+pcode =
+    pypcode>=1.1
 testing =
     cffi
 xbe =

--- a/tests/test_arch_detect.py
+++ b/tests/test_arch_detect.py
@@ -1,0 +1,32 @@
+# pylint:disable=no-self-use
+import unittest
+import os
+
+import archinfo
+
+try:
+    import pypcode
+except ImportError:
+    pypcode = None
+
+import cle
+
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../binaries/tests"))
+
+
+@unittest.skipIf(pypcode is None, "pypcode not installed")
+class TestArchPcodeDetect(unittest.TestCase):
+    """
+    Test architecture detection.
+    """
+
+    def test_elf_m68k(self):
+        binpath = os.path.join(test_location, "m68k/mul_add_sub_xor_m68k_be")
+        ld = cle.Loader(binpath)
+        arch = ld.main_object.arch
+        assert isinstance(arch, archinfo.ArchPcode)
+        assert arch.name == "68000:BE:32:default"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
If we cannot determine an architecture supported directly by archinfo, try matching e_machine and e_type against pypcode .opinion files to determine the correct language and create a corresponding ArchPcode class. pypcode is a soft dependency.

Depends:
* angr/archinfo#127
* angr/binaries#102 

Needs:
- [x] A test case

Related:
* angr/angr#3761
* angr/angr-management#879* 
* angr/angr-doc#450