### PR TITLE
Universal2 Backend: Use Archinfo.Arch.name for CPU Type Name

### DIFF
--- a/cle/backends/universal2.py
+++ b/cle/backends/universal2.py
@@ -20,10 +20,10 @@ FAT_CIGAM_64 = 0xBFBAFECA
 
 # Mach-O CPU type constants (from mach/machine.h)
 CPU_TYPE_NAMES = {
-    0x100000C: "aarch64",
-    0xC: "arm",
-    0x7: "x86",
-    0x1000007: "x64",
+    0x100000C: archinfo.ArchAArch64.name,
+    0xC: archinfo.ArchARM.name,
+    0x7: archinfo.ArchX86.name,
+    0x1000007: archinfo.ArchAMD64.name,
 }
 
 # Mapping from Mach-O cputype to archinfo ident strings (same as MachO._detect_arch_ident)

--- a/tests/test_universal2.py
+++ b/tests/test_universal2.py
@@ -89,8 +89,8 @@ def test_universal2_available_arches():
 
     archs = main.available_arches
     assert len(archs) == 2
-    assert "x64" in archs
-    assert "aarch64" in archs
+    assert "AMD64" in archs
+    assert "AARCH64" in archs
 
     # available_arches should reflect the full header even when a single arch is loaded
     ld = cle.Loader(FATBIN, auto_load_libs=False, main_opts={"arch": archinfo.ArchAMD64()})
@@ -105,5 +105,5 @@ def test_universal2_child_names():
     main = ld.main_object
 
     names = {child.binary_basename for child in main.child_objects}
-    assert any("[x64]" in n for n in names)
-    assert any("[aarch64]" in n for n in names)
+    assert any("[AMD64]" in n for n in names)
+    assert any("[AARCH64]" in n for n in names)


### PR DESCRIPTION
Allows better compatibility with other backends.