### PR TITLE
Add uefi extra depends

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,8 @@ pcode =
     pypcode>=1.1
 testing =
     cffi
+uefi =
+    uefi-firmware>=1.10
 xbe =
     pyxbe==0.0.4
 


### PR DESCRIPTION
Upstream packaging has been improved, adding this to use in the angr management build.