### PR TITLE
Don't crash when corefile references unreadable file; don't map note sections

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1228,6 +1228,8 @@ class ELF(MetaELF):
                             b"\0" * sec_readelf.header["sh_size"],
                             overwrite=True,
                         )
+                    elif section.type == "SHT_NOTE":
+                        pass  # observed this case in angr/angr#3829
                     else:  # elif section.type == 'SHT_PROGBITS':
                         self.memory.add_backer(
                             AT.from_lva(section.vaddr, self).to_rva(), sec_readelf.data(), overwrite=True

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -431,7 +431,7 @@ class ELFCore(ELF):
             try:
                 with open(filename, "rb") as fp:
                     obj = self.loader._load_object_isolated(fp)
-            except (FileNotFoundError, CLECompatibilityError) as ex:
+            except (FileNotFoundError, PermissionError, CLECompatibilityError) as ex:
                 if isinstance(ex, FileNotFoundError):
                     log.warning(
                         "Dependency %s does not exist on the current system; this core may be incomplete.", filename


### PR DESCRIPTION
Closes https://github.com/angr/angr/issues/3829