### PR TITLE
Fix bytes/str issue in PE backend

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -170,7 +170,7 @@ class PE(Backend):
             for entry in self._pe.DIRECTORY_ENTRY_IMPORT:
                 for imp in entry.imports:
                     if imp.name is None:  # must be an import by ordinal
-                        imp_name = "ordinal.%d.%s" % (imp.ordinal, entry.dll.lower())
+                        imp_name = "ordinal.%d.%s" % (imp.ordinal, entry.dll.lower().decode())
                     else:
                         imp_name = imp.name.decode()
 


### PR DESCRIPTION
When creating symbols for PE imports by ordinal, CLE uses [the `dll` field of `pefile.ImportDescData`](https://pefile.readthedocs.io/en/latest/modules/pefile.html#pefile.ImportDescData) as part of the symbol name. It's not specifically stated in the `pefile` docs, but that field is of type `bytes` in Python 3, so it ends up creating symbol names that look like `ordinal.470.b'mfc42.dll'`, whereas in Python 2 it would've been `ordinal.470.mfc42.dll`.

This can cause problems when the symbol name works its way through angr and ends up in names of Claripy bitvectors, for example `unconstrained_ret_ordinal.470.b'mfc42.dll'_4_32`. SMT-LIB identifiers can't contain single-quotes, so if you export SMT2 files involving these variables, they're invalid syntax and can't be parsed.

The fix is just to `decode()` the `bytes` to `str`.