### PR TITLE
Test CLE under Pyodide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,57 @@ jobs:
   ci:
     uses: angr/ci-settings/.github/workflows/angr-ci.yml@master
 
+  pyodide:
+    name: Test (Pyodide)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout CLE
+        uses: actions/checkout@v6
+        with:
+          path: workspace/cle
+      - name: Checkout archinfo
+        uses: actions/checkout@v6
+        with:
+          repository: angr/archinfo
+          path: workspace/archinfo
+      - name: Checkout PyVEX
+        uses: actions/checkout@v6
+        with:
+          repository: angr/pyvex
+          path: workspace/pyvex
+          submodules: recursive
+      - name: Checkout test binaries
+        uses: actions/checkout@v6
+        with:
+          repository: angr/binaries
+          path: workspace/binaries
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Build PyVEX for Pyodide
+        uses: pypa/cibuildwheel@v4.1.0
+        with:
+          package-dir: workspace/pyvex
+          output-dir: workspace/wheels
+        env:
+          CIBW_PLATFORM: pyodide
+          CIBW_PYODIDE_VERSION: "314.0.0"
+      - name: Build pure-Python wheels
+        run: |
+          uv build --wheel --out-dir workspace/wheels workspace/archinfo
+          uv build --wheel --out-dir workspace/wheels workspace/cle
+          uvx --from pip pip wheel --no-deps --wheel-dir workspace/wheels arpy==1.1.1
+      - name: Test CLE in Pyodide
+        env:
+          PYODIDE_XBUILDENV_PATH: ${{ github.workspace }}/workspace/.pyodide-xbuildenv
+        run: |
+          uvx --python 3.14 --from 'pyodide-build[resolve]' pyodide xbuildenv install 314.0.0 \
+            --path "$PYODIDE_XBUILDENV_PATH"
+          uvx --python 3.14 --from 'pyodide-build[resolve]' pyodide venv --clear workspace/venv
+          source workspace/venv/bin/activate
+          python -m pip install --force-reinstall workspace/wheels/*.whl pytest
+          cd workspace/cle
+          python -m pytest tests
+
   test:
     name: Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         env:
           CIBW_PLATFORM: pyodide
           CIBW_PYODIDE_VERSION: "314.0.0"
+          CIBW_TEST_COMMAND: pytest {package}/tests
       - name: Build pure-Python wheels
         run: |
           uv build --wheel --out-dir workspace/wheels workspace/archinfo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Sync Pyodide dependencies
         working-directory: workspace/cle
         run: |
-          uv sync --python pyodide@3.14 --group pyodide-testing --no-install-package pyvex \
+          uv sync --python pyodide@3.14 --group pyodide-testing --find-links ../wheels \
+            --no-sources-package pyvex \
             --no-build-package bitarray --no-build-package cffi --no-build-package pycryptodome
-          uv pip install --python .venv/bin/python --no-deps --force-reinstall ../wheels/pyvex*.whl
       - name: Test CLE in Pyodide
         working-directory: workspace/cle
         run: uv run --no-sync pytest tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,20 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: workspace/cle
-      - name: Checkout archinfo
-        uses: actions/checkout@v6
-        with:
-          repository: angr/archinfo
-          path: workspace/archinfo
       - name: Checkout PyVEX
         uses: actions/checkout@v6
         with:
           repository: angr/pyvex
           path: workspace/pyvex
           submodules: recursive
+      - id: binaries-ref
+        uses: angr/ci-settings/actions/binaries-ref@master
       - name: Checkout test binaries
         uses: actions/checkout@v6
         with:
           repository: angr/binaries
           path: workspace/binaries
+          ref: ${{ steps.binaries-ref.outputs.ref }}
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Build PyVEX for Pyodide
@@ -46,22 +44,15 @@ jobs:
           CIBW_PLATFORM: pyodide
           CIBW_PYODIDE_VERSION: "314.0.0"
           CIBW_TEST_COMMAND: pytest {package}/tests
-      - name: Build pure-Python wheels
+      - name: Sync Pyodide dependencies
+        working-directory: workspace/cle
         run: |
-          uv build --wheel --out-dir workspace/wheels workspace/archinfo
-          uv build --wheel --out-dir workspace/wheels workspace/cle
-          uvx --from pip pip wheel --no-deps --wheel-dir workspace/wheels arpy==1.1.1
+          uv sync --python pyodide@3.14 --group pyodide-testing --no-install-package pyvex \
+            --no-build-package bitarray --no-build-package cffi --no-build-package pycryptodome
+          uv pip install --python .venv/bin/python --no-deps --force-reinstall ../wheels/pyvex*.whl
       - name: Test CLE in Pyodide
-        env:
-          PYODIDE_XBUILDENV_PATH: ${{ github.workspace }}/workspace/.pyodide-xbuildenv
-        run: |
-          uvx --python 3.14 --from 'pyodide-build[resolve]' pyodide xbuildenv install 314.0.0 \
-            --path "$PYODIDE_XBUILDENV_PATH"
-          uvx --python 3.14 --from 'pyodide-build[resolve]' pyodide venv --clear workspace/venv
-          source workspace/venv/bin/activate
-          python -m pip install --force-reinstall workspace/wheels/*.whl pytest
-          cd workspace/cle
-          python -m pytest tests
+        working-directory: workspace/cle
+        run: uv run --no-sync pytest tests
 
   test:
     name: Test ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,13 @@ docs = [
     "sphinx",
     "sphinx-autodoc-typehints",
 ]
+pyodide-testing = [
+    "bitarray",
+    "bitstring<4.4",
+    "cffi",
+    "pycryptodome",
+    "pytest",
+]
 testing = [
     "cffi",
     "pypcode>=1.1",
@@ -72,7 +79,15 @@ py_limited_api = "cp312"
 
 [tool.uv.sources]
 archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
+bitarray = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
+cffi = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
+pycryptodome = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
 pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
+
+[[tool.uv.index]]
+name = "pyodide"
+url = "https://index.pyodide.org/314.0.0/"
+explicit = true
 
 [tool.black]
 line-length = 120

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import sys
 import timeit
 
 import cffi
+import pytest
 
 import cle
 
 
+@pytest.mark.skipif(sys.platform == "emscripten", reason="runtime CFFI compilation is unavailable in Pyodide")
 def test_cclemory():  # pylint: disable=no-member
     # This is a test case for C-backed Clemory.
 

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import sys
 import timeit
+import unittest
 
 import cffi
-import pytest
 
 import cle
 
 
-@pytest.mark.skipif(sys.platform == "emscripten", reason="runtime CFFI compilation is unavailable in Pyodide")
+@unittest.skipIf(sys.platform == "emscripten", "runtime CFFI compilation is unavailable in Pyodide")
 def test_cclemory():  # pylint: disable=no-member
     # This is a test case for C-backed Clemory.
 

--- a/tests/test_optional_backends.py
+++ b/tests/test_optional_backends.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform == "emscripten", reason="subprocesses are unavailable in Pyodide")
+
 
 def test_import_without_uefi_firmware():
     script = """

--- a/tests/test_optional_backends.py
+++ b/tests/test_optional_backends.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import subprocess
 import sys
-
-import pytest
-
-pytestmark = pytest.mark.skipif(sys.platform == "emscripten", reason="subprocesses are unavailable in Pyodide")
+import unittest
 
 
+@unittest.skipIf(sys.platform == "emscripten", "subprocesses are unavailable in Pyodide")
 def test_import_without_uefi_firmware():
     script = """
 import sys

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -12,6 +13,7 @@ import cle
 from cle.backends.pe.symbolserver import PDBInfo
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
+requires_pyxdia = unittest.skipIf(sys.platform == "emscripten", "pyxdia is unavailable in Pyodide")
 
 
 # pylint: disable=no-self-use
@@ -153,6 +155,7 @@ class TestPEBackend(unittest.TestCase):
         assert tls is not None
         assert len(ld.tls.modules) == 1
 
+    @requires_pyxdia
     def test_pdb(self):
         exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.exe")
         pdb = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.pdb")
@@ -202,6 +205,7 @@ class TestPEBackend(unittest.TestCase):
         ld = cle.Loader(exe, auto_load_libs=False)
         assert ld.find_symbol("main")
 
+    @requires_pyxdia
     def test_debug_symbol_paths_flat_layout(self):
         """Test loading PDB from debug_symbol_paths with flat layout."""
         exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.exe")
@@ -216,6 +220,7 @@ class TestPEBackend(unittest.TestCase):
             ld = cle.Loader(exe, auto_load_libs=False, load_debug_info=True, main_opts={"debug_symbol_paths": [tmpdir]})
             assert ld.find_symbol("authenticate")
 
+    @requires_pyxdia
     def test_debug_symbol_paths_symbol_store_layout(self):
         """Test loading PDB from debug_symbol_paths with symbol store layout."""
         exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.exe")
@@ -241,6 +246,7 @@ class TestPEBackend(unittest.TestCase):
                 )
                 assert ld.find_symbol("authenticate")
 
+    @requires_pyxdia
     def test_debug_symbol_paths_multiple_paths(self):
         """Test loading PDB with multiple debug_symbol_paths."""
         exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.exe")
@@ -261,6 +267,7 @@ class TestPEBackend(unittest.TestCase):
                 )
                 assert ld.find_symbol("authenticate")
 
+    @requires_pyxdia
     def test_debug_symbol_paths_nonexistent_path(self):
         """Test that nonexistent debug_symbol_paths are handled gracefully."""
         exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.exe")


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

- add a Pyodide CI job for CLE on Ubuntu
- build and test the PyVEX WebAssembly wheel with cibuildwheel
- resolve that wheel as part of the managed `uv sync` environment, then run the full CLE suite under Pyodide
- skip the small set of host-only tests with `unittest` decorators

The PyVEX wheel must be built explicitly because it is not published in the Pyodide package index. The sync step uses `--find-links` together with `--no-sources-package pyvex`, so uv selects the already-built wheel during dependency resolution instead of attempting a Git-source cross-build.

The VEX and PyVEX prerequisites are merged. This PR is independently mergeable; related browser-runtime work continues in [angr #6658](https://github.com/angr/angr/pull/6658), [claripy #737](https://github.com/angr/claripy/pull/737), and [pypcode #283](https://github.com/angr/pypcode/pull/283).

## Validation

- exact final local workflow: PyVEX Pyodide tests — 63 passed, 1 skipped
- exact final local workflow: CLE Pyodide tests — 231 passed, 17 skipped
- uv lock provenance records PyVEX `9.3.4.dev0` from the local `../wheels` registry
- PyVEX wheel SHA-256: `990660f538ba15a892501546b8993f2e73a991744abde659d106baa652ada179`
- native focused tests — 18 passed
- native full suite — 239 passed, 9 skipped
- workspace gate, changed-file lint/type comparison, and all pre-commit hooks passed

Hosted exact-head CI is pending after the branch update.
