### PR TITLE
amd64 relocation and tls correctness

### DIFF
--- a/cle/backends/elf/relocation/amd64.py
+++ b/cle/backends/elf/relocation/amd64.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from .generic import (
     GenericAbsoluteAddendReloc,
+    GenericAbsoluteReloc,
     GenericCopyReloc,
     GenericIRelativeReloc,
-    GenericJumpslotReloc,
     GenericPCRelativeAddendReloc,
     GenericRelativeReloc,
     GenericTLSDoffsetReloc,
@@ -36,11 +36,11 @@ class R_X86_64_IRELATIVE(GenericIRelativeReloc):
     pass
 
 
-class R_X86_64_GLOB_DAT(GenericJumpslotReloc):
+class R_X86_64_GLOB_DAT(GenericAbsoluteReloc):
     pass
 
 
-class R_X86_64_JUMP_SLOT(GenericJumpslotReloc):
+class R_X86_64_JUMP_SLOT(GenericAbsoluteReloc):
     pass
 
 

--- a/cle/backends/tls/tls_object.py
+++ b/cle/backends/tls/tls_object.py
@@ -38,9 +38,11 @@ class ThreadManager:
         if obj.tls_data_start < 0:
             log.warning("The provided object has a negative tls_data_start. Skip TLS loading.")
             return None
-        if obj.tls_data_size <= 0:
+        if obj.tls_data_size < 0:
             log.warning("The provided object has an invalid tls_data_size. Skip TLS loading.")
             return None
+        if obj.tls_data_size == 0:
+            return b"".ljust(obj.tls_block_size, b"\0")
         return obj.memory.load(obj.tls_data_start, obj.tls_data_size).ljust(obj.tls_block_size, b"\0")
 
     def new_thread(self, insert=True):

--- a/tests/test_amd64_relocations.py
+++ b/tests/test_amd64_relocations.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import os
+
+import cle
+from cle.backends.elf.relocation.amd64 import R_X86_64_GLOB_DAT, R_X86_64_JUMP_SLOT
+
+
+def test_amd64_jumpslot_globdat_ignore_addend():
+    """R_X86_64_JUMP_SLOT and R_X86_64_GLOB_DAT calculation is S only.
+
+    Per the AMD64 ABI (psABI), these relocations resolve to ``S``; the addend
+    field is unused. glibc's static linker, however, emits non-zero addends on
+    JUMP_SLOT entries pointing at the lazy PLT trampoline (the value the GOT
+    slot holds before the runtime resolver patches it). CLE used to compute
+    ``S + A``, which produced the pre-resolution stub address rather than the
+    resolved symbol address. Anything that loaded a glibc-built ``libc.so.6``
+    and then read the GOT (e.g. concrete-execution engines that skip the
+    runtime linker) would jump to garbage.
+    """
+    test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests"))
+    libc = os.path.join(test_location, "x86_64", "libc.so.6")
+    ld = cle.Loader(libc, auto_load_libs=False, main_opts={"base_addr": 0})
+
+    js = next(r for r in ld.main_object.relocs if isinstance(r, R_X86_64_JUMP_SLOT) and r.resolvedby is not None)
+    gd = next(r for r in ld.main_object.relocs if isinstance(r, R_X86_64_GLOB_DAT) and r.resolvedby is not None)
+
+    for r in (js, gd):
+        # Force a non-zero addend simulating a glibc-style lazy-stub offset.
+        r.is_rela = True
+        r._addend = 0x12345
+        assert r.value == r.resolvedby.rebased_addr
+
+
+if __name__ == "__main__":
+    test_amd64_jumpslot_globdat_ignore_addend()


### PR DESCRIPTION
R_X86_64_JUMP_SLOT was being calculated wrong as S + A instead of S

ThreadManager.initialization_image rejected tls_data_size == 0 as invalid and returned None but it should return a zerobuffer of tls_block_size instead