### PR TITLE
Make native-only loaders optional on Emscripten

### DIFF
--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -20,9 +20,13 @@ from .srec import SRec
 from .static_archive import StaticArchive
 from .symbol import Symbol, SymbolSubType, SymbolType
 from .te import TE
-from .uefi_firmware import UefiFirmware
 from .universal2 import Universal2
 from .xbe import XBE
+
+try:
+    from .uefi_firmware import UefiFirmware
+except ImportError:
+    UefiFirmware = None
 
 # BinjaBin is not imported by default since importing it is too slow
 # you may manually import it by running `from cle.backends.binja import BinjaBin`
@@ -60,8 +64,10 @@ __all__ = [
     "Symbol",
     "SymbolType",
     "SymbolSubType",
-    "UefiFirmware",
     "TE",
     "Universal2",
     "CARTFile",
 ]
+
+if UefiFirmware is not None:
+    __all__.append("UefiFirmware")

--- a/cle/backends/__init__.py
+++ b/cle/backends/__init__.py
@@ -20,13 +20,9 @@ from .srec import SRec
 from .static_archive import StaticArchive
 from .symbol import Symbol, SymbolSubType, SymbolType
 from .te import TE
+from .uefi_firmware import UefiFirmware
 from .universal2 import Universal2
 from .xbe import XBE
-
-try:
-    from .uefi_firmware import UefiFirmware
-except ImportError:
-    UefiFirmware = None
 
 # BinjaBin is not imported by default since importing it is too slow
 # you may manually import it by running `from cle.backends.binja import BinjaBin`
@@ -64,10 +60,8 @@ __all__ = [
     "Symbol",
     "SymbolType",
     "SymbolSubType",
+    "UefiFirmware",
     "TE",
     "Universal2",
     "CARTFile",
 ]
-
-if UefiFirmware is not None:
-    __all__.append("UefiFirmware")

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -9,7 +9,11 @@ from collections.abc import Callable
 
 import archinfo
 import pefile
-import pyxdia
+
+try:
+    import pyxdia
+except ImportError:
+    pyxdia = None
 
 from cle.address_translator import AT
 from cle.backends.backend import Backend, FunctionHint, FunctionHintSource, register_backend
@@ -215,6 +219,10 @@ class PE(Backend):
         """
         Load available symbols from PDB at `pdb_path`
         """
+        if pyxdia is None:
+            log.warning("PDB support is unavailable because pyxdia is not installed")
+            return
+
         log.debug("Loading symbols from %s", pdb_path)
         try:
             pdb = pyxdia.PDB(pdb_path)

--- a/cle/backends/uefi_firmware.py
+++ b/cle/backends/uefi_firmware.py
@@ -106,7 +106,7 @@ class UefiFirmware(Backend):
 
     @singledispatchmethod
     def _load(self, uefi_obj):
-        raise CLEUnknownFormatError(f"Can't load firmware object: {uefi_obj}")
+        raise CLEUnknownFormatError(f"{type(self).__name__} can't load firmware object: {uefi_obj}")
 
     def _load_generic(self, uefi_obj):
         for obj in uefi_obj.objects:

--- a/cle/backends/uefi_firmware.py
+++ b/cle/backends/uefi_firmware.py
@@ -105,10 +105,11 @@ class UefiFirmware(Backend):
             self.loader._main_object = None
 
     @singledispatchmethod
-    def _load(self, uefi_obj):
-        raise CLEUnknownFormatError(f"{type(self).__name__} can't load firmware object: {uefi_obj}")
+    def _load(self, uefi_obj):  # pylint: disable=no-self-use
+        raise CLEUnknownFormatError(f"Can't load firmware object: {uefi_obj}")
 
-    def _load_generic(self, uefi_obj):
+    @_load.register
+    def _load_generic(self, uefi_obj: uefi_firmware.FirmwareObject):
         for obj in uefi_obj.objects:
             self._load(obj)
 
@@ -116,7 +117,8 @@ class UefiFirmware(Backend):
     def _load_none(self, uefi_obj: None):
         pass
 
-    def _load_firmwarefile(self, uefi_obj):
+    @_load.register
+    def _load_firmwarefile(self, uefi_obj: uefi_firmware.uefi.FirmwareFile):
         old_uuid = self._current_file
         if uefi_obj.type == 7:  # driver
             uuid = UUID(bytes=uefi_obj.guid)
@@ -125,7 +127,8 @@ class UefiFirmware(Backend):
         self._load_generic(uefi_obj)
         self._current_file = old_uuid
 
-    def _load_firmwarefilesection(self, uefi_obj):
+    @_load.register
+    def _load_firmwarefilesection(self, uefi_obj: uefi_firmware.uefi.FirmwareFileSystemSection):
         pending = self._drivers_pending.get(self._current_file, None)
         if pending is not None:
             if uefi_obj.type == 16:  # pe32 image
@@ -181,7 +184,7 @@ class UefiModuleMixin(Backend):
     def __repr__(self):
         return (
             f"<{type(self).__name__} Object "
-            f"{self.guid}{f' {self.user_interface_name}' if self.user_interface_name else ''}, "
+            f'{self.guid}{f" {self.user_interface_name}" if self.user_interface_name else ""}, '
             f"maps [{self.min_addr:#x}:{self.max_addr:#x}]>"
         )
 
@@ -198,10 +201,4 @@ class UefiTE(UefiModuleMixin, TE):
     """
 
 
-if uefi_firmware is not None:
-    # singledispatchmethod exposes register on the descriptor; pylint sees only the bound method here.
-    # pylint: disable=no-member
-    UefiFirmware._load.register(uefi_firmware.FirmwareObject)(UefiFirmware._load_generic)
-    UefiFirmware._load.register(uefi_firmware.uefi.FirmwareFile)(UefiFirmware._load_firmwarefile)
-    UefiFirmware._load.register(uefi_firmware.uefi.FirmwareFileSystemSection)(UefiFirmware._load_firmwarefilesection)
-    register_backend("uefi", UefiFirmware)
+register_backend("uefi", UefiFirmware)

--- a/cle/backends/uefi_firmware.py
+++ b/cle/backends/uefi_firmware.py
@@ -8,7 +8,11 @@ from functools import singledispatchmethod
 from uuid import UUID
 
 import archinfo
-import uefi_firmware
+
+try:
+    import uefi_firmware
+except ImportError:
+    uefi_firmware = None
 
 from cle.errors import CLEUnknownFormatError
 
@@ -50,11 +54,15 @@ class UefiFirmware(Backend):
 
     @classmethod
     def is_compatible(cls, stream):
+        if uefi_firmware is None:
+            return False
         buffer = cls._to_bytes(stream)
         parser = uefi_firmware.AutoParser(buffer)
         return parser.type() != "unknown"
 
     def __init__(self, *args, **kwargs) -> None:
+        if uefi_firmware is None:
+            raise ImportError("The UEFI backend requires the uefi-firmware package")
         super().__init__(*args, **kwargs)
 
         # hack: we are using a loader internal method in a non-kosher way which will cause our children to be
@@ -97,11 +105,10 @@ class UefiFirmware(Backend):
             self.loader._main_object = None
 
     @singledispatchmethod
-    def _load(self, uefi_obj):  # pylint: disable=no-self-use
+    def _load(self, uefi_obj):
         raise CLEUnknownFormatError(f"Can't load firmware object: {uefi_obj}")
 
-    @_load.register
-    def _load_generic(self, uefi_obj: uefi_firmware.FirmwareObject):
+    def _load_generic(self, uefi_obj):
         for obj in uefi_obj.objects:
             self._load(obj)
 
@@ -109,8 +116,7 @@ class UefiFirmware(Backend):
     def _load_none(self, uefi_obj: None):
         pass
 
-    @_load.register
-    def _load_firmwarefile(self, uefi_obj: uefi_firmware.uefi.FirmwareFile):
+    def _load_firmwarefile(self, uefi_obj):
         old_uuid = self._current_file
         if uefi_obj.type == 7:  # driver
             uuid = UUID(bytes=uefi_obj.guid)
@@ -119,8 +125,7 @@ class UefiFirmware(Backend):
         self._load_generic(uefi_obj)
         self._current_file = old_uuid
 
-    @_load.register
-    def _load_firmwarefilesection(self, uefi_obj: uefi_firmware.uefi.FirmwareFileSystemSection):
+    def _load_firmwarefilesection(self, uefi_obj):
         pending = self._drivers_pending.get(self._current_file, None)
         if pending is not None:
             if uefi_obj.type == 16:  # pe32 image
@@ -176,7 +181,7 @@ class UefiModuleMixin(Backend):
     def __repr__(self):
         return (
             f"<{type(self).__name__} Object "
-            f'{self.guid}{f" {self.user_interface_name}" if self.user_interface_name else ""}, '
+            f"{self.guid}{f' {self.user_interface_name}' if self.user_interface_name else ''}, "
             f"maps [{self.min_addr:#x}:{self.max_addr:#x}]>"
         )
 
@@ -193,4 +198,10 @@ class UefiTE(UefiModuleMixin, TE):
     """
 
 
-register_backend("uefi", UefiFirmware)
+if uefi_firmware is not None:
+    # singledispatchmethod exposes register on the descriptor; pylint sees only the bound method here.
+    # pylint: disable=no-member
+    UefiFirmware._load.register(uefi_firmware.FirmwareObject)(UefiFirmware._load_generic)
+    UefiFirmware._load.register(uefi_firmware.uefi.FirmwareFile)(UefiFirmware._load_firmwarefile)
+    UefiFirmware._load.register(uefi_firmware.uefi.FirmwareFileSystemSection)(UefiFirmware._load_firmwarefilesection)
+    register_backend("uefi", UefiFirmware)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ dependencies = [
     "pyelftools>=0.29",
     "pyvex==9.3.1.dev0",
     "pyxbe~=1.0.3",
-    "pyxdia~=0.1",
+    "pyxdia~=0.1; sys_platform != 'emscripten'",
     "sortedcontainers>=2.0",
-    "uefi-firmware~=1.16",
+    "uefi-firmware~=1.16; sys_platform != 'emscripten'",
 ]
 
 [project.readme]


### PR DESCRIPTION
## Summary

- exclude pyxdia and uefi-firmware from Emscripten dependency resolution
- make PE PDB support degrade cleanly when pyxdia is unavailable
- register the UEFI backend only when its native-only dependency is importable

The remaining CLE loaders, including ELF, stay available in the browser runtime.

## Validation

Loaded and analyzed the AMD64 fauxware ELF under Pyodide. Native PE and UEFI imports continue to work with their dependencies installed.