### PR TITLE
PE: Support loading symbols from PDBs

### DIFF
--- a/cle/backends/backend.py
+++ b/cle/backends/backend.py
@@ -493,6 +493,10 @@ class Backend:
         """
         if name in self._symbol_cache:
             return self._symbol_cache[name]
+        for sym in self.symbols:
+            if sym.name == name:
+                self._symbol_cache[name] = sym
+                return sym
         return None
 
     @staticmethod

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -19,6 +19,7 @@ from .relocation import get_relocation
 from .relocation.generic import IMAGE_REL_BASED_ABSOLUTE, IMAGE_REL_BASED_HIGHADJ, DllImport
 from .symbol import WinSymbol
 
+PDB_SUPPORT_ENABLED = pyxdia is not None
 log = logging.getLogger(name=__name__)
 
 

--- a/cle/backends/pe/symbol.py
+++ b/cle/backends/pe/symbol.py
@@ -10,8 +10,10 @@ class WinSymbol(Symbol):
     Represents a symbol for the PE format.
     """
 
-    def __init__(self, owner, name, addr, is_import, is_export, ordinal_number, forwarder):
-        super().__init__(owner, name, addr, owner.arch.bytes, SymbolType.TYPE_FUNCTION)
+    def __init__(
+        self, owner, name, addr, is_import, is_export, ordinal_number, forwarder, symbol_type=SymbolType.TYPE_FUNCTION
+    ):
+        super().__init__(owner, name, addr, owner.arch.bytes, symbol_type)
         self.is_import = is_import
         self.is_export = is_export
         self.ordinal_number = ordinal_number

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ minidump =
     minidump>=0.0.10
 pcode =
     pypcode>=1.1
+pdb =
+    pyxdia~=0.0
 testing =
     cffi
     minidump>=0.0.10

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -1,129 +1,128 @@
 #!/usr/bin/env python
 
-import logging
 import os
+import unittest
 
 import cle
+
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
 
-def test_exe():
-    exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "TLS.exe")
-    ld = cle.Loader(exe, auto_load_libs=False)
-    assert isinstance(ld.main_object, cle.PE)
-    assert ld.main_object.os == "windows"
-    assert sorted([sec.name for sec in ld.main_object.sections]) == sorted(
-        [
-            ".textbss",
-            ".text\x00\x00\x00",
-            ".rdata\x00\x00",
-            ".data\x00\x00\x00",
-            ".idata\x00\x00",
-            ".tls\x00\x00\x00\x00",
-            ".gfids\x00\x00",
-            ".00cfg\x00\x00",
-            ".rsrc\x00\x00\x00",
-        ]
-    )
-    assert ld.main_object.segments is ld.main_object.sections
-    assert sorted(ld.main_object.deps) == sorted(["kernel32.dll", "vcruntime140d.dll", "ucrtbased.dll"])
-    assert sorted(ld.main_object.imports) == sorted(
-        [
-            "_configure_narrow_argv",
-            "GetLastError",
-            "HeapFree",
-            "IsProcessorFeaturePresent",
-            "__vcrt_GetModuleFileNameW",
-            "_configthreadlocale",
-            "__setusermatherr",
-            "memset",
-            "terminate",
-            "_register_onexit_function",
-            "WaitForSingleObject",
-            "_set_fmode",
-            "FreeLibrary",
-            "QueryPerformanceCounter",
-            "_controlfp_s",
-            "IsDebuggerPresent",
-            "HeapAlloc",
-            "_initialize_onexit_table",
-            "wcscpy_s",
-            "__std_type_info_destroy_list",
-            "_set_app_type",
-            "_cexit",
-            "_seh_filter_exe",
-            "_c_exit",
-            "GetCurrentProcess",
-            "_set_new_mode",
-            "__vcrt_LoadLibraryExW",
-            "__stdio_common_vsprintf_s",
-            "GetCurrentProcessId",
-            "_execute_onexit_table",
-            "WideCharToMultiByte",
-            "UnhandledExceptionFilter",
-            "MultiByteToWideChar",
-            "GetStartupInfoW",
-            "exit",
-            "GetProcAddress",
-            "InitializeSListHead",
-            "_crt_at_quick_exit",
-            "GetProcessHeap",
-            "_CrtDbgReportW",
-            "RaiseException",
-            "__telemetry_main_invoke_trigger",
-            "CreateThread",
-            "_exit",
-            "__p__commode",
-            "_get_initial_narrow_environment",
-            "__p___argc",
-            "SetUnhandledExceptionFilter",
-            "_except_handler4_common",
-            "_register_thread_local_exe_atexit_callback",
-            "GetSystemTimeAsFileTime",
-            "_initialize_narrow_environment",
-            "__vcrt_GetModuleHandleW",
-            "__p___argv",
-            "GetModuleHandleW",
-            "TerminateProcess",
-            "_initterm_e",
-            "_wmakepath_s",
-            "_seh_filter_dll",
-            "_CrtDbgReport",
-            "VirtualQuery",
-            "__telemetry_main_return_trigger",
-            "_wsplitpath_s",
-            "_initterm",
-            "GetCurrentThreadId",
-            "_crt_atexit",
-        ]
-    )
-    assert ld.main_object.provides is None
+# pylint: disable=no-self-use
+class TestPEBackend(unittest.TestCase):
+    """
+    Test PE Backend
+    """
 
+    def test_exe(self):
+        exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "TLS.exe")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        assert isinstance(ld.main_object, cle.PE)
+        assert ld.main_object.os == "windows"
+        assert sorted([sec.name for sec in ld.main_object.sections]) == sorted(
+            [
+                ".textbss",
+                ".text\x00\x00\x00",
+                ".rdata\x00\x00",
+                ".data\x00\x00\x00",
+                ".idata\x00\x00",
+                ".tls\x00\x00\x00\x00",
+                ".gfids\x00\x00",
+                ".00cfg\x00\x00",
+                ".rsrc\x00\x00\x00",
+            ]
+        )
+        assert ld.main_object.segments is ld.main_object.sections
+        assert sorted(ld.main_object.deps) == sorted(["kernel32.dll", "vcruntime140d.dll", "ucrtbased.dll"])
+        assert sorted(ld.main_object.imports) == sorted(
+            [
+                "_configure_narrow_argv",
+                "GetLastError",
+                "HeapFree",
+                "IsProcessorFeaturePresent",
+                "__vcrt_GetModuleFileNameW",
+                "_configthreadlocale",
+                "__setusermatherr",
+                "memset",
+                "terminate",
+                "_register_onexit_function",
+                "WaitForSingleObject",
+                "_set_fmode",
+                "FreeLibrary",
+                "QueryPerformanceCounter",
+                "_controlfp_s",
+                "IsDebuggerPresent",
+                "HeapAlloc",
+                "_initialize_onexit_table",
+                "wcscpy_s",
+                "__std_type_info_destroy_list",
+                "_set_app_type",
+                "_cexit",
+                "_seh_filter_exe",
+                "_c_exit",
+                "GetCurrentProcess",
+                "_set_new_mode",
+                "__vcrt_LoadLibraryExW",
+                "__stdio_common_vsprintf_s",
+                "GetCurrentProcessId",
+                "_execute_onexit_table",
+                "WideCharToMultiByte",
+                "UnhandledExceptionFilter",
+                "MultiByteToWideChar",
+                "GetStartupInfoW",
+                "exit",
+                "GetProcAddress",
+                "InitializeSListHead",
+                "_crt_at_quick_exit",
+                "GetProcessHeap",
+                "_CrtDbgReportW",
+                "RaiseException",
+                "__telemetry_main_invoke_trigger",
+                "CreateThread",
+                "_exit",
+                "__p__commode",
+                "_get_initial_narrow_environment",
+                "__p___argc",
+                "SetUnhandledExceptionFilter",
+                "_except_handler4_common",
+                "_register_thread_local_exe_atexit_callback",
+                "GetSystemTimeAsFileTime",
+                "_initialize_narrow_environment",
+                "__vcrt_GetModuleHandleW",
+                "__p___argv",
+                "GetModuleHandleW",
+                "TerminateProcess",
+                "_initterm_e",
+                "_wmakepath_s",
+                "_seh_filter_dll",
+                "_CrtDbgReport",
+                "VirtualQuery",
+                "__telemetry_main_return_trigger",
+                "_wsplitpath_s",
+                "_initterm",
+                "GetCurrentThreadId",
+                "_crt_atexit",
+            ]
+        )
+        assert ld.main_object.provides is None
 
-def test_dll():
-    pass
+    def test_tls(self):
+        exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "TLS.exe")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        tls = ld.tls.new_thread()
 
+        assert ld.main_object.tls_used
+        assert ld.main_object.tls_data_start == 0x1B000
+        assert ld.main_object.tls_data_size == 520
+        assert ld.main_object.tls_index_address == 0x41913C
+        assert ld.main_object.tls_callbacks == [0x411302]
+        assert ld.main_object.tls_block_size == ld.main_object.tls_data_size
 
-def test_tls():
-    exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "TLS.exe")
-    ld = cle.Loader(exe, auto_load_libs=False)
-    tls = ld.tls.new_thread()
-
-    assert ld.main_object.tls_used
-    assert ld.main_object.tls_data_start == 0x1B000
-    assert ld.main_object.tls_data_size == 520
-    assert ld.main_object.tls_index_address == 0x41913C
-    assert ld.main_object.tls_callbacks == [0x411302]
-    assert ld.main_object.tls_block_size == ld.main_object.tls_data_size
-
-    assert tls is not None
-    assert len(ld.tls.modules) == 1
-    assert tls.get_tls_data_addr(0) == tls.memory.unpack_word(0)
+        assert tls is not None
+        assert len(ld.tls.modules) == 1
+        assert tls.get_tls_data_addr(0) == tls.memory.unpack_word(0)
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    test_exe()
-    test_dll()
-    test_tls()
+    unittest.main()

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -5,7 +5,6 @@ import unittest
 
 import cle
 
-
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
 
@@ -122,6 +121,22 @@ class TestPEBackend(unittest.TestCase):
         assert tls is not None
         assert len(ld.tls.modules) == 1
         assert tls.get_tls_data_addr(0) == tls.memory.unpack_word(0)
+
+    @unittest.skipUnless(cle.backends.pe.pe.PDB_SUPPORT_ENABLED, "PDB")
+    def test_pdb(self):
+        exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.exe")
+        pdb = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.pdb")
+
+        ld = cle.Loader(exe, auto_load_libs=False)
+        assert not ld.find_symbol("authenticate")
+
+        # Automatically find fauxware.pdb
+        ld = cle.Loader(exe, auto_load_libs=False, load_debug_info=True)
+        assert ld.find_symbol("authenticate")
+
+        # Manually specify fauxware.pdb
+        ld = cle.Loader(exe, auto_load_libs=False, main_opts={"debug_symbols": pdb})
+        assert ld.find_symbol("authenticate")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Optionally use [pyxdia](https://pypi.org/project/pyxdia/) library to load symbols from PDB files

- [x] Fix `get_symbol`/`_symbol_cache`
- [x] Use correct `SymbolType`
- [x] Add test case