### PR TITLE
TE: Fix section metadata, entry point, and AArch64 loading

### DIFF
--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -53,6 +53,7 @@ class IMAGE_SCN(IntFlag):
     Section Flags (Characteristics field)
     """
 
+    MEM_DISCARDABLE = 0x02000000
     MEM_EXECUTE = 0x20000000
     MEM_READ = 0x40000000
     MEM_WRITE = 0x80000000

--- a/cle/backends/te.py
+++ b/cle/backends/te.py
@@ -56,22 +56,19 @@ ARCH_MAPPING = {
 
 class TESection(Section):
     """
-    A section of a Terse Executable image.
-
-    A TE section header is a COFF section header, so its permissions live in the ``IMAGE_SCN`` bits of the
-    characteristics field.
+    A section of a Terse Executable image. Its header is a COFF section header, so its permissions live in the
+    ``IMAGE_SCN`` bits of the characteristics field.
     """
 
     def __init__(self, section_header: SectionHeaderType, linked_base: int, stripped_offset: int):
         super().__init__(
             section_header.section_name.rstrip(b"\0").decode(),
-            # pointer_to_raw_data indexes the PE file the image was stripped down from, not the TE file itself
+            # pointer_to_raw_data indexes the pre-strip PE file, not the TE file
             section_header.pointer_to_raw_data - stripped_offset,
             section_header.virtual_address + linked_base,
             section_header.physical_address_virtual_size,
         )
-        # the base class assumes filesize == memsize; a TE section is only backed by size_of_raw_data bytes and the
-        # rest of its virtual size is zero-filled
+        # the base class assumes filesize == memsize; only size_of_raw_data bytes are backed
         self.filesize = section_header.size_of_raw_data
         self.characteristics = section_header.characteristics
 
@@ -89,7 +86,7 @@ class TESection(Section):
 
     @property
     def only_contains_uninitialized_data(self):
-        # a section with no raw data is zero-filled whether or not the linker set IMAGE_SCN.CNT_UNINITIALIZED_DATA
+        # zero-filled whether or not the linker set IMAGE_SCN.CNT_UNINITIALIZED_DATA
         return self.filesize == 0
 
 
@@ -119,7 +116,7 @@ class TE(Backend):
 
         stripped_offset = self.header.stripped_size - HEADER.size
         self.linked_base = self.mapped_base = self.header.image_base + stripped_offset
-        # address_of_entry_point is an RVA in the same space as the section virtual addresses below
+        # an RVA, in the same space as the section virtual addresses below
         self._entry = self.linked_base + self.header.address_of_entry_point
 
         has_relocs = False

--- a/cle/backends/te.py
+++ b/cle/backends/te.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 import archinfo
 
 from . import Backend, Section, register_backend
+from .coff import IMAGE_SCN
 
 HEADER = struct.Struct("<HHBBHIIQIIII")
 SECTION_HEADER = struct.Struct("<8sIIIIIIHHI")
@@ -49,7 +50,47 @@ ARCH_MAPPING = {
     0x8664: "X64",
     0x01C0: "ARM Cortex-M",
     0x01C2: "ARM",
+    0xAA64: "AARCH64",
 }
+
+
+class TESection(Section):
+    """
+    A section of a Terse Executable image.
+
+    A TE section header is a COFF section header, so its permissions live in the ``IMAGE_SCN`` bits of the
+    characteristics field.
+    """
+
+    def __init__(self, section_header: SectionHeaderType, linked_base: int, stripped_offset: int):
+        super().__init__(
+            section_header.section_name.rstrip(b"\0").decode(),
+            # pointer_to_raw_data indexes the PE file the image was stripped down from, not the TE file itself
+            section_header.pointer_to_raw_data - stripped_offset,
+            section_header.virtual_address + linked_base,
+            section_header.physical_address_virtual_size,
+        )
+        # the base class assumes filesize == memsize; a TE section is only backed by size_of_raw_data bytes and the
+        # rest of its virtual size is zero-filled
+        self.filesize = section_header.size_of_raw_data
+        self.characteristics = section_header.characteristics
+
+    @property
+    def is_readable(self):
+        return self.characteristics & IMAGE_SCN.MEM_READ != 0
+
+    @property
+    def is_writable(self):
+        return self.characteristics & IMAGE_SCN.MEM_WRITE != 0
+
+    @property
+    def is_executable(self):
+        return self.characteristics & IMAGE_SCN.MEM_EXECUTE != 0
+
+    @property
+    def only_contains_uninitialized_data(self):
+        # a section with no raw data is zero-filled whether or not the linker set IMAGE_SCN.CNT_UNINITIALIZED_DATA
+        return self.filesize == 0
 
 
 class TE(Backend):
@@ -76,27 +117,27 @@ class TE(Backend):
 
         self.set_arch(archinfo.arch_from_id(ARCH_MAPPING[self.header.machine]))
 
-        offset_offset = self.header.stripped_size - HEADER.size
-        self.linked_base = self.mapped_base = self.header.image_base + offset_offset
+        stripped_offset = self.header.stripped_size - HEADER.size
+        self.linked_base = self.mapped_base = self.header.image_base + stripped_offset
+        # address_of_entry_point is an RVA in the same space as the section virtual addresses below
+        self._entry = self.linked_base + self.header.address_of_entry_point
 
         has_relocs = False
         for section_header in self.section_headers:
-            region = Section(
-                section_header.section_name.rstrip(b"\0").decode(),
-                section_header.pointer_to_raw_data,
-                section_header.virtual_address + self.linked_base,
-                section_header.physical_address_virtual_size,
-            )
-            self._sections.append(region)
+            section = TESection(section_header, self.linked_base, stripped_offset)
+            self._sections.append(section)
 
-            if section_header.characteristics & 0x02000000 != 0 or section_header.physical_address_virtual_size == 0:
+            if (
+                section_header.characteristics & IMAGE_SCN.MEM_DISCARDABLE != 0
+                or section_header.physical_address_virtual_size == 0
+            ):
                 # discard or no data
                 continue
-            self._binary_stream.seek(section_header.pointer_to_raw_data - offset_offset)
-            data = self._binary_stream.read(section_header.size_of_raw_data)
-            assert len(data) == section_header.size_of_raw_data
-            if section_header.size_of_raw_data < section_header.physical_address_virtual_size:
-                data = data.ljust(section_header.physical_address_virtual_size - section_header.size_of_raw_data, b"\0")
+            self._binary_stream.seek(section.offset)
+            data = self._binary_stream.read(section.filesize)
+            assert len(data) == section.filesize
+            # zero-fill up to the virtual size; ljust takes the total width, not the shortfall
+            data = data.ljust(section.memsize, b"\0")
             self.memory.add_backer(section_header.virtual_address, data)
 
             if section_header.number_of_relocations != 0:

--- a/cle/backends/te.py
+++ b/cle/backends/te.py
@@ -56,8 +56,7 @@ ARCH_MAPPING = {
 
 class TESection(Section):
     """
-    A section of a Terse Executable image. Its header is a COFF section header, so its permissions live in the
-    ``IMAGE_SCN`` bits of the characteristics field.
+    A section of a Terse Executable image.
     """
 
     def __init__(self, section_header: SectionHeaderType, linked_base: int, stripped_offset: int):
@@ -86,7 +85,7 @@ class TESection(Section):
 
     @property
     def only_contains_uninitialized_data(self):
-        # zero-filled whether or not the linker set IMAGE_SCN.CNT_UNINITIALIZED_DATA
+        # zero-filled whether or not the linker sets IMAGE_SCN.CNT_UNINITIALIZED_DATA
         return self.filesize == 0
 
 

--- a/tests/test_te.py
+++ b/tests/test_te.py
@@ -1,82 +1,31 @@
-"""Tests for the Terse Executable backend.
+"""
+Tests for the Terse Executable backend.
 
 TE images are PE images with the DOS and PE headers replaced by a 40-byte TE header. The section table is copied
-verbatim, so its addresses and file offsets still describe the *original* PE file: an image that stripped
-``stripped_size`` bytes of headers has every recorded file offset sitting ``stripped_size - sizeof(TE header)`` bytes
-further along than the byte actually is in the TE file. These tests build TE images by hand rather than shipping a
-firmware fixture, because that header arithmetic is exactly what is being checked.
+verbatim, so every file offset it records still describes the original PE file.
 """
 
 from __future__ import annotations
 
-import io
+import os
 
 import cle
-from cle.backends.coff import IMAGE_SCN
-from cle.backends.te import HEADER, SECTION_HEADER, HeaderType, SectionHeaderType
+from cle.backends.te import HEADER
 
-TE_SIGNATURE = 0x5A56  # b"VZ"
-IMAGE_FILE_MACHINE_I386 = 0x014C
-IMAGE_FILE_MACHINE_ARM64 = 0xAA64
-EFI_APPLICATION = 10
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
-# a realistic amount of stripped PE header. Keeping this larger than HEADER.size is what makes the tests notice a
-# backend that forgets the strip adjustment; with the two equal, every address happens to come out right anyway.
+# what tests_src/te/build_te_images.py assembles: .text with the entry point 4 bytes into it, .data whose virtual
+# size runs 8 bytes past its raw data, and .bss with no raw data at all
+IMAGE_BASE = 0x400000
 STRIPPED_SIZE = 0x100
+ENTRY_RVA = 0x1004
+# the image sits stripped_size - sizeof(TE header) above image_base, and RVAs are relative to that
+ENTRY = IMAGE_BASE + STRIPPED_SIZE - HEADER.size + ENTRY_RVA
 
 
-def build_te(machine, image_base, entry_rva, sections, stripped_size=STRIPPED_SIZE):
-    """
-    Assemble a TE image.
-
-    :param sections:    ``(name, virtual_address, virtual_size, characteristics, raw_data)`` tuples, laid out in the
-                        file in the order given.
-    :return:            A stream the loader can consume.
-    """
-    # file offsets recorded in the section table are offsets into the pre-strip PE file
-    stripped_offset = stripped_size - HEADER.size
-    body_offset = HEADER.size + len(sections) * SECTION_HEADER.size
-
-    section_headers = b""
-    body = b""
-    for name, virtual_address, virtual_size, characteristics, raw_data in sections:
-        section_headers += SECTION_HEADER.pack(
-            *SectionHeaderType(
-                section_name=name.encode().ljust(8, b"\0"),
-                physical_address_virtual_size=virtual_size,
-                virtual_address=virtual_address,
-                size_of_raw_data=len(raw_data),
-                pointer_to_raw_data=body_offset + len(body) + stripped_offset,
-                pointer_to_relocations=0,
-                pointer_to_line_numbers=0,
-                number_of_relocations=0,
-                number_of_line_numbers=0,
-                characteristics=characteristics,
-            )
-        )
-        body += raw_data
-
-    header = HEADER.pack(
-        *HeaderType(
-            signature=TE_SIGNATURE,
-            machine=machine,
-            number_of_sections=len(sections),
-            subsystem=EFI_APPLICATION,
-            stripped_size=stripped_size,
-            address_of_entry_point=entry_rva,
-            base_of_code=sections[0][1] if sections else 0,
-            image_base=image_base,
-            data_directory_0_virtual_address=0,
-            data_directory_0_size=0,
-            data_directory_1_virtual_address=0,
-            data_directory_1_size=0,
-        )
-    )
-    return io.BytesIO(header + section_headers + body)
-
-
-def load_te(stream):
-    return cle.Loader(stream, auto_load_libs=False, main_opts={"backend": "te"})
+def load_te(arch):
+    path = os.path.join(TEST_BASE, "tests", arch, "te_sections.te")
+    return cle.Loader(path, auto_load_libs=False, main_opts={"backend": "te"}).main_object
 
 
 def sections_by_name(obj):
@@ -84,37 +33,17 @@ def sections_by_name(obj):
 
 
 def test_entry_point():
-    code = bytes(range(0x10))
-    stream = build_te(
-        IMAGE_FILE_MACHINE_I386,
-        image_base=0x400000,
-        entry_rva=0x1004,
-        sections=[(".text", 0x1000, len(code), IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_EXECUTE, code)],
-    )
-    obj = load_te(stream).main_object
+    obj = load_te("i386")
+    assert obj.entry == ENTRY
 
-    # the whole image sits at image_base + (stripped_size - sizeof(TE header)), so the entry RVA lands there too
-    expected = 0x400000 + STRIPPED_SIZE - HEADER.size + 0x1004
-    assert obj.entry == expected
-
-    # the entry point must agree with where the sections were actually mapped, not just with some fixed formula
+    # the entry point must agree with where the sections were actually mapped, not just with a fixed formula
     text = sections_by_name(obj)[".text"]
     assert text.contains_addr(obj.entry)
-    assert obj.loader.memory.load(obj.entry, 4) == code[4:8]
+    assert obj.loader.memory.load(obj.entry, 3) == b"\x31\xc0\xc3"  # xor eax, eax; ret
 
 
 def test_section_permissions():
-    stream = build_te(
-        IMAGE_FILE_MACHINE_I386,
-        image_base=0x400000,
-        entry_rva=0x1000,
-        sections=[
-            (".text", 0x1000, 4, IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_EXECUTE, b"\xc3\x00\x00\x00"),
-            (".data", 0x2000, 4, IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_WRITE, b"\x01\x02\x03\x04"),
-            (".bss", 0x3000, 0x20, IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_WRITE | IMAGE_SCN.CNT_UNINITIALIZED_DATA, b""),
-        ],
-    )
-    obj = load_te(stream).main_object
+    obj = load_te("i386")
     sections = sections_by_name(obj)
 
     # angr builds its permission map by walking every object's segments, which is the query that used to raise
@@ -140,50 +69,30 @@ def test_section_permissions():
 
 
 def test_section_file_offsets():
-    code = bytes(range(0x10))
-    stream = build_te(
-        IMAGE_FILE_MACHINE_I386,
-        image_base=0x400000,
-        entry_rva=0x1004,
-        sections=[(".text", 0x1000, len(code), IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_EXECUTE, code)],
-    )
-    image = stream.getvalue()
-    obj = load_te(stream).main_object
+    obj = load_te("i386")
+    with open(obj.binary, "rb") as f:
+        image = f.read()
 
     # a section offset has to index the TE file cle was handed, not the PE file the section table was copied from
     text = sections_by_name(obj)[".text"]
-    assert image[text.offset : text.offset + text.filesize] == code
+    assert image[text.offset : text.offset + text.filesize] == obj.loader.memory.load(text.vaddr, text.filesize)
     assert obj.addr_to_offset(obj.entry) == text.offset + 4
 
 
 def test_partially_backed_section():
-    initialized = b"\xaa" * 0x10
-    stream = build_te(
-        IMAGE_FILE_MACHINE_I386,
-        image_base=0x400000,
-        entry_rva=0x1000,
-        sections=[(".data", 0x1000, 0x18, IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_WRITE, initialized)],
-    )
-    obj = load_te(stream).main_object
+    obj = load_te("i386")
 
     data = sections_by_name(obj)[".data"]
     assert (data.filesize, data.memsize) == (0x10, 0x18)
     # the bytes past the raw data still belong to the section, so they have to be mapped and zeroed
-    assert obj.loader.memory.load(data.vaddr, data.memsize) == initialized + b"\0" * 8
+    assert obj.loader.memory.load(data.vaddr, data.memsize) == b"\xaa" * 0x10 + b"\0" * 8
 
 
 def test_aarch64_machine():
-    code = b"\xc0\x03\x5f\xd6"  # ret
-    stream = build_te(
-        IMAGE_FILE_MACHINE_ARM64,
-        image_base=0x400000,
-        entry_rva=0x1000,
-        sections=[(".text", 0x1000, len(code), IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_EXECUTE, code)],
-    )
-    obj = load_te(stream).main_object
+    obj = load_te("aarch64")
 
     assert obj.arch.name == "AARCH64"
-    assert obj.loader.memory.load(obj.entry, len(code)) == code
+    assert obj.loader.memory.load(obj.entry, 8) == b"\x00\x00\x80\x52\xc0\x03\x5f\xd6"  # mov w0, #0; ret
 
 
 if __name__ == "__main__":

--- a/tests/test_te.py
+++ b/tests/test_te.py
@@ -1,0 +1,194 @@
+"""Tests for the Terse Executable backend.
+
+TE images are PE images with the DOS and PE headers replaced by a 40-byte TE header. The section table is copied
+verbatim, so its addresses and file offsets still describe the *original* PE file: an image that stripped
+``stripped_size`` bytes of headers has every recorded file offset sitting ``stripped_size - sizeof(TE header)`` bytes
+further along than the byte actually is in the TE file. These tests build TE images by hand rather than shipping a
+firmware fixture, because that header arithmetic is exactly what is being checked.
+"""
+
+from __future__ import annotations
+
+import io
+
+import cle
+from cle.backends.coff import IMAGE_SCN
+from cle.backends.te import HEADER, SECTION_HEADER, HeaderType, SectionHeaderType
+
+TE_SIGNATURE = 0x5A56  # b"VZ"
+IMAGE_FILE_MACHINE_I386 = 0x014C
+IMAGE_FILE_MACHINE_ARM64 = 0xAA64
+EFI_APPLICATION = 10
+
+# a realistic amount of stripped PE header. Keeping this larger than HEADER.size is what makes the tests notice a
+# backend that forgets the strip adjustment; with the two equal, every address happens to come out right anyway.
+STRIPPED_SIZE = 0x100
+
+
+def build_te(machine, image_base, entry_rva, sections, stripped_size=STRIPPED_SIZE):
+    """
+    Assemble a TE image.
+
+    :param sections:    ``(name, virtual_address, virtual_size, characteristics, raw_data)`` tuples, laid out in the
+                        file in the order given.
+    :return:            A stream the loader can consume.
+    """
+    # file offsets recorded in the section table are offsets into the pre-strip PE file
+    stripped_offset = stripped_size - HEADER.size
+    body_offset = HEADER.size + len(sections) * SECTION_HEADER.size
+
+    section_headers = b""
+    body = b""
+    for name, virtual_address, virtual_size, characteristics, raw_data in sections:
+        section_headers += SECTION_HEADER.pack(
+            *SectionHeaderType(
+                section_name=name.encode().ljust(8, b"\0"),
+                physical_address_virtual_size=virtual_size,
+                virtual_address=virtual_address,
+                size_of_raw_data=len(raw_data),
+                pointer_to_raw_data=body_offset + len(body) + stripped_offset,
+                pointer_to_relocations=0,
+                pointer_to_line_numbers=0,
+                number_of_relocations=0,
+                number_of_line_numbers=0,
+                characteristics=characteristics,
+            )
+        )
+        body += raw_data
+
+    header = HEADER.pack(
+        *HeaderType(
+            signature=TE_SIGNATURE,
+            machine=machine,
+            number_of_sections=len(sections),
+            subsystem=EFI_APPLICATION,
+            stripped_size=stripped_size,
+            address_of_entry_point=entry_rva,
+            base_of_code=sections[0][1] if sections else 0,
+            image_base=image_base,
+            data_directory_0_virtual_address=0,
+            data_directory_0_size=0,
+            data_directory_1_virtual_address=0,
+            data_directory_1_size=0,
+        )
+    )
+    return io.BytesIO(header + section_headers + body)
+
+
+def load_te(stream):
+    return cle.Loader(stream, auto_load_libs=False, main_opts={"backend": "te"})
+
+
+def sections_by_name(obj):
+    return {section.name: section for section in obj.sections}
+
+
+def test_entry_point():
+    code = bytes(range(0x10))
+    stream = build_te(
+        IMAGE_FILE_MACHINE_I386,
+        image_base=0x400000,
+        entry_rva=0x1004,
+        sections=[(".text", 0x1000, len(code), IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_EXECUTE, code)],
+    )
+    obj = load_te(stream).main_object
+
+    # the whole image sits at image_base + (stripped_size - sizeof(TE header)), so the entry RVA lands there too
+    expected = 0x400000 + STRIPPED_SIZE - HEADER.size + 0x1004
+    assert obj.entry == expected
+
+    # the entry point must agree with where the sections were actually mapped, not just with some fixed formula
+    text = sections_by_name(obj)[".text"]
+    assert text.contains_addr(obj.entry)
+    assert obj.loader.memory.load(obj.entry, 4) == code[4:8]
+
+
+def test_section_permissions():
+    stream = build_te(
+        IMAGE_FILE_MACHINE_I386,
+        image_base=0x400000,
+        entry_rva=0x1000,
+        sections=[
+            (".text", 0x1000, 4, IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_EXECUTE, b"\xc3\x00\x00\x00"),
+            (".data", 0x2000, 4, IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_WRITE, b"\x01\x02\x03\x04"),
+            (".bss", 0x3000, 0x20, IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_WRITE | IMAGE_SCN.CNT_UNINITIALIZED_DATA, b""),
+        ],
+    )
+    obj = load_te(stream).main_object
+    sections = sections_by_name(obj)
+
+    # angr builds its permission map by walking every object's segments, which is the query that used to raise
+    assert [(s.is_readable, s.is_writable, s.is_executable) for s in obj.segments] == [
+        (True, False, True),
+        (True, True, False),
+        (True, True, False),
+    ]
+
+    text = sections[".text"]
+    assert (text.is_readable, text.is_writable, text.is_executable) == (True, False, True)
+    assert not text.only_contains_uninitialized_data
+
+    data = sections[".data"]
+    assert (data.is_readable, data.is_writable, data.is_executable) == (True, True, False)
+    assert not data.only_contains_uninitialized_data
+
+    bss = sections[".bss"]
+    assert (bss.is_readable, bss.is_writable, bss.is_executable) == (True, True, False)
+    assert bss.only_contains_uninitialized_data
+    # .bss occupies memory but no file bytes; the base class would have reported filesize == memsize
+    assert (bss.filesize, bss.memsize) == (0, 0x20)
+
+
+def test_section_file_offsets():
+    code = bytes(range(0x10))
+    stream = build_te(
+        IMAGE_FILE_MACHINE_I386,
+        image_base=0x400000,
+        entry_rva=0x1004,
+        sections=[(".text", 0x1000, len(code), IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_EXECUTE, code)],
+    )
+    image = stream.getvalue()
+    obj = load_te(stream).main_object
+
+    # a section offset has to index the TE file cle was handed, not the PE file the section table was copied from
+    text = sections_by_name(obj)[".text"]
+    assert image[text.offset : text.offset + text.filesize] == code
+    assert obj.addr_to_offset(obj.entry) == text.offset + 4
+
+
+def test_partially_backed_section():
+    initialized = b"\xaa" * 0x10
+    stream = build_te(
+        IMAGE_FILE_MACHINE_I386,
+        image_base=0x400000,
+        entry_rva=0x1000,
+        sections=[(".data", 0x1000, 0x18, IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_WRITE, initialized)],
+    )
+    obj = load_te(stream).main_object
+
+    data = sections_by_name(obj)[".data"]
+    assert (data.filesize, data.memsize) == (0x10, 0x18)
+    # the bytes past the raw data still belong to the section, so they have to be mapped and zeroed
+    assert obj.loader.memory.load(data.vaddr, data.memsize) == initialized + b"\0" * 8
+
+
+def test_aarch64_machine():
+    code = b"\xc0\x03\x5f\xd6"  # ret
+    stream = build_te(
+        IMAGE_FILE_MACHINE_ARM64,
+        image_base=0x400000,
+        entry_rva=0x1000,
+        sections=[(".text", 0x1000, len(code), IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_EXECUTE, code)],
+    )
+    obj = load_te(stream).main_object
+
+    assert obj.arch.name == "AARCH64"
+    assert obj.loader.memory.load(obj.entry, len(code)) == code
+
+
+if __name__ == "__main__":
+    test_entry_point()
+    test_section_permissions()
+    test_section_file_offsets()
+    test_partially_backed_section()
+    test_aarch64_machine()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The TE backend built plain `Section` objects, whose permission properties raise `NotImplementedError`, and it never assigned an entry point, so terse executables loaded with entry 0. `angr.Project(te).factory.entry_state()` hit both.

`TESection` answers permissions from the COFF characteristics bits, keeps `size_of_raw_data` apart from the virtual size, and reports file offsets into the TE image rather than the PE file its section table was copied from. A section shorter than its virtual size is now zero-filled up to it, and machine type `0xaa64` is mapped so AArch64 images load at all.

The tests assemble TE images in memory rather than shipping a firmware fixture, because that header arithmetic is what they check.

Validation: https://github.com/angr/cle/pull/713#issuecomment-5232336815
