### PR TITLE
Fix mips plt

### DIFF
--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -147,7 +147,7 @@ class MetaELF(Backend):
         if ".plt.got" in self.sections_map:
             plt_secs = [self.sections_map[".plt.got"]]
         if ".MIPS.stubs" in self.sections_map:
-            plt_secs = [self.sections_map[".MIPS.stubs"]]
+            plt_secs.append(self.sections_map[".MIPS.stubs"])
         if ".plt.sec" in self.sections_map:
             plt_secs.append(self.sections_map[".plt.sec"])
 

--- a/tests/test_plt.py
+++ b/tests/test_plt.py
@@ -24,7 +24,14 @@ class TestCheckPltEntries(unittest.TestCase):
             self.assertEqual(diffs, [4] * len(diffs))
             return
 
-        # all our mips samples have no PLT, just resolver stubs
+        if filename == os.path.join("mips", "checkbyte"):
+            self.assertEqual(
+                ld.main_object.plt,
+                {"read": 0x4008c0, "puts": 0x4008d0, "__libc_start_main": 0x4008e0},
+            )
+            return
+
+        # remaining mips samples have no PLT, just resolver stubs
         if filename.startswith("mips"):
             self.assertEqual(ld.main_object.plt, {})
             return

--- a/tests/test_plt.py
+++ b/tests/test_plt.py
@@ -27,7 +27,7 @@ class TestCheckPltEntries(unittest.TestCase):
         if filename == os.path.join("mips", "checkbyte"):
             self.assertEqual(
                 ld.main_object.plt,
-                {"read": 0x4008c0, "puts": 0x4008d0, "__libc_start_main": 0x4008e0},
+                {"read": 0x4008C0, "puts": 0x4008D0, "__libc_start_main": 0x4008E0},
             )
             return
 


### PR DESCRIPTION
If a MIPS binary contains a `.MIPS.stubs` section, then existing entries found in the `.plt` sections are overwritten leading to missing plt entries. This is present in the `checkbyte` binary, so I have updated the test as well.