### PR TITLE
Set explicit ctypes _layout_ in coff.py for Python 3.14

### DIFF
--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -36,6 +36,7 @@ class CoffFileHeader(ctypes.LittleEndianStructure):
     """
 
     _pack_ = 1
+    _layout_ = "ms"
     _fields_ = [
         ("Machine", ctypes.c_uint16),
         ("NumberOfSections", ctypes.c_uint16),
@@ -64,6 +65,7 @@ class CoffSectionTableEntry(ctypes.LittleEndianStructure):
     """
 
     _pack_ = 1
+    _layout_ = "ms"
     _fields_ = [
         ("Name", ctypes.c_uint8 * 8),
         ("VirtualSize", ctypes.c_uint32),
@@ -95,6 +97,7 @@ class CoffSymbolTableEntry(ctypes.LittleEndianStructure):
     """
 
     _pack_ = 1
+    _layout_ = "ms"
     _fields_ = [
         ("Name", ctypes.c_uint8 * 8),
         ("Value", ctypes.c_uint32),
@@ -135,6 +138,7 @@ class CoffRelocationTableEntry(ctypes.LittleEndianStructure):
     """
 
     _pack_ = 1
+    _layout_ = "ms"
     _fields_ = [
         ("VirtualAddress", ctypes.c_uint32),
         ("SymbolTableIndex", ctypes.c_uint32),


### PR DESCRIPTION
## Summary

Python 3.14 deprecates the implicit memory layout for `ctypes` `Structure`s that set `_pack_`, requiring an explicit `_layout_`. The implicit default is slated to become an error in Python 3.19.

This produced:

```
DeprecationWarning: Due to '_pack_', the 'CoffFileHeader' Structure will use memory layout
compatible with MSVC (Windows). If this is intended, set _layout_ to 'ms'. The implicit
default is deprecated and slated to become an error in Python 3.19.
```

COFF is a Windows/MSVC format, and the implicit default has always been the MSVC layout, so this sets `_layout_ = "ms"` on the four affected structures (`CoffFileHeader`, `CoffSectionTableEntry`, `CoffSymbolTableEntry`, `CoffRelocationTableEntry`) to preserve behavior and silence the warning.

## Compatibility

`_layout_` is ignored as an unknown class attribute on Python 3.12/3.13, so the change is a no-op on older supported versions (`requires-python = ">=3.12"`).

## Verification

Importing the module with `DeprecationWarning` promoted to an error no longer warns, and packed struct sizes are unchanged (20-byte header, 10-byte relocation entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)