### PR TITLE
Preserve PE export names with COFF symbol types

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -17,6 +17,7 @@ except ImportError:
 
 from cle.address_translator import AT
 from cle.backends.backend import Backend, FunctionHint, FunctionHintSource, register_backend
+from cle.backends.coff import IMAGE_SYM_CLASS
 from cle.backends.symbol import SymbolType
 from cle.structs import DataDirectory, MemRegion, MemRegionSort, PointerArray, StringBlob, StructArray
 from cle.utils import extract_null_terminated_bytestr
@@ -134,7 +135,8 @@ class PE(Backend):
         self._symbol_cache = self._exports  # same thing
         self._handle_imports()
         self._handle_delay_imports()
-        self._handle_exports()
+        coff_symbol_types = self._load_symbols_from_coff_header()
+        self._handle_exports(coff_symbol_types)
         self._handle_seh()
         self._parse_meta_regions()
         if self.loader._perform_relocations:
@@ -161,8 +163,6 @@ class PE(Backend):
             pdb_path = debug_symbols or self._find_pdb_path()
             if pdb_path:
                 self.load_symbols_from_pdb(pdb_path)
-
-        self._load_symbols_from_coff_header()
 
         self.is_dotnet = (
             self._pe.OPTIONAL_HEADER.DATA_DIRECTORY[
@@ -420,13 +420,19 @@ class PE(Backend):
                     self.imports[imp_name] = reloc
                     self.relocs.append(reloc)
 
-    def _handle_exports(self):
+    def _handle_exports(self, coff_symbol_types: dict[int, set[SymbolType]]):
         if hasattr(self._pe, "DIRECTORY_ENTRY_EXPORT"):
             symbols = self._pe.DIRECTORY_ENTRY_EXPORT.symbols
             for exp in symbols:
                 name = exp.name.decode() if exp.name is not None else None
                 forwarder = exp.forwarder.decode() if exp.forwarder is not None else None
-                symb = WinSymbol(self, name, exp.address, False, True, exp.ordinal, forwarder)
+                matching_types = coff_symbol_types.get(exp.address, set())
+                symbol_type = (
+                    next(iter(matching_types))
+                    if forwarder is None and len(matching_types) == 1
+                    else SymbolType.TYPE_FUNCTION
+                )
+                symb = WinSymbol(self, name, exp.address, False, True, exp.ordinal, forwarder, symbol_type)
                 self.symbols.add(symb)
                 self._exports[name] = symb
                 self._ordinal_exports[exp.ordinal] = symb
@@ -1159,9 +1165,12 @@ class PE(Backend):
         log.warning("Unable to find PDB file for this PE. Tried: %s", str(attempts))
         return None
 
-    def _load_symbols_from_coff_header(self):
+    def _load_symbols_from_coff_header(self) -> dict[int, set[SymbolType]]:
         """
-        COFF debug info is deprecated, but may still be provided (e.g. by mingw).
+        Load symbols from the deprecated COFF debug information that some toolchains (e.g. MinGW) still provide.
+
+        Return the concrete types of external definitions grouped by RVA so that the export table can reuse them.
+        Local symbols are still loaded, but cannot describe an export.
         """
         type_to_symbol_type = {
             0: SymbolType.TYPE_OBJECT,
@@ -1178,13 +1187,14 @@ class PE(Backend):
         )
         if end_of_table_offset >= len(self._raw_data):
             log.warning("PE symbol table out of bounds")
-            return
+            return {}
 
+        symbol_types: dict[int, set[SymbolType]] = {}
         idx = 0
         while idx < self._pe.FILE_HEADER.NumberOfSymbols:
             offset = self._pe.FILE_HEADER.PointerToSymbolTable + idx * sizeof_symbol_desc
             sym_desc = self._raw_data[offset : offset + sizeof_symbol_desc]
-            name, value, section, type_, _, num_aux_syms = struct.unpack("<8sIhHBB", sym_desc)
+            name, value, section, type_, storage_class, num_aux_syms = struct.unpack("<8sIhHBB", sym_desc)
             name_as_dwords = struct.unpack("<II", name)
             if name_as_dwords[0] == 0:
                 name = self._read_from_string_table(name_as_dwords[1])
@@ -1192,10 +1202,14 @@ class PE(Backend):
                 name = name.rstrip(b"\x00").decode("latin-1")
             if section > 0 and type_ in type_to_symbol_type and VALID_SYMBOL_NAME_RE.fullmatch(name):
                 rva = self._pe.sections[section - 1].VirtualAddress + value
-                symbol = WinSymbol(self, name, rva, False, False, None, None, type_to_symbol_type[type_])
+                symbol_type = type_to_symbol_type[type_]
+                symbol = WinSymbol(self, name, rva, False, False, None, None, symbol_type)
                 log.debug("Adding symbol %s", symbol)
                 self.symbols.add(symbol)
+                if storage_class == IMAGE_SYM_CLASS.EXTERNAL:
+                    symbol_types.setdefault(rva, set()).add(symbol_type)
             idx += 1 + num_aux_syms
+        return symbol_types
 
 
 register_backend("pe", PE)

--- a/tests/test_pe_coff_symbols.py
+++ b/tests/test_pe_coff_symbols.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import struct
+from types import SimpleNamespace
+from typing import Any
+
+import archinfo
+
+from cle.backends.coff import IMAGE_SYM_CLASS
+from cle.backends.pe.pe import PE
+from cle.backends.symbol import SymbolType
+
+
+class _SymbolList(list):
+    """Minimal symbol container used by the fixture-free PE tests."""
+
+    def add(self, symbol) -> None:
+        self.append(symbol)
+
+
+def _make_pe(raw_data: bytes = b"", exports=()) -> Any:
+    pe: Any = object.__new__(PE)
+    pe._arch = archinfo.ArchAMD64()
+    pe._raw_data = raw_data
+    pe._pe = SimpleNamespace(
+        FILE_HEADER=SimpleNamespace(PointerToSymbolTable=0, NumberOfSymbols=len(raw_data) // 18),
+        sections=[SimpleNamespace(VirtualAddress=0x1000)],
+        DIRECTORY_ENTRY_EXPORT=SimpleNamespace(symbols=exports),
+    )
+    pe.symbols = _SymbolList()
+    pe._exports = {}
+    pe._ordinal_exports = {}
+    pe.deps = []
+    return pe
+
+
+def _coff_symbol(name: bytes, value: int, section: int, type_: int, storage_class: int) -> bytes:
+    return struct.pack("<8sIhHBB", name, value, section, type_, storage_class, 0)
+
+
+def test_coff_symbol_type_hints_only_include_external_definitions():
+    raw_data = b"".join(
+        [
+            _coff_symbol(b"function", 0x10, 1, 0x20, IMAGE_SYM_CLASS.EXTERNAL),
+            _coff_symbol(b"object", 0x20, 1, 0, IMAGE_SYM_CLASS.EXTERNAL),
+            _coff_symbol(b"static", 0x30, 1, 0, IMAGE_SYM_CLASS.STATIC),
+            _coff_symbol(b"undefined", 0, 0, 0x20, IMAGE_SYM_CLASS.EXTERNAL),
+            _coff_symbol(b"other", 0x40, 1, 0x10, IMAGE_SYM_CLASS.EXTERNAL),
+        ]
+    )
+    pe = _make_pe(raw_data + b"\0\0\0\0")
+
+    symbol_types = pe._load_symbols_from_coff_header()
+
+    assert symbol_types == {
+        0x1010: {SymbolType.TYPE_FUNCTION},
+        0x1020: {SymbolType.TYPE_OBJECT},
+    }
+    assert {symbol.name for symbol in pe.symbols} == {"function", "object", "static"}
+
+
+def test_exports_inherit_only_unambiguous_coff_symbol_types():
+    exports = [
+        SimpleNamespace(name=b"data", address=0x1010, forwarder=None, ordinal=1),
+        SimpleNamespace(name=b"ambiguous", address=0x1020, forwarder=None, ordinal=2),
+        SimpleNamespace(name=b"missing", address=0x1030, forwarder=None, ordinal=3),
+        SimpleNamespace(name=b"forwarded", address=0x1040, forwarder=b"other.target", ordinal=4),
+    ]
+    pe = _make_pe(exports=exports)
+
+    pe._handle_exports(
+        {
+            0x1010: {SymbolType.TYPE_OBJECT},
+            0x1020: {SymbolType.TYPE_FUNCTION, SymbolType.TYPE_OBJECT},
+            0x1040: {SymbolType.TYPE_OBJECT},
+        }
+    )
+
+    assert pe._exports["data"].type is SymbolType.TYPE_OBJECT
+    assert pe._exports["ambiguous"].type is SymbolType.TYPE_FUNCTION
+    assert pe._exports["missing"].type is SymbolType.TYPE_FUNCTION
+    assert pe._exports["forwarded"].type is SymbolType.TYPE_FUNCTION
+    assert pe.deps == ["other.dll"]


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

## Summary

PE loading currently adds exports before COFF symbols. At a shared address, the later COFF spelling (for example, `_Name`) can displace the public export spelling (`Name`). At the same time, every non-forwarded export is classified as a function, so exported data loses the object information already present in the COFF table.

This change:

- loads COFF symbols before exports so the public export name remains canonical;
- uses a COFF type hint only when exactly one external, concrete FUNCTION or OBJECT definition exists at that RVA;
- keeps ordinary static/local COFF symbols available without letting them influence export typing;
- retains the existing FUNCTION fallback for absent or conflicting hints and for forwarded exports; and
- preserves PDB precedence by continuing to load PDB symbols last.

The behavior is confined to the PE backend; it does not change global symbol alias ordering for ELF or other formats.

## DecBench results

I evaluated the three Dexter PE builds in DecBench. Each build has 104 unambiguous export/COFF matches (61 functions and 43 objects).

- Exact source-name recovery for the evaluated exported functions: **0/180 before → 180/180 after** (60 per build). The one decorated `DetectShutdown` spelling per build was excluded from this exact-name count and remains conservatively unchanged.
- CFG recovery and decompilation success were unchanged in all three builds.
- Representative decompiled types were unchanged; the fix changes symbol identity/type metadata rather than control-flow recovery.

A broader scan of 101 DecBench PE binaries found 3,453 exports. The change applies to 312 unambiguous matches (183 functions and 129 objects); the other 3,141 exports remain on the existing behavior. The scan found no conflicting-type acceptance, duplicate-address mismatch, or ordinal-only-name change.

## Regression coverage

The new fixture-free tests construct minimal PE/COFF inputs and cover function and object inheritance, same-address public-name precedence, local/static-symbol exclusion, ambiguity fallback, missing-hint fallback, and forwarded-export fallback.

Validation:

- focused PE/COFF tests: 16 passed;
- complete CLE suite: 202 passed, 9 skipped;
- complete workspace gate: archinfo 17 passed; pypcode 46 passed plus 187 subtests; pyvex 63 passed; claripy 331 passed/1 skipped; angr 2,221 passed/46 skipped/2 expected xfails plus 188 subtests; angr Rust 30 passed; angr-management 500 passed.