### PR TITLE
Fix x64 TLS callback parser and add corresponding unit test

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -397,11 +397,15 @@ class PE(Backend):
         callbacks = []
 
         callback_rva = AT.from_lva(addr, self).to_rva()
-        callback = self._pe.get_dword_at_rva(callback_rva)
+        is_64bit = self.arch.bits == 64
+        ptr_size = 8 if is_64bit else 4
+        get_ptr = self._pe.get_qword_at_rva if is_64bit else self._pe.get_dword_at_rva
+
+        callback = get_ptr(callback_rva)
         while callback != 0 and callback is not None:
             callbacks.append(callback)
-            callback_rva += 4
-            callback = self._pe.get_dword_at_rva(callback_rva)
+            callback_rva += ptr_size
+            callback = get_ptr(callback_rva)
 
         return callbacks
 

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -128,6 +128,17 @@ class TestPEBackend(unittest.TestCase):
         assert len(ld.tls.modules) == 1
         assert tls.get_tls_data_addr(0) == tls.memory.unpack_word(0)
 
+    def test_tls_x64(self):
+        exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "TLS.exe")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        tls = ld.tls.new_thread()
+
+        assert ld.main_object.tls_used
+        assert ld.main_object.tls_callbacks == [0x140001000]
+
+        assert tls is not None
+        assert len(ld.tls.modules) == 1
+
     def test_pdb(self):
         exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.exe")
         pdb = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.pdb")


### PR DESCRIPTION
- Added x64 version of TLS.exe in the binaries repo
- Added unit test for 64-Bit tls callback address parsing
- Modified _register_tls_callbacks to change ptr size and get function based on architecture

Resolves #648 