### PR TITLE
Slottify Relocation and its subclasses.

### DIFF
--- a/cle/backends/binja.py
+++ b/cle/backends/binja.py
@@ -59,6 +59,8 @@ class BinjaSymbol(Symbol):
 
 
 class BinjaReloc(Relocation):
+    __slots__ = ()
+
     @property
     def value(self):
         return self.relative_addr

--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -286,6 +286,8 @@ class CoffRelocation(Relocation):
     Relocation for a COFF object.
     """
 
+    __slots__ = ()
+
     PACK_FORMAT = "<i"
 
     def relocate(self):
@@ -302,6 +304,8 @@ class CoffRelocationREL32(CoffRelocation):
     Relocation for IMAGE_REL_*_REL32
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         assert self.resolvedby is not None
@@ -314,6 +318,8 @@ class CoffRelocationDIR32(CoffRelocation):
     """
     Relocation for IMAGE_REL_*_DIR32
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -328,6 +334,8 @@ class CoffRelocationDIR32NB(CoffRelocation):
     Relocation for IMAGE_REL_*_DIR32
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         assert self.resolvedby is not None
@@ -340,6 +348,8 @@ class CoffRelocationADDR32NB(CoffRelocation):
     """
     Relocation for IMAGE_REL_AMD64_ADDR32NB
     """
+
+    __slots__ = ()
 
     PACK_FORMAT = "<I"
 
@@ -354,6 +364,8 @@ class CoffRelocationADDR64(CoffRelocation):
     Relocation for IMAGE_REL_AMD64_ADDR64
     """
 
+    __slots__ = ()
+
     PACK_FORMAT = "<Q"
 
     @property
@@ -366,6 +378,8 @@ class CoffRelocationSECTION(CoffRelocation):
     """
     Relocation for IMAGE_REL_*_SECTION
     """
+
+    __slots__ = ()
 
     PACK_FORMAT = "<H"
 
@@ -380,6 +394,8 @@ class CoffRelocationSECREL(CoffRelocation):
     """
     Relocation for IMAGE_REL_*_SECREL
     """
+
+    __slots__ = ()
 
     PACK_FORMAT = "<I"
 

--- a/cle/backends/elf/relocation/amd64.py
+++ b/cle/backends/elf/relocation/amd64.py
@@ -21,66 +21,80 @@ from .generic import (
 
 
 class R_X86_64_64(GenericAbsoluteAddendReloc):
-    pass
+    __slots__ = ()
 
 
 class R_X86_64_COPY(GenericCopyReloc):
-    pass
+    __slots__ = ()
 
 
 class R_X86_64_RELATIVE(GenericRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_X86_64_IRELATIVE(GenericIRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_X86_64_GLOB_DAT(GenericAbsoluteReloc):
-    pass
+    __slots__ = ()
 
 
 class R_X86_64_JUMP_SLOT(GenericAbsoluteReloc):
-    pass
+    __slots__ = ()
 
 
 class R_X86_64_DTPMOD64(GenericTLSModIdReloc):
-    pass
+    __slots__ = ()
 
 
 class R_X86_64_DTPOFF64(GenericTLSDoffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_X86_64_TPOFF64(GenericTLSOffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_X86_64_PC32(RelocTruncate32Mixin, GenericPCRelativeAddendReloc):
+    __slots__ = ()
+
     check_sign_extend = True
 
 
 class R_X86_64_32(RelocTruncate32Mixin, GenericAbsoluteAddendReloc):
+    __slots__ = ()
+
     check_zero_extend = True
 
 
 class R_X86_64_32S(RelocTruncate32Mixin, GenericAbsoluteAddendReloc):
+    __slots__ = ()
+
     check_sign_extend = True
 
 
 class R_X86_64_PLT32(RelocTruncate32Mixin, GenericPCRelativeAddendReloc):
+    __slots__ = ()
+
     check_sign_extend = True
 
 
 class R_X86_64_GOTPCREL(RelocGOTMixin, RelocTruncate32Mixin, GenericPCRelativeAddendReloc):
+    __slots__ = ()
+
     check_sign_extend = True
 
 
 class R_X86_64_GOTPCRELX(RelocGOTMixin, RelocTruncate32Mixin, GenericPCRelativeAddendReloc):
+    __slots__ = ()
+
     check_sign_extend = True
 
 
 class R_X86_64_REX_GOTPCRELX(RelocGOTMixin, RelocTruncate32Mixin, GenericPCRelativeAddendReloc):
+    __slots__ = ()
+
     check_sign_extend = True
 
 

--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -68,6 +68,8 @@ class R_ARM_CALL(ELFReloc):
       - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         P = self.rebased_addr  # Location of this instruction
@@ -108,6 +110,8 @@ class R_ARM_PREL31(ELFReloc):
       - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         P = self.rebased_addr  # Location of this instruction
@@ -141,6 +145,8 @@ class R_ARM_REL32(ELFReloc):
       - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         P = self.rebased_addr  # Location of this instruction
@@ -167,6 +173,8 @@ class R_ARM_ABS32(ELFReloc):
       - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend  # The instruction
@@ -189,6 +197,8 @@ class R_ARM_MOVW_ABS_NC(ELFReloc):
       - A is the addend
       - T is 1 if the symbol is of type STT_FUNC and addresses a Thumb instruction
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -224,6 +234,8 @@ class R_ARM_MOVT_ABS(ELFReloc):
       - S is the address of the symbol
       - A is the addend
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -273,6 +285,8 @@ class R_ARM_THM_CALL(ELFReloc):
 
       - Implementation appears correct with the bits placed into offset[23:22]
     """
+
+    __slots__ = ("_insn_bytes",)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -374,61 +388,61 @@ class R_ARM_THM_CALL(ELFReloc):
 
 
 class R_ARM_COPY(GenericCopyReloc):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_GLOB_DAT(GenericJumpslotReloc):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_JUMP_SLOT(GenericJumpslotReloc):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_RELATIVE(GenericRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_ABS32_NOI(GenericAbsoluteAddendReloc):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_REL32_NOI(GenericPCRelativeAddendReloc):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_TLS_DTPMOD32(GenericTLSModIdReloc):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_TLS_DTPOFF32(GenericTLSDoffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_TLS_TPOFF32(GenericTLSOffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_JUMP24(R_ARM_CALL):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_PC24(R_ARM_CALL):
-    pass
+    __slots__ = ()
 
 
 # EDG says: Implementing these the easy way.
 # Inaccuracies may exist.  This is ARM, after all.
 class R_ARM_THM_JUMP24(R_ARM_THM_CALL):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_THM_JUMP19(R_ARM_THM_CALL):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_THM_JUMP6(R_ARM_THM_CALL):
-    pass
+    __slots__ = ()
 
 
 class R_ARM_THM_MOVW_ABS_NC(ELFReloc):
@@ -436,6 +450,8 @@ class R_ARM_THM_MOVW_ABS_NC(ELFReloc):
     ((S + A) | T) & 0xffff
     Ref: https://github.com/ARM-software/abi-aa/blob/main/aaelf32/aaelf32.rst
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -478,6 +494,8 @@ class R_ARM_THM_MOVT_ABS(ELFReloc):
     Ref: https://github.com/ARM-software/abi-aa/blob/main/aaelf32/aaelf32.rst
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         insn_bytes = self.owner.memory.load(self.relative_addr, 4)
@@ -517,6 +535,8 @@ class R_ARM_GOT_PREL(GenericPCRelativeAddendReloc, RelocTruncate32Mixin, RelocGO
     GOT(S) + A - P
     Ref: https://github.com/ARM-software/abi-aa/blob/main/aaelf32/aaelf32.rst
     """
+
+    __slots__ = ()
 
 
 relocation_table_arm = {

--- a/cle/backends/elf/relocation/arm64.py
+++ b/cle/backends/elf/relocation/arm64.py
@@ -25,42 +25,44 @@ log = logging.getLogger(name=__name__)
 
 
 class R_AARCH64_ABS64(GenericAbsoluteAddendReloc):
-    pass
+    __slots__ = ()
 
 
 class R_AARCH64_COPY(GenericCopyReloc):
-    pass
+    __slots__ = ()
 
 
 class R_AARCH64_GLOB_DAT(GenericJumpslotReloc):
-    pass
+    __slots__ = ()
 
 
 class R_AARCH64_JUMP_SLOT(GenericJumpslotReloc):
-    pass
+    __slots__ = ()
 
 
 class R_AARCH64_RELATIVE(GenericRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_AARCH64_IRELATIVE(GenericIRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_AARCH64_TLS_DTPREL(GenericTLSDoffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_AARCH64_TLS_DTPMOD(GenericTLSModIdReloc):
-    pass
+    __slots__ = ()
 
 
 class R_AARCH64_TLS_TPREL(GenericTLSOffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_AARCH64_TLSDESC(GenericTLSDescriptorReloc):
+    __slots__ = ()
+
     RESOLVER_ADDR = 0xFFFF_FFFF_FFFF_FE00
 
 
@@ -70,12 +72,16 @@ class R_AARCH64_PREL32(GenericPCRelativeAddendReloc):
     Calculation: (S + A - P)
     """
 
+    __slots__ = ()
+
 
 class R_AARCH64_JUMP26(ELFReloc):
     """
     Relocation Type: 282
     Calculation: (S + A - P)
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -101,6 +107,8 @@ class R_AARCH64_CALL26(ELFReloc):
     Calculation: (S + A - P)
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -124,6 +132,8 @@ class R_AARCH64_ADR_PREL_PG_HI21(ELFReloc):
     Relocation Type: 275
     Calculation: Page(S + A) - Page(P)
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -151,6 +161,8 @@ class R_AARCH64_ADD_ABS_LO12_NC(ELFReloc):
     Calculation: (S + A)
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -171,6 +183,8 @@ class R_AARCH64_LDST8_ABS_LO12_NC(ELFReloc):
     Relocation Type: 278
     Calculation: (S + A)
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -193,6 +207,8 @@ class R_AARCH64_LDST16_ABS_LO12_NC(ELFReloc):
     Calculation: (S + A)
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -213,6 +229,8 @@ class R_AARCH64_LDST32_ABS_LO12_NC(ELFReloc):
     Relocation Type: 285
     Calculation: (S + A)
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -235,6 +253,8 @@ class R_AARCH64_LDST64_ABS_LO12_NC(ELFReloc):
     Calculation: (S + A)
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -255,6 +275,8 @@ class R_AARCH64_LDST128_ABS_LO12_NC(ELFReloc):
     Relocation Type: 299
     Calculation: (S + A)
     """
+
+    __slots__ = ()
 
     @property
     def value(self):

--- a/cle/backends/elf/relocation/elfreloc.py
+++ b/cle/backends/elf/relocation/elfreloc.py
@@ -8,6 +8,8 @@ log = logging.getLogger(name=__name__)
 
 
 class ELFReloc(Relocation):
+    __slots__ = ("is_rela", "_addend")
+
     def __init__(self, owner, symbol, relative_addr, addend=None):
         super().__init__(owner, symbol, relative_addr)
 

--- a/cle/backends/elf/relocation/generic.py
+++ b/cle/backends/elf/relocation/generic.py
@@ -31,6 +31,8 @@ __all__ = [
 
 
 class GenericTLSDoffsetReloc(ELFReloc):
+    __slots__ = ()
+
     @property
     def value(self):
         return self.addend + self.symbol.relative_addr
@@ -41,6 +43,8 @@ class GenericTLSDoffsetReloc(ELFReloc):
 
 
 class GenericTLSOffsetReloc(ELFReloc):
+    __slots__ = ()
+
     AUTO_HANDLE_NONE = True
 
     def relocate(self):
@@ -66,6 +70,8 @@ class GenericTLSDescriptorReloc(ELFReloc):
     # is passed a pointer to the descriptor. My guess is the resolver is supposed to basically perform
     # _tls_get_addr, but the intention is probably to make it possible to work with dynamically loaded objects.
 
+    __slots__ = ()
+
     RESOLVER_ADDR: int = NotImplemented
     AUTO_HANDLE_NONE = True
 
@@ -85,6 +91,8 @@ class GenericTLSDescriptorReloc(ELFReloc):
 
 
 class GenericTLSModIdReloc(ELFReloc):
+    __slots__ = ()
+
     AUTO_HANDLE_NONE = True
 
     def relocate(self):
@@ -97,6 +105,8 @@ class GenericTLSModIdReloc(ELFReloc):
 
 
 class GenericIRelativeReloc(ELFReloc):
+    __slots__ = ()
+
     AUTO_HANDLE_NONE = True
 
     def relocate(self):
@@ -107,18 +117,24 @@ class GenericIRelativeReloc(ELFReloc):
 
 
 class GenericAbsoluteAddendReloc(ELFReloc):
+    __slots__ = ()
+
     @property
     def value(self):
         return self.resolvedby.rebased_addr + self.addend
 
 
 class GenericPCRelativeAddendReloc(ELFReloc):
+    __slots__ = ()
+
     @property
     def value(self):
         return self.resolvedby.rebased_addr + self.addend - self.rebased_addr
 
 
 class GenericJumpslotReloc(ELFReloc):
+    __slots__ = ()
+
     @property
     def value(self):
         if self.is_rela:
@@ -128,6 +144,8 @@ class GenericJumpslotReloc(ELFReloc):
 
 
 class GenericRelativeReloc(ELFReloc):
+    __slots__ = ()
+
     AUTO_HANDLE_NONE = True
 
     @property
@@ -138,12 +156,16 @@ class GenericRelativeReloc(ELFReloc):
 
 
 class GenericAbsoluteReloc(ELFReloc):
+    __slots__ = ()
+
     @property
     def value(self):
         return self.resolvedby.rebased_addr
 
 
 class GenericCopyReloc(ELFReloc):
+    __slots__ = ()
+
     def resolve_symbol(self, solist, **kwargs):
         new_solist = [x for x in solist if x is not self.owner]
         super().resolve_symbol(new_solist, **kwargs)
@@ -160,10 +182,12 @@ class GenericCopyReloc(ELFReloc):
 
 
 class MipsGlobalReloc(GenericAbsoluteReloc):
-    pass
+    __slots__ = ()
 
 
 class MipsLocalReloc(ELFReloc):
+    __slots__ = ()
+
     AUTO_HANDLE_NONE = True
 
     def resolve_symbol(self, solist, **kwargs):
@@ -186,6 +210,8 @@ class RelocTruncate32Mixin:
     """
     A mix-in class for relocations that cover a 32-bit field regardless of the architecture's address word length.
     """
+
+    __slots__ = ()
 
     # If True, 32-bit truncated value must equal to its original when zero-extended
     check_zero_extend = False
@@ -221,6 +247,8 @@ class RelocGOTMixin:
     """
     A mix-in class which will cause the symbol to be resolved to a pointer to the symbol instead of the symbol
     """
+
+    __slots__ = ()
 
     def resolve(self, symbol, extern_object=None):
         assert extern_object is not None, "I have no idea how this would happen"

--- a/cle/backends/elf/relocation/i386.py
+++ b/cle/backends/elf/relocation/i386.py
@@ -26,6 +26,8 @@ class R_386_32(GenericAbsoluteAddendReloc):
     Calculation: S + A
     """
 
+    __slots__ = ()
+
 
 class R_386_PC32(GenericPCRelativeAddendReloc):
     """
@@ -33,6 +35,8 @@ class R_386_PC32(GenericPCRelativeAddendReloc):
     Field: word32
     Calculation: S + A - P
     """
+
+    __slots__ = ()
 
 
 class R_386_COPY(GenericCopyReloc):
@@ -42,6 +46,8 @@ class R_386_COPY(GenericCopyReloc):
     Calculation:
     """
 
+    __slots__ = ()
+
 
 class R_386_GLOB_DAT(GenericJumpslotReloc):
     """
@@ -49,6 +55,8 @@ class R_386_GLOB_DAT(GenericJumpslotReloc):
     Field: word32
     Calculation: S
     """
+
+    __slots__ = ()
 
 
 class R_386_JMP_SLOT(GenericJumpslotReloc):
@@ -58,6 +66,8 @@ class R_386_JMP_SLOT(GenericJumpslotReloc):
     Calculation: S
     """
 
+    __slots__ = ()
+
 
 class R_386_RELATIVE(GenericRelativeReloc):
     """
@@ -65,6 +75,8 @@ class R_386_RELATIVE(GenericRelativeReloc):
     Field: word32
     Calculation: B + A
     """
+
+    __slots__ = ()
 
 
 class R_386_IRELATIVE(GenericIRelativeReloc):
@@ -74,6 +86,8 @@ class R_386_IRELATIVE(GenericIRelativeReloc):
     Calculation: indirect (B + A)
     """
 
+    __slots__ = ()
+
 
 class R_386_TLS_DTPMOD32(GenericTLSModIdReloc):
     """
@@ -81,6 +95,8 @@ class R_386_TLS_DTPMOD32(GenericTLSModIdReloc):
     Field: word32
     Calculation:
     """
+
+    __slots__ = ()
 
 
 class R_386_TLS_TPOFF(GenericTLSOffsetReloc):
@@ -90,6 +106,8 @@ class R_386_TLS_TPOFF(GenericTLSOffsetReloc):
     Calculation:
     """
 
+    __slots__ = ()
+
 
 class R_386_TLS_DTPOFF32(GenericTLSDoffsetReloc):
     """
@@ -97,6 +115,8 @@ class R_386_TLS_DTPOFF32(GenericTLSDoffsetReloc):
     Field: word32
     Calculation:
     """
+
+    __slots__ = ()
 
 
 class R_386_PLT32(GenericPCRelativeAddendReloc):
@@ -106,6 +126,8 @@ class R_386_PLT32(GenericPCRelativeAddendReloc):
     Calculation: L + A - P
     """
 
+    __slots__ = ()
+
 
 class R_386_GOTPC(GenericPCRelativeAddendReloc, RelocGOTMixin):
     """
@@ -113,6 +135,8 @@ class R_386_GOTPC(GenericPCRelativeAddendReloc, RelocGOTMixin):
     Field: word32
     Calculation: GOT + A - P
     """
+
+    __slots__ = ()
 
 
 relocation_table_i386 = {

--- a/cle/backends/elf/relocation/mips.py
+++ b/cle/backends/elf/relocation/mips.py
@@ -28,14 +28,16 @@ from .generic import (
 
 
 class R_MIPS_32(GenericAbsoluteAddendReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_REL32(GenericRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_26(GenericAbsoluteReloc):
+    __slots__ = ()
+
     def relocate(self):
         if not self.resolved:
             return False
@@ -48,26 +50,28 @@ class R_MIPS_26(GenericAbsoluteReloc):
 
 
 class R_MIPS_JUMP_SLOT(GenericAbsoluteReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_GLOB_DAT(GenericAbsoluteReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_TLS_DTPMOD32(GenericTLSModIdReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_TLS_TPREL32(GenericTLSOffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_TLS_DTPREL32(GenericTLSDoffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_HI16(GenericAbsoluteReloc):
+
+    __slots__ = ()
 
     def find_matching_lo16_relocation(self):
         current_hi16_index = self.owner.relocs.index(self)
@@ -103,6 +107,8 @@ class R_MIPS_HI16(GenericAbsoluteReloc):
 
 
 class R_MIPS_LO16(GenericAbsoluteReloc):
+    __slots__ = ()
+
     def relocate(self):
         if not self.resolved:
             return False
@@ -118,23 +124,23 @@ class R_MIPS_LO16(GenericAbsoluteReloc):
 
 
 class R_MIPS_64(GenericAbsoluteAddendReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_COPY(GenericCopyReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_TLS_DTPMOD64(GenericTLSModIdReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_TLS_DTPREL64(GenericTLSDoffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_MIPS_TLS_TPREL64(GenericTLSOffsetReloc):
-    pass
+    __slots__ = ()
 
 
 relocation_table_mips = {

--- a/cle/backends/elf/relocation/ppc.py
+++ b/cle/backends/elf/relocation/ppc.py
@@ -34,7 +34,7 @@ PPC_BL_INST = 0x48000001
 
 
 class R_PPC_ADDR32(GenericAbsoluteAddendReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC_ADDR24(ELFReloc):
@@ -43,6 +43,8 @@ class R_PPC_ADDR24(ELFReloc):
     Calculation: (S + A) >> 2
     Field: low24*
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -60,6 +62,8 @@ class R_PPC_ADDR16(ELFReloc):
     Field: half16*
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -75,6 +79,8 @@ class R_PPC_ADDR16_LO(ELFReloc):
     Calculation: #lo(S + A)
     Field: half16
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -99,6 +105,8 @@ class R_PPC_ADDR16_HI(ELFReloc):
     Field: half16
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -121,6 +129,8 @@ class R_PPC_ADDR16_HA(ELFReloc):  # pylint: disable=undefined-variable
     Calculation: #ha(S + A)
     Field: half16
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -145,6 +155,8 @@ class R_PPC_ADDR14(ELFReloc):
     Field: low14*
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -161,6 +173,8 @@ class R_PPC_ADDR14_BRTAKEN(ELFReloc):
     Field: low14*
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -176,6 +190,8 @@ class R_PPC_ADDR14_BRNTAKEN(ELFReloc):
     Calculation: (S + A) >> 2
     Field: low14*
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -203,6 +219,8 @@ class R_PPC_REL24(ELFReloc):
     The result must be resolved to the correct instruction encoding.
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -223,6 +241,8 @@ class R_PPC_REL14(ELFReloc):
     Field: low14*
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -241,6 +261,8 @@ class R_PPC_REL14_BRTAKEN(ELFReloc):
     Calculation: (S + A - P) >> 2
     Field: low14*
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -261,6 +283,8 @@ class R_PPC_REL14_BRNTAKEN(ELFReloc):
     Field: low14*
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -274,14 +298,16 @@ class R_PPC_REL14_BRNTAKEN(ELFReloc):
 
 
 class R_PPC_COPY(GenericCopyReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC_GLOB_DAT(GenericJumpslotReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC_JMP_SLOT(GenericJumpslotReloc):
+    __slots__ = ()
+
     def relocate(self):
         if "DT_PPC_GOT" not in self.owner._dynamic and "DT_LOPROC" not in self.owner._dynamic:
             # old PowerPC ABI - we overwrite this location with a jump (b, 0x12. .. .. .1) to the actual target
@@ -292,7 +318,7 @@ class R_PPC_JMP_SLOT(GenericJumpslotReloc):
 
 
 class R_PPC_RELATIVE(GenericRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC_UADDR32(ELFReloc):
@@ -301,6 +327,8 @@ class R_PPC_UADDR32(ELFReloc):
     Calculation: S + A
     Field: word32
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -318,6 +346,8 @@ class R_PPC_UADDR16(ELFReloc):
     Field: half16*
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -333,6 +363,8 @@ class R_PPC_REL32(ELFReloc):  # pylint: disable=undefined-variable
     Calculation: S + A - P
     Field: word32
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -351,6 +383,8 @@ class R_PPC_SECTOFF(ELFReloc):
     Field: half16*
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         R = self.relative_addr
@@ -366,6 +400,8 @@ class R_PPC_SECTOFF_LO(ELFReloc):
     Calculation: #lo(R + A)
     Field: half16
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -384,6 +420,8 @@ class R_PPC_SECTOFF_HI(ELFReloc):
     Field: half16
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         R = self.relative_addr
@@ -400,6 +438,8 @@ class R_PPC_SECTOFF_HA(ELFReloc):
     Calculation: #ha(R + A)
     Field: half16
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -418,6 +458,8 @@ class R_PPC_ADDR30(ELFReloc):
     Field: word30
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         S = self.resolvedby.rebased_addr
@@ -429,15 +471,15 @@ class R_PPC_ADDR30(ELFReloc):
 
 
 class R_PPC_DTPMOD32(GenericTLSModIdReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC_DTPREL32(GenericTLSDoffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC_TPREL32(GenericTLSOffsetReloc):
-    pass
+    __slots__ = ()
 
 
 relocation_table_ppc = {

--- a/cle/backends/elf/relocation/ppc64.py
+++ b/cle/backends/elf/relocation/ppc64.py
@@ -24,6 +24,8 @@ log = logging.getLogger(name=__name__)
 
 
 class R_PPC64_JMP_SLOT(ELFReloc):
+    __slots__ = ()
+
     def relocate(self):
         if self.owner.is_ppc64_abiv1:
             # R_PPC64_JMP_SLOT
@@ -41,31 +43,31 @@ class R_PPC64_JMP_SLOT(ELFReloc):
 
 
 class R_PPC64_RELATIVE(GenericRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC64_IRELATIVE(GenericIRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC64_ADDR64(GenericAbsoluteAddendReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC64_GLOB_DAT(GenericJumpslotReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC64_DTPMOD64(GenericTLSModIdReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC64_DTPREL64(GenericTLSDoffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC64_TPREL64(GenericTLSOffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_PPC64_REL24(ELFReloc):
@@ -74,6 +76,8 @@ class R_PPC64_REL24(ELFReloc):
     Calculation: (S + A - P) >> 2
     Field: low24*
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -97,6 +101,8 @@ class R_PPC64_TOC16_LO(ELFReloc):
     Calculation: #lo(S + A - .TOC.)
     Field: half16
     """
+
+    __slots__ = ()
 
     @property
     def value(self):
@@ -122,6 +128,8 @@ class R_PPC64_TOC16_HI(ELFReloc):
     Field: half16
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -146,6 +154,8 @@ class R_PPC64_TOC16_HA(ELFReloc):
     Field: half16
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         A = self.addend
@@ -169,6 +179,8 @@ class R_PPC64_TOC(ELFReloc):
     Calculation: .TOC.
     Field: doubleword64
     """
+
+    __slots__ = ()
 
     @property
     def value(self):

--- a/cle/backends/elf/relocation/s390x.py
+++ b/cle/backends/elf/relocation/s390x.py
@@ -16,31 +16,31 @@ from .generic import (
 
 
 class R_390_GLOB_DAT(GenericJumpslotReloc):
-    pass
+    __slots__ = ()
 
 
 class R_390_JMP_SLOT(GenericJumpslotReloc):
-    pass
+    __slots__ = ()
 
 
 class R_390_RELATIVE(GenericRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_390_64(GenericAbsoluteAddendReloc):
-    pass
+    __slots__ = ()
 
 
 class R_390_TLS_TPOFF(GenericTLSOffsetReloc):
-    pass
+    __slots__ = ()
 
 
 class R_390_IRELATIVE(GenericIRelativeReloc):
-    pass
+    __slots__ = ()
 
 
 class R_390_COPY(GenericCopyReloc):
-    pass
+    __slots__ = ()
 
 
 relocation_table_s390x = {

--- a/cle/backends/elf/relocation/sparc.py
+++ b/cle/backends/elf/relocation/sparc.py
@@ -15,6 +15,8 @@ class R_SPARC_HI22(ELFReloc):
     Calculation: (S + A) >> 10
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         result = (self.resolvedby.rebased_addr + self.addend) >> 10
@@ -30,6 +32,8 @@ class R_SPARC_WDISP30(ELFReloc):
     Calculation: (S + A - P) >> 2
     """
 
+    __slots__ = ()
+
     @property
     def value(self):
         result = (self.resolvedby.rebased_addr + self.addend - self.rebased_addr) >> 2
@@ -44,6 +48,8 @@ class R_SPARC_LO10(ELFReloc):
     Field: T-simm13
     Calculation: (S + A) & 0x3ff
     """
+
+    __slots__ = ()
 
     @property
     def value(self):

--- a/cle/backends/externs/__init__.py
+++ b/cle/backends/externs/__init__.py
@@ -48,6 +48,8 @@ class ExternSegment(Segment):
 
 
 class TOCRelocation(Relocation):
+    __slots__ = ()
+
     @property
     def value(self):
         return self.resolvedby.rebased_addr

--- a/cle/backends/externs/simdata/common.py
+++ b/cle/backends/externs/simdata/common.py
@@ -93,6 +93,8 @@ class SimDataSimpleRelocation(Relocation):
     A relocation used to implement PointTo. Pretty simple.
     """
 
+    __slots__ = ("addend", "preresolved")
+
     def __init__(self, owner, symbol, addr, addend, preresolved=False):
         super().__init__(owner, symbol, addr)
         self.addend = addend

--- a/cle/backends/macho/binding.py
+++ b/cle/backends/macho/binding.py
@@ -492,6 +492,8 @@ class MachOSymbolRelocation(Relocation):
     Generic Relocation for MachO. It handles relocations that point to symbols
     """
 
+    __slots__ = ("data",)
+
     symbol: AbstractMachOSymbol
 
     def __init__(self, owner: MachO, symbol: AbstractMachOSymbol, relative_addr: int, data):
@@ -536,6 +538,8 @@ class MachOPointerRelocation(Relocation):
     A relocation for a pointer without any associated symbol
     These are either generated while handling the rebase blob, or while parsing chained fixups
     """
+
+    __slots__ = ("data",)
 
     def __init__(self, owner: MachO, relative_addr: int, data):
         """

--- a/cle/backends/pe/relocation/arm.py
+++ b/cle/backends/pe/relocation/arm.py
@@ -4,11 +4,11 @@ from .pereloc import PEReloc
 
 
 class IMAGE_REL_BASED_ARM_MOV32(PEReloc):
-    pass
+    __slots__ = ()
 
 
 class IMAGE_REL_BASED_THUMB_MOV32(PEReloc):
-    pass
+    __slots__ = ()
 
 
 relocation_table_arm = {

--- a/cle/backends/pe/relocation/generic.py
+++ b/cle/backends/pe/relocation/generic.py
@@ -26,15 +26,19 @@ class DllImport(PEReloc):
     provides a unique name to the relocation type.
     """
 
-    pass
+    __slots__ = ()
 
 
 class IMAGE_REL_BASED_ABSOLUTE(PEReloc):
+    __slots__ = ()
+
     def relocate(self):
         pass
 
 
 class IMAGE_REL_BASED_HIGHADJ(PEReloc):
+    __slots__ = ("next_rva",)
+
     def __init__(self, owner, addr, next_rva):
         super().__init__(owner, None, addr)
         self.next_rva = next_rva
@@ -55,6 +59,8 @@ class IMAGE_REL_BASED_HIGHADJ(PEReloc):
 
 
 class IMAGE_REL_BASED_HIGHLOW(PEReloc):
+    __slots__ = ()
+
     @property
     def value(self):
         org_bytes = self.owner.memory.load(self.relative_addr, 4)
@@ -65,6 +71,8 @@ class IMAGE_REL_BASED_HIGHLOW(PEReloc):
 
 
 class IMAGE_REL_BASED_DIR64(PEReloc):
+    __slots__ = ()
+
     @property
     def value(self):
         org_bytes = self.owner.memory.load(self.relative_addr, 8)
@@ -82,6 +90,8 @@ class IMAGE_REL_BASED_DIR64(PEReloc):
 
 
 class IMAGE_REL_BASED_HIGH(PEReloc):
+    __slots__ = ()
+
     @property
     def value(self):
         org_bytes = self.owner.memory.load(self.relative_addr, 2)
@@ -93,6 +103,8 @@ class IMAGE_REL_BASED_HIGH(PEReloc):
 
 
 class IMAGE_REL_BASED_LOW(PEReloc):
+    __slots__ = ()
+
     @property
     def value(self):
         org_bytes = self.owner.memory.load(self.relative_addr, 2)

--- a/cle/backends/pe/relocation/mips.py
+++ b/cle/backends/pe/relocation/mips.py
@@ -4,11 +4,11 @@ from .pereloc import PEReloc
 
 
 class IMAGE_REL_BASED_MIPS_JMPADDR(PEReloc):
-    pass
+    __slots__ = ()
 
 
 class IMAGE_REL_BASED_MIPS_JMPADDR16(PEReloc):
-    pass
+    __slots__ = ()
 
 
 relocation_table_mips = {

--- a/cle/backends/pe/relocation/pereloc.py
+++ b/cle/backends/pe/relocation/pereloc.py
@@ -9,6 +9,8 @@ log = logging.getLogger(name=__name__)
 
 # Reference: https://msdn.microsoft.com/en-us/library/ms809762.aspx
 class PEReloc(Relocation):
+    __slots__ = ()
+
     AUTO_HANDLE_NONE = True
 
     def __init__(self, owner, symbol, addr, resolvewith=None):  # pylint: disable=unused-argument

--- a/cle/backends/pe/relocation/riscv.py
+++ b/cle/backends/pe/relocation/riscv.py
@@ -4,15 +4,15 @@ from .pereloc import PEReloc
 
 
 class IMAGE_REL_BASED_RISCV_HIGH20(PEReloc):
-    pass
+    __slots__ = ()
 
 
 class IMAGE_REL_BASED_RISCV_LOW12I(PEReloc):
-    pass
+    __slots__ = ()
 
 
 class IMAGE_REL_BASED_RISCV_LOW12S(PEReloc):
-    pass
+    __slots__ = ()
 
 
 relocation_table_riscv = {

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -30,11 +30,10 @@ class Relocation:
     :ivar resolved:         Whether the application of this relocation was successful
     """
 
-    __slots__ = ("owner", "arch", "symbol", "relative_addr", "resolvedby", "resolved", "resolvewith", "__weakref__")
+    __slots__ = ("owner", "symbol", "relative_addr", "resolvedby", "resolved", "resolvewith", "__weakref__")
 
     def __init__(self, owner: Backend, symbol: Symbol | None, relative_addr: int):
         self.owner = owner
-        self.arch = owner.arch
         self.symbol = symbol
         self.relative_addr = relative_addr
         self.resolvedby: Symbol | None = None
@@ -114,6 +113,10 @@ class Relocation:
         else:
             if not self.AUTO_HANDLE_NONE:
                 raise TypeError("Programming error: resolving symbol with None but does not have CAN_HANDLE_NONE set")
+
+    @property
+    def arch(self):
+        return self.owner.arch
 
     @property
     def rebased_addr(self):

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -30,6 +30,8 @@ class Relocation:
     :ivar resolved:         Whether the application of this relocation was successful
     """
 
+    __slots__ = ("owner", "arch", "symbol", "relative_addr", "resolvedby", "resolved", "resolvewith", "__weakref__")
+
     def __init__(self, owner: Backend, symbol: Symbol | None, relative_addr: int):
         self.owner = owner
         self.arch = owner.arch

--- a/cle/backends/tls/tls_object.py
+++ b/cle/backends/tls/tls_object.py
@@ -58,6 +58,8 @@ class ThreadManager:
 
 
 class InternalTLSRelocation(Relocation):
+    __slots__ = ("val",)
+
     AUTO_HANDLE_NONE = True
 
     def __init__(self, val, offset, owner):


### PR DESCRIPTION
Each Relocation class is reduced from ~170 bytes to ~96 bytes. On a PE file (`OUTLOOK.exe`) with 230k relocations, we save about 18 MB of RAM.