### PR TITLE
PE: Truncate PE image if extra data exist at the end.

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -138,7 +138,14 @@ class PE(Backend):
 
         self.linking = "dynamic" if self.deps else "static"
         self.jmprel = self._get_jmprel()
-        self.memory.add_backer(0, self._pe.get_memory_mapped_image(max_virtual_address=0x100000000))
+        mapped_image = self._pe.get_memory_mapped_image(max_virtual_address=0x100000000)
+        if self.max_addr - self.min_addr < len(mapped_image):
+            # we are loading more bytes than max_addr would allow (there is data at the end of the file that is not
+            # covered by any sections), so we need to truncate mapped_image.
+            # this is actually caused by PE.get_memory_mapped_image() not passing ignore_padding=True to
+            # section.get_data().
+            mapped_image = mapped_image[: self.max_addr - self.min_addr]
+        self.memory.add_backer(0, mapped_image)
 
         if debug_symbols or self.loader._load_debug_info:
             pdb_path = debug_symbols or self._find_pdb_path()

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -258,6 +258,18 @@ class TestPEBackend(unittest.TestCase):
             )
             assert ld.find_symbol("authenticate")
 
+    def test_load_binary_larger_than_highest_address(self):
+        # https://github.com/angr/angr/issues/6209
+        exe = os.path.join(
+            TEST_BASE, "tests", "i386", "windows", "aa893de523f58ee14972b94fef7ecdbb930cbdc700d8be097eb8a6de2549ce73"
+        )
+        ld = cle.Loader(exe, auto_load_libs=False)
+
+        assert len(ld.all_objects) == 2
+        assert ld.main_object.min_addr == 0x400000
+        assert ld.main_object.max_addr == 0x44F02D
+        assert ld.all_objects[1].min_addr == 0x500000
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Close angr/angr#6209.