### PR TITLE
PE: Support section names via string table, symbols via COFF header

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -368,10 +368,8 @@ class PE(Backend):
         :param offset: Byte offset of the string.
         :param encoding: String encoding (default utf-8).
         """
-        return extract_null_terminated_bytestr(
-            self._raw_data,
-            (self._pe.FILE_HEADER.PointerToSymbolTable + self._pe.FILE_HEADER.NumberOfSymbols * 18 + offset),
-        ).decode(encoding)
+        offset += self._pe.FILE_HEADER.PointerToSymbolTable + self._pe.FILE_HEADER.NumberOfSymbols * 18
+        return extract_null_terminated_bytestr(self._raw_data, offset).decode(encoding)
 
     def _register_sections(self):
         """

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -24,11 +24,10 @@ from .relocation.generic import IMAGE_REL_BASED_ABSOLUTE, IMAGE_REL_BASED_HIGHAD
 from .symbol import WinSymbol
 
 PDB_SUPPORT_ENABLED = pyxdia is not None
-log = logging.getLogger(name=__name__)
-
 SECTION_NAME_STRING_TABLE_OFFSET_RE = re.compile(r"\/(\d+)")
-
 VALID_SYMBOL_NAME_RE = re.compile(r"[A-Za-z0-9_@$?]+")
+
+log = logging.getLogger(name=__name__)
 
 
 class PE(Backend):

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -361,12 +361,12 @@ class PE(Backend):
 
         return callbacks
 
-    def _read_from_string_table(self, offset: int, encoding: str = "utf-8") -> str:
+    def _read_from_string_table(self, offset: int, encoding: str = "latin-1") -> str:
         """
         Read a null-terminated string from the string table given a byte offset.
 
         :param offset: Byte offset of the string.
-        :param encoding: String encoding (default utf-8).
+        :param encoding: String encoding (default latin-1).
         """
         offset += self._pe.FILE_HEADER.PointerToSymbolTable + self._pe.FILE_HEADER.NumberOfSymbols * 18
         return extract_null_terminated_bytestr(self._raw_data, offset).decode(encoding)
@@ -377,7 +377,7 @@ class PE(Backend):
         """
 
         for pe_section in self._pe.sections:
-            name = pe_section.Name.rstrip(b"\x00").decode("utf-8")
+            name = pe_section.Name.rstrip(b"\x00").decode("latin-1")
             # Match indirect section names given by a forward slash and a
             # decimal byte offset into the string table.
             str_tbl_offset_match = SECTION_NAME_STRING_TABLE_OFFSET_RE.fullmatch(name)
@@ -443,7 +443,7 @@ class PE(Backend):
             if name_as_dwords[0] == 0:
                 name = self._read_from_string_table(name_as_dwords[1])
             else:
-                name = name.rstrip(b"\x00").decode("utf-8")
+                name = name.rstrip(b"\x00").decode("latin-1")
             if section > 0 and type_ in type_to_symbol_type and VALID_SYMBOL_NAME_RE.fullmatch(name):
                 rva = self._pe.sections[section - 1].VirtualAddress + value
                 symbol = WinSymbol(self, name, rva, False, False, None, None, type_to_symbol_type[type_])

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -379,7 +379,7 @@ class PE(Backend):
         """
 
         for pe_section in self._pe.sections:
-            name = pe_section.Name.decode("utf-8")
+            name = pe_section.Name.rstrip(b"\x00").decode("utf-8")
             # Match indirect section names given by a forward slash and a
             # decimal byte offset into the string table.
             str_tbl_offset_match = SECTION_NAME_STRING_TABLE_OFFSET_RE.fullmatch(name)
@@ -429,10 +429,10 @@ class PE(Backend):
 
     def _load_symbols_from_coff_header(self):
         """
-        COFF debug data is deprecated, but some tools (namely mingw) will still provide them.
+        COFF debug info is deprecated, but may still be provided (e.g. by mingw).
         """
         type_to_symbol_type = {
-            0: SymbolType.TYPE_OBJECT,  # "Not a function"
+            0: SymbolType.TYPE_OBJECT,
             0x20: SymbolType.TYPE_FUNCTION,
         }
 

--- a/cle/backends/pe/regions.py
+++ b/cle/backends/pe/regions.py
@@ -10,7 +10,7 @@ class PESection(Section):
 
     def __init__(self, pe_section, remap_offset=0, name: str | None = None):
         super().__init__(
-            name or pe_section.Name.decode("utf-8"),  # ensure all bytes can be decoded
+            name or pe_section.Name.decode("latin-1"),  # ensure all bytes can be decoded
             pe_section.PointerToRawData,
             pe_section.VirtualAddress + remap_offset,
             pe_section.Misc_VirtualSize,

--- a/cle/backends/pe/regions.py
+++ b/cle/backends/pe/regions.py
@@ -10,7 +10,7 @@ class PESection(Section):
 
     def __init__(self, pe_section, remap_offset=0, name: str | None = None):
         super().__init__(
-            name or pe_section.Name.decode("latin-1"),  # ensure all bytes can be decoded
+            name or pe_section.Name.decode("utf-8"),  # ensure all bytes can be decoded
             pe_section.PointerToRawData,
             pe_section.VirtualAddress + remap_offset,
             pe_section.Misc_VirtualSize,

--- a/cle/backends/pe/regions.py
+++ b/cle/backends/pe/regions.py
@@ -8,9 +8,9 @@ class PESection(Section):
     Represents a section for the PE format.
     """
 
-    def __init__(self, pe_section, remap_offset=0):
+    def __init__(self, pe_section, remap_offset=0, name: str | None = None):
         super().__init__(
-            pe_section.Name.decode("latin-1"),  # ensure all bytes can be decoded
+            name or pe_section.Name.decode("latin-1"),  # ensure all bytes can be decoded
             pe_section.PointerToRawData,
             pe_section.VirtualAddress + remap_offset,
             pe_section.Misc_VirtualSize,

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -21,7 +21,7 @@ class Relocation:
     A representation of a relocation in a binary file. Smart enough to
     relocate itself.
 
-    :ivar owner:            The binary this relocation was originaly found in, as a cle object
+    :ivar owner:            The binary this relocation was originally found in, as a cle object
     :ivar symbol:           The Symbol object this relocation refers to
     :ivar relative_addr:    The address in owner this relocation would like to write to
     :ivar resolvedby:       If the symbol this relocation refers to is an import symbol and that import has been

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -120,7 +120,7 @@ class Relocation:
         return self.relative_addr
 
     @property
-    def value(self):  # pylint: disable=no-self-use
+    def value(self) -> int:  # pylint: disable=no-self-use
         log.error("Value property of Relocation must be overridden by subclass!")
         return 0
 

--- a/cle/utils.py
+++ b/cle/utils.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import contextlib
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Buffer
 
 import elftools
 
@@ -148,3 +152,10 @@ def get_text_offset(path):
     with stream_or_path(path) as f:
         e = elftools.elf.elffile.ELFFile(f)
         return e.get_section_by_name(".text").header.sh_offset
+
+
+def extract_null_terminated_bytestr(data: Buffer, offset: int = 0, sentinel_value: bytes = b"\x00") -> bytes:
+    """
+    Return an exclusive null-terminated sequence of bytes at `offset` in `data`.
+    """
+    return bytes(data[offset : data.find(sentinel_value, offset)])

--- a/cle/utils.py
+++ b/cle/utils.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import Buffer
 
 import elftools
 
@@ -154,7 +150,7 @@ def get_text_offset(path):
         return e.get_section_by_name(".text").header.sh_offset
 
 
-def extract_null_terminated_bytestr(data: Buffer, offset: int = 0, sentinel_value: bytes = b"\x00") -> bytes:
+def extract_null_terminated_bytestr(data: bytes | bytearray, offset: int = 0, sentinel_value: bytes = b"\x00") -> bytes:
     """
     Return an exclusive null-terminated sequence of bytes at `offset` in `data`.
     """

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -23,14 +23,14 @@ class TestPEBackend(unittest.TestCase):
         assert sorted([sec.name for sec in ld.main_object.sections]) == sorted(
             [
                 ".textbss",
-                ".text\x00\x00\x00",
-                ".rdata\x00\x00",
-                ".data\x00\x00\x00",
-                ".idata\x00\x00",
-                ".tls\x00\x00\x00\x00",
-                ".gfids\x00\x00",
-                ".00cfg\x00\x00",
-                ".rsrc\x00\x00\x00",
+                ".text",
+                ".rdata",
+                ".data",
+                ".idata",
+                ".tls",
+                ".gfids",
+                ".00cfg",
+                ".rsrc",
             ]
         )
         assert ld.main_object.segments is ld.main_object.sections

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -139,6 +139,31 @@ class TestPEBackend(unittest.TestCase):
         ld = cle.Loader(exe, auto_load_libs=False, main_opts={"debug_symbols": pdb})
         assert ld.find_symbol("authenticate")
 
+    def test_long_section_names(self):
+        exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "simple_crackme_x64.exe")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        section_names = [section.name for section in ld.main_object.sections]
+
+        # Assert no string table references remain
+        assert not any(name.startswith("/") for name in section_names)
+
+        debug_section_names = [
+            ".debug_aranges",
+            ".debug_info",
+            ".debug_abbrev",
+            ".debug_line",
+            ".debug_frame",
+            ".debug_str",
+            ".debug_loc",
+            ".debug_ranges",
+        ]
+        assert section_names[-len(debug_section_names) :] == debug_section_names
+
+    def test_coff_symbol_loaded(self):
+        exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "simple_crackme_x64.exe")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        assert ld.find_symbol("main")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Support some unconventional things done by mingw32:
* Long section names given in string table
* Symbols via COFF header

todo:
- [x] Test case
