### PR TITLE
Remove reference to nonexistant dependencies from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "archinfo==9.2.176.dev0",
+    "archinfo==9.2.175",
     "cart",
     "pefile",
     "pyelftools>=0.29",
-    "pyvex==9.2.176.dev0",
+    "pyvex==9.2.175",
     "sortedcontainers>=2.0",
 ]
 


### PR DESCRIPTION
The version `9.2.176.dev0` for the dependencies pyvex and archinfo were automatically updated into the `pyproject.toml` file of this repository, but appear to have been later deleted from the artifactory:

https://pypi.org/project/archinfo/#history

https://pypi.org/project/pyvex/#history

This made it impossible to run e.g. `uv sync` from the master of this repo, because the dependencies were not found.