### PR TITLE
Implement outer backends.

### DIFF
--- a/cle/__init__.py
+++ b/cle/__init__.py
@@ -67,6 +67,8 @@ from .errors import (
     CLEMemoryError,
     CLEOperationError,
     CLEUnknownFormatError,
+    CLEInvalidFileFormatError,
+    CLEInvalidEncryptionError,
 )
 from .gdb import GDB_SEARCH_PATH, convert_info_proc_maps, convert_info_sharedlibrary
 from .loader import Loader
@@ -118,6 +120,8 @@ __all__ = [
     "CLEError",
     "CLEFileNotFoundError",
     "CLEInvalidBinaryError",
+    "CLEInvalidEncryptionError",
+    "CLEInvalidFileFormatError",
     "CLEOperationError",
     "CLEUnknownFormatError",
     "CLEMemoryError",

--- a/cle/__init__.py
+++ b/cle/__init__.py
@@ -64,11 +64,11 @@ from .errors import (
     CLEError,
     CLEFileNotFoundError,
     CLEInvalidBinaryError,
+    CLEInvalidEncryptionError,
+    CLEInvalidFileFormatError,
     CLEMemoryError,
     CLEOperationError,
     CLEUnknownFormatError,
-    CLEInvalidFileFormatError,
-    CLEInvalidEncryptionError,
 )
 from .gdb import GDB_SEARCH_PATH, convert_info_proc_maps, convert_info_sharedlibrary
 from .loader import Loader

--- a/cle/backends/backend.py
+++ b/cle/backends/backend.py
@@ -124,6 +124,7 @@ class Backend:
     """
 
     is_default = False
+    is_outer = False
 
     def __init__(
         self,
@@ -151,6 +152,8 @@ class Backend:
             self.binary_basename = os.path.basename(self._binary_stream.name)
         else:
             self.binary_basename = str(self._binary_stream)
+        # if the backend unpacks another file, this field will hold the name of the file
+        self.unpacked_name: str | None = None
 
         for k in list(kwargs.keys()):
             if k == "custom_entry_point":

--- a/cle/backends/cartfile.py
+++ b/cle/backends/cartfile.py
@@ -1,6 +1,6 @@
 import logging
-import struct
 import os
+import struct
 from io import BytesIO
 
 from cle.errors import CLEError, CLEInvalidEncryptionError, CLEInvalidFileFormatError

--- a/cle/backends/cartfile.py
+++ b/cle/backends/cartfile.py
@@ -1,8 +1,9 @@
 import logging
 import struct
+import os
 from io import BytesIO
 
-from cle.errors import CLEError
+from cle.errors import CLEError, CLEInvalidEncryptionError, CLEInvalidFileFormatError
 
 from .backend import Backend, register_backend
 
@@ -20,9 +21,13 @@ class CARTFile(Backend):
     cannot be executed and encrypts it so anti-virus software cannot flag the CaRT file as malware.
 
     Ref: https://github.com/CybercentreCanada/cart
+
+    CART file does not store the name of the unpacked file. This backend automatically creates one and stores at
+    self.unpacked_name.
     """
 
     is_default = True
+    is_outer = True
 
     def __init__(self, binary, binary_stream, *args, arc4_key=None, **kwargs):
         if cart is None:
@@ -35,14 +40,22 @@ class CARTFile(Backend):
         # marked as the main binary if we are also the main binary
         # work around this by setting ourself here:
         ostream = BytesIO()
-        _ = cart.unpack_stream(
-            binary_stream,
-            ostream,
-            arc4_key_override=arc4_key,
-        )
+        try:
+            _ = cart.unpack_stream(
+                binary_stream,
+                ostream,
+                arc4_key_override=arc4_key,
+            )
+        except cart.cart.InvalidARC4KeyException as ex:
+            raise CLEInvalidEncryptionError(backend=CARTFile, enckey_argname="arc4_key") from ex
+        except cart.cart.InvalidCARTException as ex:
+            raise CLEInvalidFileFormatError() from ex
+
+        self.unpacked_name = self.get_unpacked_name(binary)
+
         if self.loader._main_object is None:
             self.loader._main_object = self
-        child = self.loader._load_object_isolated(ostream)
+        child = self.loader._load_object_isolated(ostream, obj_ident=self.unpacked_name)
         self.child_objects.append(child)
         self.has_memory = False
 
@@ -61,6 +74,12 @@ class CARTFile(Backend):
             return False
         (magic, version) = struct.unpack("4sh", header)
         return magic == b"CART" and version == 1
+
+    @staticmethod
+    def get_unpacked_name(file_path: str) -> str:
+        if isinstance(file_path, str):
+            return os.path.basename(file_path) + ".unpacked"
+        return "cart.unpacked"
 
 
 register_backend("cart", CARTFile)

--- a/cle/backends/static_archive.py
+++ b/cle/backends/static_archive.py
@@ -19,6 +19,7 @@ class StaticArchive(Backend):
         return stream.read(8) == b"!<arch>\n"
 
     is_default = True
+    is_outer = True
 
     def __init__(self, *args, **kwargs):
         if arpy is None:

--- a/cle/errors.py
+++ b/cle/errors.py
@@ -63,3 +63,19 @@ class CLEMemoryError(CLEError):
     """
 
     pass
+
+
+class CLEInvalidFileFormatError(CLEError):
+    """
+    Error raised when loading a file with an invalid format.
+    """
+
+
+class CLEInvalidEncryptionError(CLEError):
+    """
+    Error raised when loading an encrypted file (e.g., CART) with an incorrect encryption key.
+    """
+
+    def __init__(self, backend=None, enckey_argname=None):
+        self.backend = backend
+        self.enckey_argname = enckey_argname

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -1,5 +1,5 @@
-import logging
 import itertools
+import logging
 import os
 import platform
 import sys

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -1,4 +1,5 @@
 import logging
+import itertools
 import os
 import platform
 import sys
@@ -169,6 +170,7 @@ class Loader:
         self.aslr = aslr
         self.page_size = page_size
         self._memory = None
+        self._original_main_object = None
         self._main_object = None
         self._tls = None
         self._kernel_object: KernelObject | None = None
@@ -199,6 +201,13 @@ class Loader:
         result = self._main_object
         if result is None:
             raise ValueError("Cannot access main_object before loading is complete")
+        return result
+
+    @property
+    def original_main_object(self) -> Backend:
+        result = self._original_main_object
+        if result is None:
+            raise ValueError("Cannot access original_main_object before loading is complete")
         return result
 
     @property
@@ -781,11 +790,13 @@ class Loader:
             if self._main_object is None:
                 # this is technically the first place we can start to initialize things based on platform
                 if obj.force_main_object is not None:
+                    self._original_main_object = obj
                     self._main_object = obj.force_main_object
+                    self._main_object.is_main_bin = True
                     # just to be safe, we clear obj.force_main_object here
                     obj.force_main_object = None
                 else:
-                    self._main_object = obj
+                    self._original_main_object = self._main_object = obj
                 self._memory = Clemory(self._main_object.arch, root=True)
 
                 chk_obj = (
@@ -930,7 +941,7 @@ class Loader:
 
         return objects
 
-    def _load_object_isolated(self, spec):
+    def _load_object_isolated(self, spec, obj_ident: str | None = None):
         """
         Given a partial specification of a dependency, this will return the loaded object as a backend instance.
         It will not touch any loader-global data.
@@ -959,9 +970,11 @@ class Loader:
             if self._main_object is None:
                 options = dict(self._main_opts)
             else:
-                for ident in self._possible_idents(
-                    binary_stream if binary is None else binary
+                for ident in itertools.chain(
+                    [obj_ident], self._possible_idents(binary_stream if binary is None else binary)
                 ):  # also allowed to cheat
+                    if ident is None:
+                        continue
                     if ident in self._lib_opts:
                         options = dict(self._lib_opts[ident])
                         break

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -34,6 +34,60 @@ def test_cart_elf():
     assert ld.main_object.os == "UNIX - System V"
 
 
+def test_cart_elf_with_load_options():
+    cartfile = os.path.join(
+        TEST_BASE,
+        "tests",
+        "x86_64",
+        "1after909.cart",
+    )
+    unpacked_name = cle.backends.CARTFile.get_unpacked_name(cartfile)
+    ld = cle.Loader(
+        cartfile,
+        auto_load_libs=False,
+        main_opts={
+            "arc4_key": b"\x02\xf53asdf\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+        },
+        lib_opts={
+            unpacked_name: {
+                "base_addr": 0x500000,
+            }
+        },
+    )
+    assert isinstance(ld.main_object, cle.ELF)
+    assert ld.main_object.mapped_base == 0x500000
+
+
+def test_cart_blob_with_load_options():
+    cartfile = os.path.join(
+        TEST_BASE,
+        "tests",
+        "x86_64",
+        "1after909.cart",
+    )
+    unpacked_name = cle.backends.CARTFile.get_unpacked_name(cartfile)
+    ld = cle.Loader(
+        cartfile,
+        auto_load_libs=False,
+        main_opts={
+            "arc4_key": b"\x02\xf53asdf\x00\x00\x00\x00\x00\x00\x00\x00\x00",
+        },
+        lib_opts={
+            unpacked_name: {
+                "backend": cle.backends.Blob,
+                "arch": "amd64",
+                "entry_point": 0x600000,
+                "base_addr": 0x500000,
+            }
+        },
+    )
+    assert isinstance(ld.main_object, cle.Blob)
+    assert ld.main_object.mapped_base == 0x500000
+    assert ld.main_object.entry == 0x600000
+
+
 if __name__ == "__main__":
     test_cart_pe()
     test_cart_elf()
+    test_cart_elf_with_load_options()
+    test_cart_blob_with_load_options()


### PR DESCRIPTION
- Introduce CLEInvalidFileFormatError and CLEInvalidEncryptionError.
- Allow setting load options for main objects after loading using outer backends.