### PR TITLE
Guard optional UEFI dispatch registration

### DIFF
--- a/cle/backends/uefi_firmware.py
+++ b/cle/backends/uefi_firmware.py
@@ -4,7 +4,7 @@ import io
 import logging
 import mmap
 from dataclasses import dataclass
-from functools import singledispatchmethod
+from typing import cast
 from uuid import UUID
 
 import archinfo
@@ -104,42 +104,36 @@ class UefiFirmware(Backend):
         if self.loader._main_object is self:
             self.loader._main_object = None
 
-    @singledispatchmethod
-    def _load(self, uefi_obj):  # pylint: disable=no-self-use
-        raise CLEUnknownFormatError(f"Can't load firmware object: {uefi_obj}")
+    def _load(self, uefi_obj):
+        if uefi_obj is None:
+            return
+        if uefi_firmware is None:
+            raise ImportError("The UEFI backend requires the uefi-firmware package")
 
-    @_load.register
-    def _load_none(self, uefi_obj: None):
-        pass
-
-    if uefi_firmware is not None:
-
-        @_load.register
-        def _load_generic(self, uefi_obj: uefi_firmware.FirmwareObject):
-            for obj in uefi_obj.objects:
-                self._load(obj)
-
-        @_load.register
-        def _load_firmwarefile(self, uefi_obj: uefi_firmware.uefi.FirmwareFile):
-            old_uuid = self._current_file
+        is_firmware_file = isinstance(uefi_obj, uefi_firmware.uefi.FirmwareFile)
+        old_uuid = self._current_file
+        if is_firmware_file:
             if uefi_obj.type == 7:  # driver
                 uuid = UUID(bytes=uefi_obj.guid)
                 self._drivers_pending[uuid] = UefiModulePending()
                 self._current_file = uuid
-            self._load_generic(uefi_obj)
-            self._current_file = old_uuid
-
-        @_load.register
-        def _load_firmwarefilesection(self, uefi_obj: uefi_firmware.uefi.FirmwareFileSystemSection):
-            pending = self._drivers_pending.get(self._current_file, None)
+        elif isinstance(uefi_obj, uefi_firmware.uefi.FirmwareFileSystemSection):
+            pending = self._drivers_pending.get(self._current_file) if self._current_file is not None else None
             if pending is not None:
                 if uefi_obj.type == 16:  # pe32 image
-                    pending.pe_image = uefi_obj.content
+                    pending.pe_image = cast(bytes, uefi_obj.content)
                 elif uefi_obj.type == 18:  # te image
-                    pending.te_image = uefi_obj.content
+                    pending.te_image = cast(bytes, uefi_obj.content)
                 elif uefi_obj.type == 21:  # user interface name
-                    pending.name = uefi_obj.content.decode("utf-16").strip("\0")
-            self._load_generic(uefi_obj)
+                    pending.name = cast(bytes, uefi_obj.content).decode("utf-16").strip("\0")
+        elif not isinstance(uefi_obj, uefi_firmware.FirmwareObject):
+            raise CLEUnknownFormatError(f"Can't load firmware object: {uefi_obj}")
+
+        for obj in uefi_obj.objects:
+            self._load(obj)
+
+        if is_firmware_file:
+            self._current_file = old_uuid
 
 
 @dataclass
@@ -186,7 +180,7 @@ class UefiModuleMixin(Backend):
     def __repr__(self):
         return (
             f"<{type(self).__name__} Object "
-            f'{self.guid}{f" {self.user_interface_name}" if self.user_interface_name else ""}, '
+            f"{self.guid}{f' {self.user_interface_name}' if self.user_interface_name else ''}, "
             f"maps [{self.min_addr:#x}:{self.max_addr:#x}]>"
         )
 
@@ -203,5 +197,4 @@ class UefiTE(UefiModuleMixin, TE):
     """
 
 
-if uefi_firmware is not None:
-    register_backend("uefi", UefiFirmware)
+register_backend("uefi", UefiFirmware)

--- a/cle/backends/uefi_firmware.py
+++ b/cle/backends/uefi_firmware.py
@@ -109,35 +109,37 @@ class UefiFirmware(Backend):
         raise CLEUnknownFormatError(f"Can't load firmware object: {uefi_obj}")
 
     @_load.register
-    def _load_generic(self, uefi_obj: uefi_firmware.FirmwareObject):
-        for obj in uefi_obj.objects:
-            self._load(obj)
-
-    @_load.register
     def _load_none(self, uefi_obj: None):
         pass
 
-    @_load.register
-    def _load_firmwarefile(self, uefi_obj: uefi_firmware.uefi.FirmwareFile):
-        old_uuid = self._current_file
-        if uefi_obj.type == 7:  # driver
-            uuid = UUID(bytes=uefi_obj.guid)
-            self._drivers_pending[uuid] = UefiModulePending()
-            self._current_file = uuid
-        self._load_generic(uefi_obj)
-        self._current_file = old_uuid
+    if uefi_firmware is not None:
 
-    @_load.register
-    def _load_firmwarefilesection(self, uefi_obj: uefi_firmware.uefi.FirmwareFileSystemSection):
-        pending = self._drivers_pending.get(self._current_file, None)
-        if pending is not None:
-            if uefi_obj.type == 16:  # pe32 image
-                pending.pe_image = uefi_obj.content
-            elif uefi_obj.type == 18:  # te image
-                pending.te_image = uefi_obj.content
-            elif uefi_obj.type == 21:  # user interface name
-                pending.name = uefi_obj.content.decode("utf-16").strip("\0")
-        self._load_generic(uefi_obj)
+        @_load.register
+        def _load_generic(self, uefi_obj: uefi_firmware.FirmwareObject):
+            for obj in uefi_obj.objects:
+                self._load(obj)
+
+        @_load.register
+        def _load_firmwarefile(self, uefi_obj: uefi_firmware.uefi.FirmwareFile):
+            old_uuid = self._current_file
+            if uefi_obj.type == 7:  # driver
+                uuid = UUID(bytes=uefi_obj.guid)
+                self._drivers_pending[uuid] = UefiModulePending()
+                self._current_file = uuid
+            self._load_generic(uefi_obj)
+            self._current_file = old_uuid
+
+        @_load.register
+        def _load_firmwarefilesection(self, uefi_obj: uefi_firmware.uefi.FirmwareFileSystemSection):
+            pending = self._drivers_pending.get(self._current_file, None)
+            if pending is not None:
+                if uefi_obj.type == 16:  # pe32 image
+                    pending.pe_image = uefi_obj.content
+                elif uefi_obj.type == 18:  # te image
+                    pending.te_image = uefi_obj.content
+                elif uefi_obj.type == 21:  # user interface name
+                    pending.name = uefi_obj.content.decode("utf-16").strip("\0")
+            self._load_generic(uefi_obj)
 
 
 @dataclass
@@ -201,4 +203,5 @@ class UefiTE(UefiModuleMixin, TE):
     """
 
 
-register_backend("uefi", UefiFirmware)
+if uefi_firmware is not None:
+    register_backend("uefi", UefiFirmware)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ py_limited_api = "cp312"
 
 [tool.uv.sources]
 archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
-pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
+pyvex = { git = "https://github.com/angr/pyvex.git", branch = "wasm-host-support" }
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ py_limited_api = "cp312"
 
 [tool.uv.sources]
 archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
-pyvex = { git = "https://github.com/angr/pyvex.git", branch = "wasm-host-support" }
+pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
 
 [tool.black]
 line-length = 120

--- a/tests/test_optional_backends.py
+++ b/tests/test_optional_backends.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_import_without_uefi_firmware():
+    script = """
+import sys
+
+sys.modules["uefi_firmware"] = None
+
+import cle
+from cle.backends import ALL_BACKENDS
+
+assert "uefi" not in ALL_BACKENDS
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)

--- a/tests/test_optional_backends.py
+++ b/tests/test_optional_backends.py
@@ -13,6 +13,6 @@ sys.modules["uefi_firmware"] = None
 import cle
 from cle.backends import ALL_BACKENDS
 
-assert "uefi" not in ALL_BACKENDS
+assert "uefi" in ALL_BACKENDS
 """
     subprocess.run([sys.executable, "-c", script], check=True)


### PR DESCRIPTION
Follow-up to #702.

The merged cleanup registers singledispatch handlers whose annotations refer to uefi_firmware even when that optional dependency is unavailable. On Pyodide, importing CLE then fails while resolving those annotations.

This keeps the dependency-specific handlers and backend registration conditional, adds a subprocess regression test for importing without uefi_firmware, and selects the tandem PyVEX branch through tool.uv.sources.