### PR TITLE
Backend: Compute md5/sha256 lazily on first access.

### DIFF
--- a/cle/backends/backend.py
+++ b/cle/backends/backend.py
@@ -214,9 +214,9 @@ class Backend:
         # loader will pick it up
         self.force_main_object = None
 
-        # checksums
-        self.md5 = None
-        self.sha256 = None
+        # Lazy checksums — computed on first access via the `md5` / `sha256` properties.
+        self._md5: bytes | None = None
+        self._sha256: bytes | None = None
 
         self.mapped_base_symbolic = 0
         # These are set by cle, and should not be overriden manually
@@ -284,7 +284,28 @@ class Backend:
             raise CLEError(f"Bad parameter: arch={arch}")
 
         self._cache_content()
-        self._checksum()
+
+    @property
+    def md5(self) -> bytes | None:
+        """MD5 digest of the binary, computed lazily on first access."""
+        if self._md5 is None:
+            self._md5 = self._compute_digest(hashlib.md5)
+        return self._md5
+
+    @property
+    def sha256(self) -> bytes | None:
+        """SHA-256 digest of the binary, computed lazily on first access."""
+        if self._sha256 is None:
+            self._sha256 = self._compute_digest(hashlib.sha256)
+        return self._sha256
+
+    def _compute_digest(self, hasher) -> bytes | None:
+        if self._binary_stream is None:
+            return None
+        self._binary_stream.seek(0)
+        data = self._binary_stream.read()
+        self._binary_stream.seek(0)
+        return hasher(data).digest()
 
     @property
     def arch(self) -> archinfo.Arch:
@@ -585,18 +606,6 @@ class Backend:
             data = self._binary_stream.read()
             self._binary_stream.seek(0)
             self.cached_content = data
-
-    def _checksum(self):
-        """
-        Calculate MD5 and SHA256 checksum for the binary.
-        """
-
-        if self._binary_stream is not None:
-            self._binary_stream.seek(0)
-            data = self._binary_stream.read()
-            self._binary_stream.seek(0)
-            self.md5 = hashlib.md5(data).digest()
-            self.sha256 = hashlib.sha256(data).digest()
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/cle/backends/blob.py
+++ b/cle/backends/blob.py
@@ -68,9 +68,9 @@ class Blob(Backend):
         for file_offset, mem_addr, size in segments:
             self._load(file_offset, mem_addr, size)
 
-    @staticmethod
-    def is_compatible(stream):
-        return stream == 0  # I hate pylint
+    @classmethod
+    def is_compatible(cls, stream):  # pylint: disable=unused-argument
+        return False
 
     @property
     def min_addr(self):

--- a/cle/backends/blob.py
+++ b/cle/backends/blob.py
@@ -116,8 +116,5 @@ class Blob(Backend):
     def _cache_content(self):
         return
 
-    def _checksum(self):
-        return
-
 
 register_backend("blob", Blob)


### PR DESCRIPTION
## Summary

- Previously every loaded object hashed its entire binary twice during `__init__`, which is noticeable on large files (~1s for a 280MB binary).
- `md5` / `sha256` are kept as public attributes for downstream consumers (e.g. angr management), but are now `@property`-backed: they only compute on first access, then memoize.
- Also fixes a pre-existing `Blob.is_compatible` signature that mismatched the `Backend` base (`@staticmethod` vs `@classmethod`); this is required to keep the typecheck badness-ratio CI green.


🤖 Generated with [Claude Code](https://claude.com/claude-code)