### PR TITLE
Unvendor uefi-firmware and pin it to ~1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: cle
-          submodules: recursive
       - uses: actions/checkout@v6
         with:
           repository: angr/binaries

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/uefi-firmware"]
-	path = deps/uefi-firmware
-	url = https://github.com/theopolis/uefi-firmware-parser.git

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,6 @@
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 version: 2
-submodules:
-  include: all
-  recursive: true
 sphinx:
   configuration: docs/conf.py
 formats: [pdf]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pyxbe~=1.0.3",
     "pyxdia~=0.1",
     "sortedcontainers>=2.0",
+    "uefi-firmware>=1.10",
 ]
 
 [project.readme]
@@ -59,29 +60,6 @@ testing = [
 
 [tool.setuptools]
 include-package-data = true
-
-[tool.setuptools.packages.find]
-where = [".", "deps/uefi-firmware"]
-include = ["cle*", "uefi_firmware*"]
-
-[[tool.setuptools.ext-modules]]
-name = "uefi_firmware.efi_compressor"
-include-dirs = ["deps/uefi-firmware/uefi_firmware/compression/Include"]
-sources = [
-    "deps/uefi-firmware/uefi_firmware/compression/EfiCompressor.c",
-    "deps/uefi-firmware/uefi_firmware/compression/LZMA/LzmaCompress.c",
-    "deps/uefi-firmware/uefi_firmware/compression/LZMA/LzmaDecompress.c",
-    "deps/uefi-firmware/uefi_firmware/compression/LZMA/SDK/C/Bra.c",
-    "deps/uefi-firmware/uefi_firmware/compression/LZMA/SDK/C/Bra86.c",
-    "deps/uefi-firmware/uefi_firmware/compression/LZMA/SDK/C/CpuArch.c",
-    "deps/uefi-firmware/uefi_firmware/compression/LZMA/SDK/C/LzFind.c",
-    "deps/uefi-firmware/uefi_firmware/compression/LZMA/SDK/C/LzmaDec.c",
-    "deps/uefi-firmware/uefi_firmware/compression/LZMA/SDK/C/LzmaEnc.c",
-    "deps/uefi-firmware/uefi_firmware/compression/Tiano/Decompress.c",
-    "deps/uefi-firmware/uefi_firmware/compression/Tiano/EfiCompress.c",
-    "deps/uefi-firmware/uefi_firmware/compression/Tiano/TianoCompress.c",
-]
-py-limited-api=true
 
 [tool.setuptools.dynamic]
 version = { attr = "cle.__version__" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "pyxbe~=1.0.3",
     "pyxdia~=0.1",
     "sortedcontainers>=2.0",
-    "uefi-firmware>=1.10",
+    "uefi-firmware~=1.16",
 ]
 
 [project.readme]

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -7,10 +7,8 @@ import cffi
 import cle
 
 
-def disabled_test_cclemory():  # pylint: disable=no-member
+def test_cclemory():  # pylint: disable=no-member
     # This is a test case for C-backed Clemory.
-    # Fish disabled this test case until the bug in py-cffi is fixed:
-    # https://github.com/python-cffi/cffi/issues/246
 
     clemory = cle.Clemory(None, root=True)
     clemory.add_backer(0, b"\x90" * 1000)


### PR DESCRIPTION
A new release with vulnerability fixes has been published on PyPI for uefi-firmware, so we unvendor this package.