### PR TITLE
A minor fix of logging message for MachO

### DIFF
--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -325,8 +325,7 @@ class MachO(Backend):
                 pass
             else:
                 try:
-                    command_name = LC(cmd)
-                    log.warning("%s is not handled yet", str(command_name))
+                    log.warning("%s is not handled yet", LC(cmd).name)
                 except ValueError:
                     log.error("Command %s is not recognized!", hex(cmd))
             # update bookkeeping


### PR DESCRIPTION
A really tiny fix, but as the logging level is set to `WARNING`, a user would see this often

Before: 
```
WARNING  | 2025-08-28 02:42:50,703 | cle.backends.macho.macho | The Mach-O backend is not well-supported. Good luck!
WARNING  | 2025-08-28 02:42:52,060 | cle.backends.macho.macho | 14 is not handled yet
WARNING  | 2025-08-28 02:42:52,714 | cle.backends.macho.macho | 27 is not handled yet
WARNING  | 2025-08-28 02:42:53,088 | cle.backends.macho.macho | 42 is not handled yet
WARNING  | 2025-08-28 02:42:53,253 | cle.backends.macho.macho | 29 is not handled yet
```

After:
```
WARNING  | 2025-08-28 02:35:28,319 | cle.backends.macho.macho | The Mach-O backend is not well-supported. Good luck!
WARNING  | 2025-08-28 02:36:21,170 | cle.backends.macho.macho | LC_LOAD_DYLINKER is not handled yet
WARNING  | 2025-08-28 02:36:22,134 | cle.backends.macho.macho | LC_UUID is not handled yet
WARNING  | 2025-08-28 02:36:22,717 | cle.backends.macho.macho | LC_SOURCE_VERSION is not handled yet
WARNING  | 2025-08-28 02:36:22,891 | cle.backends.macho.macho | LC_CODE_SIGNATURE is not handled yet
```

