### PR TITLE
_parse_exports: fix for empty export_blob

### DIFF
--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -485,7 +485,7 @@ class MachO(Backend):
         """
         log.debug("Parsing exports")
         blob = self.export_blob
-        if blob is None:
+        if blob is None or len(blob) == 0:
             log.debug("Parsing exports done: No exports found")
             return
 


### PR DESCRIPTION
Rare binaries have an _empty_ export blob, this fixes the crash that would otherwise occur when trying to read the data