### PR TITLE
Fix short description in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,7 @@
 [metadata]
 name = cle
 version = attr: cle.__version__
-description = |
-    CLE Loads Everything (at least, many binary formats!) and provides a
-    pythonic interface to analyze what they are and what they would look like in
-    memory.
+description = CLE Loads Everything (at least, many binary formats!) and provides a pythonic interface to analyze what they are and what they would look like in memory.
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/angr/cle


### PR DESCRIPTION
Right now the description is just `|`, as it doesn't follow the yaml syntax.