### PR TITLE
MetaELF: Catch KeyErrors when creating blocks in load_plt.

### DIFF
--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -386,7 +386,12 @@ class MetaELF(Backend):
                     addr = AT.from_rva(self._plt[name], self).to_lva()
 
             if addr is not None:
-                b0 = self._block(addr, skip_stmts=True)
+                try:
+                    b0 = self._block(addr, skip_stmts=True)
+                except KeyError:
+                    # the address does not exist; maybe it's not in the current binary?
+                    log.warning("Failed to create a block at address %#x; the address does not exist.", addr)
+                    continue
                 stub_size = b0.size
                 if isinstance(b0.next, pyvex.expr.Const) and b0.next.con.value == addr + b0.size:
                     b1 = self._block(addr + b0.size, skip_stmts=True)


### PR DESCRIPTION
The exception backtrace that it fixes:

```
Exception while running job "Loading file":
Traceback (most recent call last):
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\angrmanagement\logic\jobmanager.py", line 86, in run
    result = job.run(ctx)
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\angrmanagement\data\jobs\loading.py", line 81, in run
    partial_ld = cle.Loader(
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\cle\loader.py", line 185, in __init__
    self.initial_load_objects = self._internal_load(
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\cle\loader.py", line 795, in _internal_load
    obj = self._load_object_isolated(main_spec)
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\cle\loader.py", line 1007, in _load_object_isolated
    result = backend_cls(binary, binary_stream, is_main_bin=self._main_object is None, loader=self, **options)
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\cle\backends\elf\elf.py", line 232, in __init__
    self._load_plt()
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\cle\backends\elf\metaelf.py", line 389, in _load_plt
    b0 = self._block(addr, skip_stmts=True)
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\cle\backends\elf\metaelf.py", line 81, in _block
    dat = self._block_bytes(realaddr, 40)
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\cle\backends\elf\metaelf.py", line 85, in _block_bytes
    return self.memory.load(AT.from_lva(addr, self).to_rva(), size)
  File "C:\Users\admin\AppData\Local\Programs\Python\Python310\lib\site-packages\cle\memory.py", line 412, in load
    raise KeyError(addr)
KeyError: 5879504
```