### PR TITLE
Fix section relative relocations

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -188,10 +188,10 @@ class ELF(MetaELF):
         except ValueError:
             log.info("no PT_LOAD segments identified")
 
-        if not discard_program_headers:
-            self.__register_segments()
         if not discard_section_headers:
             self.__register_sections()
+        if not discard_program_headers:
+            self.__register_segments()
 
         if not self.symbols:
             self._desperate_for_symbols = True

--- a/cle/backends/elf/symbol.py
+++ b/cle/backends/elf/symbol.py
@@ -44,6 +44,12 @@ class ELFSymbol(Symbol):
         if owner.is_relocatable and isinstance(sec_ndx, int):
             value += owner.sections[sec_ndx].remap_offset
 
+        # A symbol of type STT_SECTION is relative to its section
+        if self.subtype == ELFSymbolType.STT_SECTION:
+            section_address = owner.sections[sec_ndx].vaddr
+            section_offset_from_base = AT.from_lva(section_address, owner).to_rva()
+            value -= section_offset_from_base
+
         super().__init__(
             owner, maybedecode(symb.name), AT.from_lva(value, owner).to_rva(), symb.entry.st_size, self.type
         )


### PR DESCRIPTION
A symbol of type `STT_SECTION` is relative to its section's base address (according to `man elf`). 
Therefore, it should also be relocated according to the section's base.