### PR TITLE
Add archinfo dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
+    archinfo==9.2.81.dev0
     pefile
     pyelftools>=0.27
     pyvex==9.2.81.dev0


### PR DESCRIPTION
This was a transitive dependency of pyvex previously, but since pyvex doesn't depend on archinfo anymore, we have to declare it explicitly.