### PR TITLE
Simplify unnecessary return paths in relocation and loader modules

### DIFF
--- a/cle/backends/backend.py
+++ b/cle/backends/backend.py
@@ -93,8 +93,7 @@ class ExceptionHandling:
                 f"<ExceptionHandling@{self.start_addr:#x}-{self.start_addr + self.size:#x}: "
                 f"handler@{self.handler_addr:#x}>"
             )
-        else:
-            return f"<ExceptionHandling@{self.start_addr:#x}-{self.start_addr + self.size:#x}: no handler>"
+        return f"<ExceptionHandling@{self.start_addr:#x}-{self.start_addr + self.size:#x}: no handler>"
 
 
 class Backend:
@@ -465,8 +464,7 @@ class Backend:
         loadable = self.find_loadable_containing(addr)
         if loadable is not None:
             return loadable.addr_to_offset(addr)
-        else:
-            return None
+        return None
 
     def offset_to_addr(self, offset: int) -> int | None:
         if self.segments:

--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -386,8 +386,7 @@ class CoffRelocationSECTION(CoffRelocation):
     @property
     def value(self):
         assert isinstance(self.owner, Coff)
-        section_idx = 0  # FIXME
-        return section_idx
+        return 0  # FIXME
 
 
 class CoffRelocationSECREL(CoffRelocation):
@@ -402,8 +401,7 @@ class CoffRelocationSECREL(CoffRelocation):
     @property
     def value(self):
         assert isinstance(self.owner, Coff)
-        offset_to_symbol = 0  # FIXME
-        return offset_to_symbol
+        return 0  # FIXME
 
 
 RELOC_CLASSES: dict[IntEnum, dict[IntEnum, type[Relocation]]] = {
@@ -537,7 +535,7 @@ class Coff(Backend):
             if sym.SectionNumber > 0:
                 sym_addr = self._coff.sections[sym.SectionNumber - 1].PointerToRawData + sym.Value
                 return Symbol(self, name, sym_addr, 1, symbol_type)
-            elif sym.SectionNumber == 0:
+            if sym.SectionNumber == 0:
                 if produce_extern_symbols:
                     return Symbol(self, name, 0, sym.Value, symbol_type)
                 return None

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -342,7 +342,7 @@ class ELF(MetaELF):
                     return archinfo.ArchARMCortexM("Iend_LE")
             if reader.header.e_flags & 0x200:
                 return archinfo.ArchARMEL("Iend_LE" if reader.little_endian else "Iend_BE")
-            elif reader.header.e_flags & 0x400:
+            if reader.header.e_flags & 0x400:
                 return archinfo.ArchARMHF("Iend_LE" if reader.little_endian else "Iend_BE")
 
         try:

--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -441,10 +441,9 @@ class MetaELF(Backend):
         """
         if self.is_ppc64_abiv1:
             return self._ppc64_abiv1_initial_rtoc
-        elif self.is_ppc64_abiv2:
+        if self.is_ppc64_abiv2:
             return self._ppc64_abiv2_get_initial_rtoc()
-        else:
-            return None
+        return None
 
     def _ppc64_abiv1_entry_fix(self):
         """

--- a/cle/backends/elf/relocation/generic.py
+++ b/cle/backends/elf/relocation/generic.py
@@ -139,8 +139,7 @@ class GenericJumpslotReloc(ELFReloc):
     def value(self):
         if self.is_rela:
             return self.resolvedby.rebased_addr + self.addend
-        else:
-            return self.resolvedby.rebased_addr
+        return self.resolvedby.rebased_addr
 
 
 class GenericRelativeReloc(ELFReloc):

--- a/cle/backends/elf/relocation/ppc.py
+++ b/cle/backends/elf/relocation/ppc.py
@@ -51,8 +51,7 @@ class R_PPC_ADDR24(ELFReloc):
         A = self.addend
         S = self.resolvedby.rebased_addr
 
-        result = (S + A) >> 2
-        return result
+        return (S + A) >> 2
 
 
 class R_PPC_ADDR16(ELFReloc):
@@ -69,8 +68,7 @@ class R_PPC_ADDR16(ELFReloc):
         A = self.addend
         S = self.resolvedby.rebased_addr
 
-        result = S + A
-        return result
+        return S + A
 
 
 class R_PPC_ADDR16_LO(ELFReloc):
@@ -88,8 +86,7 @@ class R_PPC_ADDR16_LO(ELFReloc):
         S = self.resolvedby.rebased_addr
 
         result = S + A
-        result = result & PPC_HALF16
-        return result
+        return result & PPC_HALF16
 
     def relocate(self):
         if not self.resolved:
@@ -113,8 +110,7 @@ class R_PPC_ADDR16_HI(ELFReloc):
         S = self.resolvedby.rebased_addr
 
         result = (S + A) >> 16
-        result = result & PPC_HALF16
-        return result
+        return result & PPC_HALF16
 
     def relocate(self):
         if not self.resolved:
@@ -138,8 +134,7 @@ class R_PPC_ADDR16_HA(ELFReloc):  # pylint: disable=undefined-variable
         S = self.resolvedby.rebased_addr
 
         result = S + A
-        result = ((result >> 16) + (1 if (result & 0x8000) else 0)) & PPC_HALF16
-        return result
+        return ((result >> 16) + (1 if (result & 0x8000) else 0)) & PPC_HALF16
 
     def relocate(self):
         if not self.resolved:
@@ -162,8 +157,7 @@ class R_PPC_ADDR14(ELFReloc):
         A = self.addend
         S = self.resolvedby.rebased_addr
 
-        result = (S + A) >> 2
-        return result
+        return (S + A) >> 2
 
 
 class R_PPC_ADDR14_BRTAKEN(ELFReloc):
@@ -180,8 +174,7 @@ class R_PPC_ADDR14_BRTAKEN(ELFReloc):
         A = self.addend
         S = self.resolvedby.rebased_addr
 
-        result = (S + A) >> 2
-        return result
+        return (S + A) >> 2
 
 
 class R_PPC_ADDR14_BRNTAKEN(ELFReloc):
@@ -198,8 +191,7 @@ class R_PPC_ADDR14_BRNTAKEN(ELFReloc):
         A = self.addend
         S = self.resolvedby.rebased_addr
 
-        result = (S + A) >> 2
-        return result
+        return (S + A) >> 2
 
 
 class R_PPC_REL24(ELFReloc):
@@ -230,8 +222,7 @@ class R_PPC_REL24(ELFReloc):
         result = (S + A - P) >> 2
         result = (result << 2) & PPC_LOW24
         result = (A & ~PPC_LOW24) | result
-        result = result | PPC_BL_INST
-        return result
+        return result | PPC_BL_INST
 
 
 class R_PPC_REL14(ELFReloc):
@@ -251,8 +242,7 @@ class R_PPC_REL14(ELFReloc):
 
         result = (S + A - P) >> 2
         result = (result << 2) & PPC_LOW14
-        result = (A & ~PPC_LOW14) | result
-        return result
+        return (A & ~PPC_LOW14) | result
 
 
 class R_PPC_REL14_BRTAKEN(ELFReloc):
@@ -272,8 +262,7 @@ class R_PPC_REL14_BRTAKEN(ELFReloc):
 
         result = (S + A - P) >> 2
         result = (result << 2) & PPC_LOW14
-        result = (A & ~PPC_LOW14) | result
-        return result
+        return (A & ~PPC_LOW14) | result
 
 
 class R_PPC_REL14_BRNTAKEN(ELFReloc):
@@ -293,8 +282,7 @@ class R_PPC_REL14_BRNTAKEN(ELFReloc):
 
         result = (S + A - P) >> 2
         result = (result << 2) & PPC_LOW14
-        result = (A & ~PPC_LOW14) | result
-        return result
+        return (A & ~PPC_LOW14) | result
 
 
 class R_PPC_COPY(GenericCopyReloc):
@@ -335,8 +323,7 @@ class R_PPC_UADDR32(ELFReloc):
         A = self.addend
         S = self.resolvedby.rebased_addr
 
-        result = S + A
-        return result
+        return S + A
 
 
 class R_PPC_UADDR16(ELFReloc):
@@ -353,8 +340,7 @@ class R_PPC_UADDR16(ELFReloc):
         A = self.addend
         S = self.resolvedby.rebased_addr
 
-        result = S + A
-        return result
+        return S + A
 
 
 class R_PPC_REL32(ELFReloc):  # pylint: disable=undefined-variable
@@ -372,8 +358,7 @@ class R_PPC_REL32(ELFReloc):  # pylint: disable=undefined-variable
         A = self.addend
         S = self.resolvedby.rebased_addr
 
-        result = (S + A - P) & PPC_WORD32
-        return result
+        return (S + A - P) & PPC_WORD32
 
 
 class R_PPC_SECTOFF(ELFReloc):
@@ -390,8 +375,7 @@ class R_PPC_SECTOFF(ELFReloc):
         R = self.relative_addr
         A = self.addend
 
-        result = R + A
-        return result
+        return R + A
 
 
 class R_PPC_SECTOFF_LO(ELFReloc):
@@ -409,8 +393,7 @@ class R_PPC_SECTOFF_LO(ELFReloc):
         A = self.addend
 
         result = R + A
-        result = result & PPC_HALF16
-        return result
+        return result & PPC_HALF16
 
 
 class R_PPC_SECTOFF_HI(ELFReloc):
@@ -428,8 +411,7 @@ class R_PPC_SECTOFF_HI(ELFReloc):
         A = self.addend
 
         result = (R + A) >> 16
-        result = result & PPC_HALF16
-        return result
+        return result & PPC_HALF16
 
 
 class R_PPC_SECTOFF_HA(ELFReloc):
@@ -447,8 +429,7 @@ class R_PPC_SECTOFF_HA(ELFReloc):
         A = self.addend
 
         result = R + A
-        result = ((result >> 16) + (1 if (result & 0x8000) else 0)) & PPC_HALF16
-        return result
+        return ((result >> 16) + (1 if (result & 0x8000) else 0)) & PPC_HALF16
 
 
 class R_PPC_ADDR30(ELFReloc):
@@ -466,8 +447,7 @@ class R_PPC_ADDR30(ELFReloc):
         A = self.addend
         P = self.rebased_addr
 
-        result = (S + A - P) >> 2
-        return result
+        return (S + A - P) >> 2
 
 
 class R_PPC_DTPMOD32(GenericTLSModIdReloc):

--- a/cle/backends/elf/symbol_type.py
+++ b/cle/backends/elf/symbol_type.py
@@ -108,23 +108,22 @@ class ELFSymbolType(SymbolSubType):
         if self is ELFSymbolType.STT_NOTYPE:
             return SymbolType.TYPE_NONE
 
-        elif self in [ELFSymbolType.STT_FUNC, ELFSymbolType.STT_GNU_IFUNC]:
+        if self in [ELFSymbolType.STT_FUNC, ELFSymbolType.STT_GNU_IFUNC]:
             return SymbolType.TYPE_FUNCTION
 
-        elif self in [ELFSymbolType.STT_OBJECT, ELFSymbolType.STT_COMMON]:
+        if self in [ELFSymbolType.STT_OBJECT, ELFSymbolType.STT_COMMON]:
             return SymbolType.TYPE_OBJECT
 
-        elif self is ELFSymbolType.STT_SECTION:
+        if self is ELFSymbolType.STT_SECTION:
             return SymbolType.TYPE_SECTION
 
-        elif self is ELFSymbolType.STT_TLS:
+        if self is ELFSymbolType.STT_TLS:
             return SymbolType.TYPE_TLS_OBJECT
 
-        elif self is ELFSymbolType.STT_GNU_IFUNC:
+        if self is ELFSymbolType.STT_GNU_IFUNC:
             return SymbolType.TYPE_FUNCTION
 
-        else:
-            return SymbolType.TYPE_OTHER
+        return SymbolType.TYPE_OTHER
 
 
 def __ELFSymbolTypeArchParser(cls, value):
@@ -139,8 +138,7 @@ def __ELFSymbolTypeArchParser(cls, value):
     """
     if isinstance(value, int):
         return super(ELFSymbolType, cls).__new__(cls, (value, None))
-    else:
-        return super(ELFSymbolType, cls).__new__(cls, value)
+    return super(ELFSymbolType, cls).__new__(cls, value)
 
 
 setattr(ELFSymbolType, "__new__", __ELFSymbolTypeArchParser)

--- a/cle/backends/elf/variable_type.py
+++ b/cle/backends/elf/variable_type.py
@@ -39,15 +39,15 @@ class VariableType:
         """
         if die.tag == "DW_TAG_base_type":
             return BaseType.read_from_die(die, elf_object)
-        elif die.tag == "DW_TAG_pointer_type":
+        if die.tag == "DW_TAG_pointer_type":
             return PointerType.read_from_die(die, elf_object)
-        elif die.tag == "DW_TAG_structure_type":
+        if die.tag == "DW_TAG_structure_type":
             return StructType.read_from_die(die, elf_object)
-        elif die.tag == "DW_TAG_array_type":
+        if die.tag == "DW_TAG_array_type":
             return ArrayType.read_from_die(die, elf_object)
-        elif die.tag == "DW_TAG_typedef":
+        if die.tag == "DW_TAG_typedef":
             return TypedefType.read_from_die(die, elf_object)
-        elif die.tag == "DW_TAG_union_type":
+        if die.tag == "DW_TAG_union_type":
             return UnionType.read_from_die(die, elf_object)
         return None
 

--- a/cle/backends/externs/__init__.py
+++ b/cle/backends/externs/__init__.py
@@ -219,18 +219,16 @@ class ExternObject(Backend):
         if next_start >= limit:
             if self._is_mapped:
                 return None
+            if tls:
+                self.tls_data_size += next_start - limit
             else:
-                if tls:
-                    self.tls_data_size += next_start - limit
-                else:
-                    self.map_size += next_start - limit
+                self.map_size += next_start - limit
 
         if tls:
             self.tls_next_addr = next_start
             return addr
-        else:
-            self.next_addr = next_start
-            return addr
+        self.next_addr = next_start
+        return addr
 
     @property
     def max_addr(self):
@@ -247,13 +245,12 @@ class ExternObject(Backend):
             # the world.
             self._import_symbols[name] = sym
             return sym
-        else:
-            sym = self._import_symbols[name]
-            if sym.type != sym_type:
-                raise CLEOperationError(
-                    "Created the same extern import %s with two different types. Something isn't right!"
-                )
-            return sym
+        sym = self._import_symbols[name]
+        if sym.type != sym_type:
+            raise CLEOperationError(
+                "Created the same extern import %s with two different types. Something isn't right!"
+            )
+        return sym
 
     def _init_symbol(self, symbol):
         if isinstance(symbol, SimData):

--- a/cle/backends/externs/simdata/simdata.py
+++ b/cle/backends/externs/simdata/simdata.py
@@ -66,7 +66,7 @@ def lookup(name: str, libname) -> type[SimData] | None:
     for simdata_cls in registered_data[name]:
         if type(libname) is type(simdata_cls.libname) is str and simdata_cls.libname.startswith(libname):  # noqa: E721
             return simdata_cls
-        elif simdata_cls is None or libname is None:
+        if simdata_cls is None or libname is None:
             weak_option = simdata_cls
 
     return weak_option

--- a/cle/backends/java/soot.py
+++ b/cle/backends/java/soot.py
@@ -115,8 +115,7 @@ class Soot(Backend):
         except KeyError:
             if none_if_missing:
                 return None
-            else:
-                raise CLEError(f'Class "{cls_name}" does not exist.')
+            raise CLEError(f'Class "{cls_name}" does not exist.')
 
     def get_soot_method(self, thing, class_name=None, params=(), none_if_missing=False):
         """
@@ -162,8 +161,7 @@ class Soot(Backend):
         except CLEError:
             if none_if_missing:
                 return None
-            else:
-                raise
+            raise
 
         # Step 3: Get all methods matching the description
         methods = [
@@ -175,12 +173,11 @@ class Soot(Backend):
         if not methods:
             if none_if_missing:
                 return None
-            else:
-                raise CLEError(
-                    "Method with description {} does not exist in class {}.".format(
-                        method_description, method_description["class_name"]
-                    )
+            raise CLEError(
+                "Method with description {} does not exist in class {}.".format(
+                    method_description, method_description["class_name"]
                 )
+            )
 
         if len(methods) > 1:
             # Warn if we found several matching methods

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -67,8 +67,7 @@ class SymbolList(SortedKeyList):
     def get_by_name_and_ordinal(self, name: str, ordinal: int, include_stab=False) -> list[AbstractMachOSymbol]:
         if include_stab:
             return self._symbol_cache[(name, ordinal)]
-        else:
-            return [symbol for symbol in self._symbol_cache[(name, ordinal)] if not symbol.is_stab]
+        return [symbol for symbol in self._symbol_cache[(name, ordinal)] if not symbol.is_stab]
 
 
 # pylint: enable =abstract-method
@@ -472,22 +471,20 @@ class MachO(Backend):
             if magic in [MachO.MH_MAGIC_64, MachO.MH_MAGIC]:
                 log.debug("Detected little-endian")
                 return "<"
-            elif magic in [MachO.MH_CIGAM, MachO.MH_CIGAM_64]:
+            if magic in [MachO.MH_CIGAM, MachO.MH_CIGAM_64]:
                 log.debug("Detected big-endian")
                 return ">"
-            else:
-                log.debug("Not a mach-o file")
-                raise CLECompatibilityError()
+            log.debug("Not a mach-o file")
+            raise CLECompatibilityError()
         else:
             if magic in [MachO.MH_MAGIC_64, MachO.MH_MAGIC]:
                 log.debug("Detected big-endian")
                 return ">"
-            elif magic in [MachO.MH_CIGAM_64, MachO.MH_CIGAM]:
+            if magic in [MachO.MH_CIGAM_64, MachO.MH_CIGAM]:
                 log.debug("Detected little-endian")
                 return "<"
-            else:
-                log.debug("Not a mach-o file")
-                raise CLECompatibilityError()
+            log.debug("Not a mach-o file")
+            raise CLECompatibilityError()
 
     def do_binding(self):
         # Perform binding

--- a/cle/backends/macho/structs.py
+++ b/cle/backends/macho/structs.py
@@ -178,8 +178,7 @@ class Arm64e(ctypes.Union):
         addend19 = self.bind.addend
         if addend19 & 0x40000:
             return addend19 | 0xFFFFFFFFFFFC0000
-        else:
-            return addend19
+        return addend19
 
     @property
     def unpack_target(self):
@@ -295,24 +294,18 @@ class ChainedFixupPointerOnDisk(ctypes.Union):
                 if self.arm64e.authBind.auth:
                     if pointer_format == DyldChainedPtrFormats.DYLD_CHAINED_PTR_ARM64E_USERLAND24:
                         return self.arm64e.authBind24.ordinal, 0
-                    else:
-                        return self.arm64e.authBind.ordinal, 0
-                else:
-                    if pointer_format == DyldChainedPtrFormats.DYLD_CHAINED_PTR_ARM64E_USERLAND24:
-                        return self.arm64e.bind24.ordinal, self.arm64e.sign_extended_addend
-                    else:
-                        return self.arm64e.bind.ordinal, self.arm64e.sign_extended_addend
-            else:
-                return None
-        elif Generic64.check_valid_pointer_format(pointer_format):
+                    return self.arm64e.authBind.ordinal, 0
+                if pointer_format == DyldChainedPtrFormats.DYLD_CHAINED_PTR_ARM64E_USERLAND24:
+                    return self.arm64e.bind24.ordinal, self.arm64e.sign_extended_addend
+                return self.arm64e.bind.ordinal, self.arm64e.sign_extended_addend
+            return None
+        if Generic64.check_valid_pointer_format(pointer_format):
             # https://github.com/apple-opensource/dyld/blob/852.2/dyld3/MachOLoaded.cpp#L1126-L1132
             if self.generic64.bind.bind:
                 return self.generic64.bind.ordinal, self.generic64.bind.addend
-            else:
-                return None
+            return None
 
-        else:
-            raise NotImplementedError(f"Not yet supported pointer format {pointer_format}")
+        raise NotImplementedError(f"Not yet supported pointer format {pointer_format}")
 
     def isRebase(
         self, pointer_format: DyldChainedPtrFormats, preferredLoadAddress: MemoryPointer
@@ -330,32 +323,28 @@ class ChainedFixupPointerOnDisk(ctypes.Union):
             # https://github.com/apple-opensource/dyld/blob/852.2/dyld3/MachOLoaded.cpp#L1049-L1067
             if self.arm64e.bind.bind:
                 return False
-            else:
-                if self.arm64e.authRebase.auth:
-                    return self.arm64e.authRebase.target
-                else:
-                    targetRuntimeOffset = self.arm64e.unpack_target
-                    if pointer_format in [
-                        DyldChainedPtrFormats.DYLD_CHAINED_PTR_ARM64E,
-                        DyldChainedPtrFormats.DYLD_CHAINED_PTR_ARM64E_FIRMWARE,
-                    ]:
-                        targetRuntimeOffset -= preferredLoadAddress
+            if self.arm64e.authRebase.auth:
+                return self.arm64e.authRebase.target
+            targetRuntimeOffset = self.arm64e.unpack_target
+            if pointer_format in [
+                DyldChainedPtrFormats.DYLD_CHAINED_PTR_ARM64E,
+                DyldChainedPtrFormats.DYLD_CHAINED_PTR_ARM64E_FIRMWARE,
+            ]:
+                targetRuntimeOffset -= preferredLoadAddress
 
-                    return targetRuntimeOffset
+            return targetRuntimeOffset
 
-        elif Generic64.check_valid_pointer_format(pointer_format):
+        if Generic64.check_valid_pointer_format(pointer_format):
             # https://github.com/apple-opensource/dyld/blob/852.2/dyld3/MachOLoaded.cpp#L1068-L1076
             rebase = self.generic64.rebase
             if rebase.bind:
                 # Then this wasn't actually a rebase
                 return False
-            else:
-                targetRuntimeOffset = rebase.unpackedTarget
-                if pointer_format == DyldChainedPtrFormats.DYLD_CHAINED_PTR_64:
-                    targetRuntimeOffset -= preferredLoadAddress
-                return targetRuntimeOffset
-        else:
-            raise NotImplementedError(f"Not yet supported pointer format {pointer_format}")
+            targetRuntimeOffset = rebase.unpackedTarget
+            if pointer_format == DyldChainedPtrFormats.DYLD_CHAINED_PTR_64:
+                targetRuntimeOffset -= preferredLoadAddress
+            return targetRuntimeOffset
+        raise NotImplementedError(f"Not yet supported pointer format {pointer_format}")
 
 
 # DYLD_CHAINED_PTR_BASE: Dict[DyldChainedPtrFormats, Type[ChainedFixupPointerOnDisk]] = {

--- a/cle/backends/macho/symbol.py
+++ b/cle/backends/macho/symbol.py
@@ -146,30 +146,26 @@ class SymbolTableSymbol(AbstractMachOSymbol):
             if LIBRARY_ORDINAL_DYN_LOOKUP == self.library_ordinal:
                 log.warning("LIBRARY_ORDINAL_DYN_LOOKUP found, cannot handle")
                 return None
-            else:
-                return self.owner.imported_libraries[self.library_ordinal]
+            return self.owner.imported_libraries[self.library_ordinal]
         return None
 
     @property
     def segment_name(self):
         if self.sym_type == SYMBOL_TYPE_SECT:
             return self.owner.sections_by_ordinal[self.n_sect].segname
-        else:
-            return None
+        return None
 
     @property
     def section_name(self):
         if self.sym_type == SYMBOL_TYPE_SECT:
             return self.owner.sections_by_ordinal[self.n_sect].sectname
-        else:
-            return None
+        return None
 
     @property
     def value(self):
         if self.sym_type == SYMBOL_TYPE_INDIR:
             return 0
-        else:
-            return self.n_value
+        return self.n_value
 
     @property
     def referenced_symbol_index(self):
@@ -177,8 +173,7 @@ class SymbolTableSymbol(AbstractMachOSymbol):
         symbol's name"""
         if self.sym_type == SYMBOL_TYPE_INDIR:
             return self.n_value
-        else:
-            return None
+        return None
 
     @property
     def is_weak(self):
@@ -208,8 +203,7 @@ class SymbolTableSymbol(AbstractMachOSymbol):
     def sym_type(self):  # cannot be called "type" as that shadows a builtin variable from Symbol
         if self.is_stab:
             return self.n_type
-        else:
-            return self.n_type & 0x0E
+        return self.n_type & 0x0E
 
     @property
     def is_common(self):
@@ -286,7 +280,7 @@ class DyldBoundSymbol(AbstractMachOSymbol):
         if BIND_SPECIAL_DYLIB_FLAT_LOOKUP == self.lib_ordinal:
             log.warning("BIND_SPECIAL_DYLIB_FLAT_LOOKUP found, cannot handle")
             return None
-        elif BIND_SPECIAL_DYLIB_WEAK_LOOKUP == self.lib_ordinal:
+        if BIND_SPECIAL_DYLIB_WEAK_LOOKUP == self.lib_ordinal:
             return None
         try:
             return self.owner.imported_libraries[self.lib_ordinal]

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -1000,14 +1000,11 @@ class PE(Backend):
     def _make_reloc(self, addr, reloc_type, symbol=None, next_rva=None, resolvewith=None):
         # Handle special cases first
         if reloc_type == 0:  # 0 simply means "ignore this relocation"
-            reloc = IMAGE_REL_BASED_ABSOLUTE(owner=self, symbol=symbol, addr=addr, resolvewith=resolvewith)
-            return reloc
+            return IMAGE_REL_BASED_ABSOLUTE(owner=self, symbol=symbol, addr=addr, resolvewith=resolvewith)
         if reloc_type is None:  # for DLL imports
-            reloc = DllImport(owner=self, symbol=symbol, addr=addr, resolvewith=resolvewith)
-            return reloc
+            return DllImport(owner=self, symbol=symbol, addr=addr, resolvewith=resolvewith)
         if next_rva is not None:
-            reloc = IMAGE_REL_BASED_HIGHADJ(owner=self, addr=addr, next_rva=next_rva)
-            return reloc
+            return IMAGE_REL_BASED_HIGHADJ(owner=self, addr=addr, next_rva=next_rva)
 
         # Handle all the normal base relocations
         RelocClass = get_relocation(self.arch.name, reloc_type)

--- a/cle/backends/pe/relocation/generic.py
+++ b/cle/backends/pe/relocation/generic.py
@@ -54,8 +54,7 @@ class IMAGE_REL_BASED_HIGHADJ(PEReloc):
         org_value = struct.unpack("<H", org_bytes)[0]
         adjusted_value = (org_value << 16) + self.next_rva
         adjusted_value = (AT.from_lva(adjusted_value, self.owner).to_mva() & 0xFFFF0000) >> 16
-        adjusted_bytes = struct.pack("<I", adjusted_value)
-        return adjusted_bytes
+        return struct.pack("<I", adjusted_value)
 
 
 class IMAGE_REL_BASED_HIGHLOW(PEReloc):
@@ -66,8 +65,7 @@ class IMAGE_REL_BASED_HIGHLOW(PEReloc):
         org_bytes = self.owner.memory.load(self.relative_addr, 4)
         org_value = struct.unpack("<I", org_bytes)[0]
         rebased_value = AT.from_lva(org_value, self.owner).to_mva()
-        rebased_bytes = struct.pack("<I", rebased_value & 0xFFFFFFFF)
-        return rebased_bytes
+        return struct.pack("<I", rebased_value & 0xFFFFFFFF)
 
 
 class IMAGE_REL_BASED_DIR64(PEReloc):
@@ -85,8 +83,7 @@ class IMAGE_REL_BASED_DIR64(PEReloc):
                 self.owner,
             )
             return None
-        rebased_bytes = struct.pack("<Q", rebased_value)
-        return rebased_bytes
+        return struct.pack("<Q", rebased_value)
 
 
 class IMAGE_REL_BASED_HIGH(PEReloc):
@@ -98,8 +95,7 @@ class IMAGE_REL_BASED_HIGH(PEReloc):
         org_value = struct.unpack("<H", org_bytes)[0]
         rebased_value = AT.from_lva(org_value, self.owner).to_mva()
         adjusted_value = (rebased_value >> 16) & 0xFFFF
-        adjusted_bytes = struct.pack("<H", adjusted_value)
-        return adjusted_bytes
+        return struct.pack("<H", adjusted_value)
 
 
 class IMAGE_REL_BASED_LOW(PEReloc):
@@ -111,8 +107,7 @@ class IMAGE_REL_BASED_LOW(PEReloc):
         org_value = struct.unpack("<H", org_bytes)[0]
         rebased_value = AT.from_lva(org_value, self.owner).to_mva()
         adjusted_value = rebased_value & 0x0000FFFF
-        adjusted_bytes = struct.pack("<H", adjusted_value)
-        return adjusted_bytes
+        return struct.pack("<H", adjusted_value)
 
 
 relocation_table_generic = {

--- a/cle/backends/pe/symbolserver.py
+++ b/cle/backends/pe/symbolserver.py
@@ -42,7 +42,7 @@ class PDBInfo:
             # Check for RSDS signature (PDB 7.0 format)
             if debug_entry.entry.name == "CV_INFO_PDB70":  # type: ignore
                 return cls._parse_rsds(debug_entry.entry)
-            elif debug_entry.entry.name == "CV_INFO_PDB20":  # type: ignore
+            if debug_entry.entry.name == "CV_INFO_PDB20":  # type: ignore
                 return cls._parse_nb10(debug_entry.entry)
 
         return None

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -69,7 +69,7 @@ class Relocation:
                 if not symbol.is_weak:
                     self.resolve(symbol, extern_object=extern_object)
                     return
-                elif weak_result is None:
+                if weak_result is None:
                     weak_result = symbol
             # TODO: Was this check obsolted by the addition of is_static?
             # I think right now symbol.is_import = !symbol.is_export
@@ -77,7 +77,7 @@ class Relocation:
                 if not symbol.is_weak:
                     self.resolve(symbol, extern_object=extern_object)
                     return
-                elif weak_result is None:
+                if weak_result is None:
                     weak_result = symbol
 
         if weak_result is not None:

--- a/cle/backends/symbol.py
+++ b/cle/backends/symbol.py
@@ -78,8 +78,7 @@ class Symbol:
     def __repr__(self):
         if self.is_import:
             return f'<Symbol "{self.name}" in {self.owner.binary_basename} (import)>'
-        else:
-            return f'<Symbol "{self.name}" in {self.owner.binary_basename} at {self.rebased_addr:#x}>'
+        return f'<Symbol "{self.name}" in {self.owner.binary_basename} at {self.rebased_addr:#x}>'
 
     def resolve(self, obj):
         self.resolved = True

--- a/cle/backends/tls/elf_tls.py
+++ b/cle/backends/tls/elf_tls.py
@@ -49,8 +49,7 @@ class ELFThreadManager(ThreadManager):
     def _thread_cls(self):
         if self.arch.elf_tls.variant == 1:
             return ELFTLSObjectV1
-        else:
-            return ELFTLSObjectV2
+        return ELFTLSObjectV2
 
 
 class ELFTLSObject(TLSObject):

--- a/cle/backends/tls/pe_tls.py
+++ b/cle/backends/tls/pe_tls.py
@@ -123,8 +123,7 @@ class PETLSObject(TLSObject):
         """
         if 0 <= tls_idx < self.used_modules:
             return self.memory.unpack_word(tls_idx * self.arch.bytes)
-        else:
-            raise IndexError("TLS index out of range")
+        raise IndexError("TLS index out of range")
 
     @property
     def max_addr(self):

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -243,8 +243,7 @@ class Loader:
     def __repr__(self):
         if self._main_binary_stream is None and self._main_binary_path is not None:
             return f"<Loaded {os.path.basename(self._main_binary_path)}, maps [{self.min_addr:#x}:{self.max_addr:#x}]>"
-        else:
-            return f"<Loaded from stream, maps [{self.min_addr:#x}:{self.max_addr:#x}]>"
+        return f"<Loaded from stream, maps [{self.min_addr:#x}:{self.max_addr:#x}]>"
 
     @property
     def max_addr(self) -> int:
@@ -453,11 +452,10 @@ class Loader:
                     self._last_object = obj_
                     return obj_
                 return None
-            elif isinstance(obj_.memory, str):
+            if isinstance(obj_.memory, str):
                 self._last_object = obj_
                 return obj_
-            else:
-                raise CLEError(f"Unsupported memory type {type(obj_.memory)}")
+            raise CLEError(f"Unsupported memory type {type(obj_.memory)}")
 
         # check the cache first
         if (
@@ -589,7 +587,7 @@ class Loader:
             # Soot address
             # TODO launch this shit into the sun
             return thing.method.fullname  # type: ignore
-        elif isinstance(thing, int):
+        if isinstance(thing, int):
             # address
             if fuzzy:
                 so = self.find_object_containing(thing)
@@ -969,7 +967,7 @@ class Loader:
         # STEP 1: identify file
         if isinstance(spec, Backend):
             return spec
-        elif hasattr(spec, "read") and hasattr(spec, "seek"):
+        if hasattr(spec, "read") and hasattr(spec, "seek"):
             binary_stream = spec
             binary = None
             close = False
@@ -1247,8 +1245,7 @@ class Loader:
             return None
         if basefinal:
             return os.path.join(dirname, basefinal) + suffix
-        else:
-            return None
+        return None
 
     def _possible_idents(self, spec, lowercase=False):
         """
@@ -1318,12 +1315,11 @@ class Loader:
     def _backend_resolver(backend: str | type[Backend], default: T | None = None) -> type[Backend] | T | None:
         if isinstance(backend, type) and issubclass(backend, Backend):
             return backend
-        elif backend in ALL_BACKENDS:
+        if backend in ALL_BACKENDS:
             return ALL_BACKENDS[backend]
-        elif backend is None:
+        if backend is None:
             return default
-        else:
-            raise CLEError(f"Invalid backend: {backend}")
+        raise CLEError(f"Invalid backend: {backend}")
 
     #
     # Memory data loading methods

--- a/cle/memory.py
+++ b/cle/memory.py
@@ -351,7 +351,6 @@ class Clemory(ClemoryBase):
             "max_addr": self.max_addr,
         }
 
-
     def __setstate__(self, s):
         self._arch = s["_arch"]
         self._backers = s["_backers"]

--- a/cle/memory.py
+++ b/cle/memory.py
@@ -326,13 +326,12 @@ class Clemory(ClemoryBase):
         # Fast path
         if self.consecutive:
             return self.min_addr <= k < self.max_addr
-        else:
-            # Check if this is an empty Clemory instance
-            if not self._backers:
-                return False
-            # Check if it is out of the memory range
-            if k < self.min_addr or k >= self.max_addr:
-                return False
+        # Check if this is an empty Clemory instance
+        if not self._backers:
+            return False
+        # Check if it is out of the memory range
+        if k < self.min_addr or k >= self.max_addr:
+            return False
 
         try:
             self.__getitem__(k)
@@ -342,7 +341,7 @@ class Clemory(ClemoryBase):
             return True
 
     def __getstate__(self):
-        s = {
+        return {
             "_arch": self._arch,
             "_backers": self._backers,
             "_pointer": self._pointer,
@@ -352,7 +351,6 @@ class Clemory(ClemoryBase):
             "max_addr": self.max_addr,
         }
 
-        return s
 
     def __setstate__(self, s):
         self._arch = s["_arch"]


### PR DESCRIPTION
## Summary

**Repo health:** 53/100

Our analysis found **2,209 format/lint issues** (under ShipGate's stricter rules) and about **57 refactoring opportunities** across the reviewed scope. Security scans were clean; code duplication is modest (~2.5%); cyclomatic complexity and maintainability index flag several modules; structural refactor suggestions remain in relocation and binding helpers.

This pull request is a **sample** of those findings — **23 files, ~129 focused line changes** — and is not a full format pass or refactor cleanup.

## What you are doing right

- No secrets detected and no high-severity security patterns in scope (gitleaks, bandit, semgrep clean).
- Code duplication is modest — ~2.5% (jscpd), just above the 2% threshold.
- No unused functions or modules flagged by dead-code scanners in scope.
- Your declared ruff configuration (E, F, I, TID, UP at line-length 120) already passes cleanly on the main package.

## What you could improve

**Refactoring (included in example PR)**

- About **57** structural refactor opportunities — unnecessary return assignments (RET504) and redundant `else` branches after `return` (RET505) across ELF, PE, Mach-O, and loader modules. **This PR simplifies 98 of those patterns in 23 files.**

**Maintainability & complexity (follow-up)**

- P95 cyclomatic complexity (10) exceeds the configured ceiling (7); **75** functions/blocks flagged by complexity metrics.
- Several modules have low maintainability index (rank C) — e.g. binding helpers and large backend parsers.

**Dependencies (follow-up)**

- `pyelftools` and `pyxbe` are declared but reported unused by deptry (may be optional/runtime paths).

**Duplication (follow-up)**

- jscpd reports ~2.5% duplicate code — slightly above the 2% threshold; repeated string literals in Mach-O binding and loader utilities.

**Lint / style (follow-up)**

- Under ShipGate's bundled ruff profile (100-char lines), ~2,100 style findings remain — mostly line length (E501), pathlib migration (PTH), and naming conventions in tests. Your project ruff config intentionally uses 120-char lines, so many are policy differences rather than bugs.

## Changes

- `cle/backends/elf/relocation/ppc.py` — collapse unnecessary `result` temporaries before return (20 sites).
- `cle/backends/macho/structs.py`, `cle/backends/macho/symbol.py`, `cle/backends/macho/macho.py` — RET505/RET504 simplifications in Mach-O parsing.
- `cle/backends/pe/pe.py`, `cle/backends/pe/relocation/generic.py` — remove unnecessary relocation temporaries.
- `cle/backends/coff.py`, `cle/backends/backend.py`, `cle/backends/relocation.py` — simplify return paths in COFF/PE relocation helpers.
- `cle/loader.py`, `cle/memory.py` — streamline loader and memory serialization returns.
- `cle/backends/elf/metaelf.py`, `cle/backends/elf/symbol_type.py`, `cle/backends/elf/variable_type.py` — ELF symbol/type helpers.
- `cle/backends/externs/__init__.py`, `cle/backends/java/soot.py`, `cle/backends/tls/*.py` — minor return-path cleanup in extern and TLS backends.
---
*Review summary produced with [ShipGate](https://github.com/inquilabee/shipgate) — a policy-first quality orchestrator that runs linters, formatters, security scanners, and refactor checks from one catalog. This PR used `check` + `refactor check --strict` to find issues; [docs](https://inquilabee.github.io/shipgate/).*