### PR TITLE
Allow Mach-O relocations to be skipped

### DIFF
--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -99,6 +99,7 @@ class MachO(Backend):
     sizeofcmds: int
 
     def __init__(self, *args, **kwargs):
+        skip_relocations = kwargs.pop("skip_relocations", False)
         super().__init__(*args, **kwargs)
         self.symbols = SymbolList(key=self._get_symbol_relative_addr)
 
@@ -240,12 +241,13 @@ class MachO(Backend):
         log.info("Parsing module init/term function pointers")
         self._parse_mod_funcs()
 
-        if self._dyld_chained_fixups_offset:
-            log.info("Parsing dyld bound symbols and fixup chains (ios15 and above)")
-            self._parse_dyld_chained_fixups()
-        else:
-            log.info("Parsing binding bytecode stream")
-            self.do_binding()
+        if not skip_relocations:
+            if self._dyld_chained_fixups_offset:
+                log.info("Parsing dyld bound symbols and fixup chains (ios15 and above)")
+                self._parse_dyld_chained_fixups()
+            else:
+                log.info("Parsing binding bytecode stream")
+                self.do_binding()
 
         self._load_stubs()
 


### PR DESCRIPTION
The computation of Mach-O relocs can be a slow and in rare cases it can make sense to skip them. I originally implemented this to speed up the analysis for [this paper](https://sure-workshop.org/accepted-papers/2025/sure25-4.pdf)