### PR TITLE
Add support for `DT_RELR` dynamic relocations in ELF loader

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -19,7 +19,7 @@ from elftools.dwarf.dwarf_expr import DWARFExprParser
 from elftools.dwarf.dwarfinfo import DWARFInfo
 from elftools.dwarf.ranges import BaseAddressEntry, RangeEntry
 from elftools.elf import dynamic, elffile, enums, sections
-from elftools.elf.relocation import RelocationSection
+from elftools.elf.relocation import RelocationSection, RelrRelocationSection
 from sortedcontainers import SortedDict
 
 from cle.address_translator import AT
@@ -35,7 +35,7 @@ from .lsda import LSDAExceptionTable
 from .metaelf import MetaELF, maybedecode
 from .regions import ELFSection, ELFSegment
 from .relocation import get_relocation
-from .relocation.generic import MipsGlobalReloc, MipsLocalReloc
+from .relocation.generic import MipsGlobalReloc, MipsLocalReloc, GenericRelativeReloc
 from .subprogram import LexicalBlock, Subprogram
 from .symbol import ELFSymbol, Symbol, SymbolType
 from .variable import Variable
@@ -561,9 +561,13 @@ class ELF(MetaELF):
 
         self.memory.add_backer(AT.from_lva(mapstart, self).to_rva(), data, overwrite=True)
 
-    def _make_reloc(self, readelf_reloc, symbol, dest_section: ELFSection | None = None):
+    def _make_reloc(self, readelf_reloc, symbol, dest_section: ELFSection | None = None, is_relr: bool = False):
         addend = readelf_reloc.entry.r_addend if readelf_reloc.is_RELA() else None
-        RelocClass = get_relocation(self.arch.name, readelf_reloc.entry.r_info_type)
+        # RELR relocations are compressed forms of R_*_RELATIVE relocations.
+        # If is_relr is True, the readelf_reloc.entry object does not have r_info_type,
+        # so we cannot dispatch through get_relocation. Instead, handle it as a special
+        # case by always using GenericRelativeReloc.
+        RelocClass = GenericRelativeReloc if is_relr else get_relocation(self.arch.name, readelf_reloc.entry.r_info_type)
         if RelocClass is None:
             return None
 
@@ -1126,6 +1130,27 @@ class ELF(MetaELF):
                 readelf_jmprelsec.elffile = None
                 self.__register_relocs(readelf_jmprelsec, dynsym, force_jmprel=True)
 
+            # try to parse relocations out of a table of type DT_RELR
+            if "DT_RELR" in self._dynamic:
+                reloffset = AT.from_lva(self._dynamic["DT_RELR"], self).to_rva()
+                if "DT_RELRSZ" not in self._dynamic:
+                    raise CLEInvalidBinaryError("Dynamic section contains DT_RELR but not DT_RELRSZ")
+                relsz = self._dynamic["DT_RELRSZ"]
+                fakerelheader = {
+                    "sh_offset": reloffset,
+                    "sh_type": "SHT_" + "RELR",
+                    "sh_entsize": self._reader.structs.Elf_Relr.sizeof(),
+                    "sh_size": relsz,
+                    "sh_flags": 0,
+                    "sh_addralign": 0,
+                }
+                readelf_relrsec = RelrRelocationSection(fakerelheader, "relr_cle", self._reader)
+                # support multiple versions of pyelftools
+                readelf_relrsec.stream = self.memory
+                readelf_relrsec._stream = self.memory
+                readelf_relrsec.elffile = None
+                self.__register_relocs(readelf_relrsec, dynsym)
+
             self.__register_section_symbols(dynsym)
 
     def __parse_rpath(self, runpath, rpath):
@@ -1183,9 +1208,17 @@ class ELF(MetaELF):
             symtab = self._reader.get_section_by_name(".symtab")
         relocs = []
         for readelf_reloc in section.iter_relocations():
+            # Handle packed RELR relocations specially
+            # These entries lack r_info_sym/r_info_type, so this branch must be
+            # exclusive — do NOT fall through into later cases.
+            if section.header.get("sh_type") == "SHT_RELR":
+                reloc = self._make_reloc(readelf_reloc, self._nullsymbol, dest_sec, True)
+                if reloc is not None:
+                    relocs.append(reloc)
+                    self.relocs.append(reloc)
             # MIPS64 is just plain old fucked up
             # https://www.sourceware.org/ml/libc-alpha/2003-03/msg00153.html
-            if self.arch.name == "MIPS64":
+            elif self.arch.name == "MIPS64":
                 if not hasattr(readelf_reloc.entry, "r_info_type2") and hasattr(readelf_reloc.entry, "r_info_type3"):
                     raise CLECompatibilityError(
                         "This code relies on `pyelftools` features that are not available on versions 0.26 and below."
@@ -1320,8 +1353,8 @@ class ELF(MetaELF):
         for sec_readelf, section in sec_list:
             if isinstance(sec_readelf, sections.SymbolTableSection):
                 self.__register_section_symbols(sec_readelf)
-            if isinstance(sec_readelf, RelocationSection) and not (
-                "DT_REL" in self._dynamic or "DT_RELA" in self._dynamic or "DT_JMPREL" in self._dynamic
+            if isinstance(sec_readelf, (RelocationSection, RelrRelocationSection)) and not (
+                "DT_REL" in self._dynamic or "DT_RELA" in self._dynamic or "DT_JMPREL" in self._dynamic or "DT_RELR" in self._dynamic
             ):
                 self.__register_relocs(sec_readelf, dynsym=None)
 


### PR DESCRIPTION
This enables correct loading of ELF binaries using RELR tables, improving compatibility with modern glibc binaries.