### PR TITLE
Add Clemory indirection to raise exception on accesses to encrypted memory areas

### DIFF
--- a/cle/backends/macho/encrypted_sentinel_backer.py
+++ b/cle/backends/macho/encrypted_sentinel_backer.py
@@ -1,4 +1,5 @@
-from cle.errors import CLEMemoryError
+from __future__ import annotations
+
 from cle.memory import Clemory
 
 
@@ -69,4 +70,5 @@ class EncryptedDataAccessException(Exception):
     def __init__(self, message, addr):
         super().__init__(message)
         self.addr = addr
+
     pass

--- a/cle/backends/macho/encrypted_sentinel_backer.py
+++ b/cle/backends/macho/encrypted_sentinel_backer.py
@@ -67,8 +67,9 @@ class CryptSentinel(Clemory):
 
 
 class EncryptedDataAccessException(Exception):
+    """
+    Special exception to be raised when access to encrypted memory is attempted
+    """
     def __init__(self, message, addr):
         super().__init__(message)
         self.addr = addr
-
-    pass

--- a/cle/backends/macho/encrypted_sentinel_backer.py
+++ b/cle/backends/macho/encrypted_sentinel_backer.py
@@ -1,0 +1,72 @@
+from cle.errors import CLEMemoryError
+from cle.memory import Clemory
+
+
+class CryptSentinel(Clemory):
+    """
+    Mach-O binaries are often encrypted, and some area of memory is only decrypted at runtime later in the loading
+    process. This decryption process can't easily be implemented in CLE and is typically done with separate tools
+    But not all data is encrypted, and various metadata is still accessible.
+
+    This Clemory serves as a shim that allows us to notice accesses to encrypted areas of memory and raise an exception
+    This means that all code that was written will loudly fail on access to encrypted memory, instead of silently
+    reading garbage data.
+    """
+
+    def __init__(self, arch, root=False):
+        super().__init__(arch, root)
+        self._crypt_start = None
+        self._crypt_end = None
+        self._is_encrypted: bool = False
+
+    def load(self, addr, n):
+        self._assert_unencrypted_access(addr, n)
+        return super().load(addr, n)
+
+    def store(self, addr, data):
+        self._assert_unencrypted_access(addr, len(data))
+        return super().store(addr, data)
+
+    def find(self, data, search_min=None, search_max=None):
+        if self._is_encrypted:
+            raise EncryptedDataAccessException("Cannot search encrypted memory region", self._crypt_start)
+        return super().find(data, search_min, search_max)
+
+    def set_crypt_info(self, cryptid, start, size):
+        self._is_encrypted = cryptid != 0 and size > 0
+        self._crypt_start = start
+        self._crypt_end = start + size
+
+    def backers(self, addr=0):
+        if self._is_encrypted:
+            if self._crypt_start <= addr < self._crypt_end:
+                raise EncryptedDataAccessException("Accessing encrypted memory region", addr)
+        return super().backers(addr)
+
+    def _assert_unencrypted_access(self, addr, size):
+        """
+        Make sure that the access does not cover encrypted memory regions
+        If it does, raise an error
+
+        Cases:
+        - Access starts before encrypted region and ends after it
+        - Access starts within encrypted region
+        - Access ends within encrypted region
+
+        :param addr:
+        :param size:
+        :return:
+        """
+        if not self._is_encrypted:
+            return
+
+        encrypted_range = range(self._crypt_start, self._crypt_end)
+        if addr in encrypted_range or (addr + size) in encrypted_range or (addr < self._crypt_start < addr + size):
+            raise EncryptedDataAccessException("Accessing encrypted memory region", addr)
+
+
+class EncryptedDataAccessException(Exception):
+    def __init__(self, message, addr):
+        super().__init__(message)
+        self.addr = addr
+    pass

--- a/cle/backends/macho/encrypted_sentinel_backer.py
+++ b/cle/backends/macho/encrypted_sentinel_backer.py
@@ -70,6 +70,7 @@ class EncryptedDataAccessException(Exception):
     """
     Special exception to be raised when access to encrypted memory is attempted
     """
+
     def __init__(self, message, addr):
         super().__init__(message)
         self.addr = addr

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -20,6 +20,7 @@ from cle.backends.macho.binding import BindingHelper, MachOPointerRelocation, Ma
 from cle.backends.regions import Regions
 from cle.errors import CLECompatibilityError, CLEInvalidBinaryError, CLEOperationError
 
+from .encrypted_sentinel_backer import CryptSentinel
 from .macho_enums import LoadCommands as LC
 from .macho_enums import MachoFiletype, MH_flags
 from .section import MachOSection
@@ -36,8 +37,6 @@ from .structs import (
     dyld_chained_starts_in_segment,
 )
 from .symbol import AbstractMachOSymbol, DyldBoundSymbol, SymbolTableSymbol
-from .encrypted_sentinel_backer import CryptSentinel
-
 
 log = logging.getLogger(name=__name__)
 

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -36,6 +36,8 @@ from .structs import (
     dyld_chained_starts_in_segment,
 )
 from .symbol import AbstractMachOSymbol, DyldBoundSymbol, SymbolTableSymbol
+from .encrypted_sentinel_backer import CryptSentinel
+
 
 log = logging.getLogger(name=__name__)
 
@@ -244,6 +246,10 @@ class MachO(Backend):
             log.info("Parsing binding bytecode stream")
             self.do_binding()
 
+    def set_arch(self, arch):
+        super().set_arch(arch)
+        self.memory = CryptSentinel(arch=arch)
+
     @property
     def min_addr(self):
         return self.mapped_base
@@ -296,7 +302,10 @@ class MachO(Backend):
                 self._load_lc_data_in_code(binary_file, offset)
             elif cmd in [LC.LC_ENCRYPTION_INFO, LC.LC_ENCRYPTION_INFO_64]:  # LC_ENCRYPTION_INFO(_64)
                 log.debug("Found LC_ENCRYPTION_INFO @ %#x", offset)
-                # self._assert_unencrypted(binary_file, offset)
+                # Store the offset and size of the encrypted section for later
+                (_, _, cryptoff, cryptsize, cryptid) = self._unpack("5I", binary_file, offset, 20)
+                self.memory.set_crypt_info(cryptid, cryptoff, cryptsize)
+
             elif cmd in [LC.LC_DYLD_CHAINED_FIXUPS]:
                 log.info("Found LC_DYLD_CHAINED_FIXUPS @ %#x", offset)
                 (_, _, dataoff, datasize) = self._unpack("4I", binary_file, offset, 16)
@@ -585,13 +594,6 @@ class MachO(Backend):
             self.lc_data_in_code.append(blob)
 
         log.debug("Done parsing data in code")
-
-    def _assert_unencrypted(self, f, off):
-        log.debug("Asserting unencrypted file")
-        (_, _, _, _, cryptid) = self._unpack("5I", f, off, 20)
-        if cryptid > 0:
-            log.error("Cannot load encrypted files")
-            raise CLEInvalidBinaryError()
 
     def _load_lc_function_starts(self, f, off):
         # note that the logic below is based on Apple's dyldinfo.cpp, no official docs seem to exist


### PR DESCRIPTION
This allows angr/CLE to load encrypted Mach-O binaries insofar as any analysis code never actually _accesses_ the encrypted memory region