### PR TITLE
Load partial-memory minidumps

### DIFF
--- a/cle/backends/minidump/__init__.py
+++ b/cle/backends/minidump/__init__.py
@@ -9,7 +9,7 @@ from minidump.streams import SystemInfoStream
 
 from cle.backends.backend import Backend, register_backend
 from cle.backends.region import Section, Segment
-from cle.errors import CLEError, CLEInvalidBinaryError
+from cle.errors import CLEError
 
 
 class MinidumpMissingStreamError(Exception):
@@ -17,6 +17,37 @@ class MinidumpMissingStreamError(Exception):
         super().__init__()
         self.message = message
         self.stream = stream
+
+
+class MinidumpSection(Section):
+    """
+    A module loaded in the dumped process.
+
+    A minidump records each module's base address and image size but not its section table, so there is nothing to
+    derive real permissions from; every module reports read, write and execute, as the backend's segments do.
+    """
+
+    def __init__(self, name, offset, vaddr, filesize, memsize):
+        super().__init__(name, offset, vaddr, memsize)
+        # Section makes filesize equal memsize. A minidump captures selected memory ranges rather than whole
+        # images, so only the captured prefix of the module is actually present in the file.
+        self.filesize = filesize
+
+    @property
+    def is_readable(self):
+        return True
+
+    @property
+    def is_writable(self):
+        return True
+
+    @property
+    def is_executable(self):
+        return True
+
+    @property
+    def only_contains_uninitialized_data(self):
+        return self.filesize == 0
 
 
 class Minidump(Backend):
@@ -64,12 +95,29 @@ class Minidump(Backend):
             self.memory.add_backer(segment.start_virtual_address, data)
 
         for module in self._mdf.modules.modules:
-            for segment in segments:
-                if segment.start_virtual_address == module.baseaddress:
-                    break
+            # A minidump captures only the memory ranges the dump writer selected, so a module's image may be
+            # present in full, in part, or not at all. Map as much of it as the capture covers from the module's
+            # base address onwards. A module with nothing captured still gets a section: its address range is
+            # what tells an analysis which module an address belongs to.
+            segment = self.segments.find_region_containing(module.baseaddress)
+            if segment is None:
+                file_offset = 0
+                file_size = 0
             else:
-                raise CLEInvalidBinaryError("Missing segment for loaded module: " + module.name)
-            section = Section(module.name, segment.start_file_address, module.baseaddress, module.size)
+                file_offset = segment.offset + module.baseaddress - segment.vaddr
+                # An image is normally captured as several ranges, one per run of pages sharing a protection.
+                # Ranges that are adjacent in memory are written adjacently in the file, so such a module still
+                # occupies a single range of the file.
+                captured_end = segment.vaddr + segment.memsize
+                captured_file_end = segment.offset + segment.memsize
+                while captured_end - module.baseaddress < module.size:
+                    following = self.segments.find_region_containing(captured_end)
+                    if following is None or following.offset != captured_file_end:
+                        break
+                    captured_end += following.memsize
+                    captured_file_end += following.memsize
+                file_size = min(module.size, captured_end - module.baseaddress)
+            section = MinidumpSection(module.name, file_offset, module.baseaddress, file_size, module.size)
             self.sections.append(section)
             self.sections_map[ntpath.basename(section.name)] = section
 
@@ -149,9 +197,14 @@ class Minidump(Backend):
         for register, position in fmt_registers.items():
             thread_registers[register] = members[position]
 
+        # The segment base lives in the thread's TEB rather than in its saved context, and a dump that captured only
+        # a few memory ranges usually does not include the TEB page. Leave the register out when it cannot be read,
+        # so that everything the context does record stays usable.
         if self.arch.name == "AMD64" or self.wow64:
-            gs_base = self.memory.unpack_word(teb + 0x30)
-            thread_registers["gs_const"] = gs_base
+            try:
+                thread_registers["gs_const"] = self.memory.unpack_word(teb + 0x30)
+            except KeyError:
+                pass
             if self.arch.name == "AMD64":
                 NUM_XMM_REGS = 16
                 xmms = struct.unpack_from("16s" * NUM_XMM_REGS, data, offset=0x1A0)
@@ -159,8 +212,10 @@ class Minidump(Backend):
                     f"xmm{i}": int.from_bytes(xmm, "little", signed=False) for i, xmm in enumerate(xmms)
                 }
         elif self.arch.name == "X86":
-            fs_base = self.memory.unpack_word(teb + 0x18)
-            thread_registers["fs"] = fs_base
+            try:
+                thread_registers["fs"] = self.memory.unpack_word(teb + 0x18)
+            except KeyError:
+                pass
 
         if self.wow64:
             register_translation = [
@@ -177,7 +232,11 @@ class Minidump(Backend):
                 ("fs", "gs_const"),  # ???
             ]
 
-            thread_registers = {ereg: thread_registers[rreg] & 0xFFFFFFFF for ereg, rreg in register_translation}
+            thread_registers = {
+                ereg: thread_registers[rreg] & 0xFFFFFFFF
+                for ereg, rreg in register_translation
+                if rreg in thread_registers
+            }
 
         return thread_registers
 

--- a/cle/backends/tls/minidump_tls.py
+++ b/cle/backends/tls/minidump_tls.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
 
+import logging
+
 import archinfo
 
 from cle.backends.tls.tls_object import ThreadManager
+
+log = logging.getLogger(__name__)
 
 
 class MinidumpThreadManager(ThreadManager):
     def __init__(self, loader, arch, **kwargs):  # pylint: disable=unused-argument
         self.loader = loader
         self.arch = arch
-        self.threads = [
-            MinidumpThread(loader, arch, loader.main_object.thread_registers(tid)) for tid in loader.main_object.threads
-        ]
+        self.threads = []
+        for tid in loader.main_object.threads:
+            try:
+                self.threads.append(MinidumpThread(loader, arch, loader.main_object.thread_registers(tid)))
+            except KeyError:
+                # Locating a thread's TLS array means reading its TEB, which a dump that captured only a few
+                # memory ranges usually leaves out. Such a thread has no reachable thread-local storage, but the
+                # rest of the dump still loads.
+                log.warning("Skipping thread %#x: the minidump did not capture its TEB", tid)
         self.modules = []  # ???
 
     def new_thread(self, insert=False):  # pylint: disable=no-self-use

--- a/tests/test_minidump.py
+++ b/tests/test_minidump.py
@@ -23,7 +23,32 @@ def test_minidump():
     assert "jusched.exe" in sections_map
     assert "kernel32.dll" in sections_map
 
+    # A minidump has no per-module section table to derive permissions from, so every module is fully permissive.
+    jusched = sections_map["jusched.exe"]
+    assert jusched.is_readable
+    assert jusched.is_writable
+    assert jusched.is_executable
+    assert not jusched.only_contains_uninitialized_data
+
+    # jusched.exe is captured whole, in five ranges that are adjacent both in memory and in the file, so its
+    # section covers the entire image and the last bytes of the image are readable from the file offset it gives.
+    assert jusched.memsize == 0x92000
+    assert jusched.filesize == jusched.memsize
+    assert ld.memory.load(jusched.vaddr, 2) == b"MZ"
+    assert jusched.addr_to_offset(jusched.vaddr) == jusched.offset
+    with open(exe, "rb") as fp:
+        fp.seek(jusched.addr_to_offset(jusched.max_addr - 15))
+        assert fp.read(16) == ld.memory.load(jusched.max_addr - 15, 16)
+
+    # Only the first page of kernel32.dll was captured, so its section maps that much of the image and no more.
+    kernel32 = sections_map["kernel32.dll"]
+    assert kernel32.memsize == 0x140000
+    assert kernel32.filesize == 0x1000
+    assert not kernel32.only_contains_uninitialized_data
+    assert kernel32.addr_to_offset(kernel32.vaddr + kernel32.filesize) is None
+
     assert len(ld.main_object.threads) == 2
+    assert len(ld.tls.threads) == 2
     registers = ld.main_object.thread_registers(0x0548)
     assert isinstance(registers, dict)
     assert registers == {
@@ -44,5 +69,55 @@ def test_minidump():
     }
 
 
+@unittest.skipIf(cle.backends.minidump.minidumpfile is None, "minidump not available")
+def test_partial_minidump():
+    # A crash dump this small captures the faulting instruction and the thread stacks and nothing else, so not one
+    # of the modules it lists is captured at its base address.
+    exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "partial", "minidump2.dmp")
+    ld = cle.Loader(exe, auto_load_libs=False)
+    obj = ld.main_object
+
+    assert isinstance(obj, cle.Minidump)
+    assert isinstance(obj.arch, archinfo.ArchX86)
+    assert obj.os == "windows"
+    assert len(obj.segments) == 3
+    assert len(obj.sections) == 13
+    assert "test_app.exe" in obj.sections_map
+    assert "kernel32.dll" in obj.sections_map
+
+    # Uncaptured modules still get a section, so an analysis can tell which module an address belongs to, but the
+    # section maps no file bytes.
+    assert all(section.memsize > 0 for section in obj.sections)
+    assert all(section.filesize == 0 for section in obj.sections)
+    assert all(section.only_contains_uninitialized_data for section in obj.sections)
+    assert all(section.addr_to_offset(section.vaddr) is None for section in obj.sections)
+
+    ntdll = obj.sections_map["ntdll.dll"]
+    assert ntdll.vaddr == 0x7C900000
+    assert ntdll.memsize == 0xB0000
+    # The one captured code range lives inside ntdll but does not start at its base address.
+    assert ld.memory.load(0x7C90EB14, 4) == bytes.fromhex("ff83c4ec")
+
+    # The TEB pages are not captured, so the general-purpose registers survive without the fs segment base.
+    assert obj.threads == [0x0BF4, 0x11C0]
+    assert obj.thread_registers(0x0BF4) == {
+        "edi": 0x0,
+        "esi": 0x7B8,
+        "ebx": 0x7C883780,
+        "edx": 0x7C97C0D8,
+        "ecx": 0x7C80B46E,
+        "eax": 0x400000,
+        "ebp": 0x12F384,
+        "eip": 0x7C90EB94,
+        "eflags": 0x246,
+        "esp": 0x12F320,
+    }
+
+    # Without a TEB there is no way to reach a thread's TLS array, so no thread is modeled rather than the load
+    # failing outright.
+    assert not ld.tls.threads
+
+
 if __name__ == "__main__":
     test_minidump()
+    test_partial_minidump()

--- a/tests/test_minidump.py
+++ b/tests/test_minidump.py
@@ -4,6 +4,7 @@ import os
 import unittest
 
 import archinfo
+import pefile
 
 import cle
 
@@ -34,7 +35,7 @@ def test_minidump():
     # section covers the entire image and the last bytes of the image are readable from the file offset it gives.
     assert jusched.memsize == 0x92000
     assert jusched.filesize == jusched.memsize
-    assert ld.memory.load(jusched.vaddr, 2) == b"MZ"
+    assert ld.memory.load(jusched.vaddr, 2) == pefile.IMAGE_DOS_SIGNATURE.to_bytes(2, "little")
     assert jusched.addr_to_offset(jusched.vaddr) == jusched.offset
     with open(exe, "rb") as fp:
         fp.seek(jusched.addr_to_offset(jusched.max_addr - 15))


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

**Closed 2026-09-08 — the content of this pull request is in #759.** The two
rewrote the same loop in `cle/backends/minidump/__init__.py` and could not both
merge. Everything here except one class is in #759 at `c36ece7ea0c1cf7fdaa702ec9b44b48b9f56a7c8`: the dropped
exact-base requirement, the separate `filesize`, the guarded TEB reads, the wow64
register translation, `cle/backends/tls/minidump_tls.py`, and
`test_partial_minidump`. `MinidumpSection` — one permissive section per module —
is superseded by #759's `DumpSection`, which reports each module's real per-section
permissions; the measurement behind that choice is in the closing comment below.
The description that follows is the original and is left as it was written.

---

THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A minidump only captures the memory ranges its writer chose, and cle assumed
every listed module was captured at its base address. The Breakpad crash dump
`binaries/tests/x86/windows/partial/minidump2.dmp`, which holds the faulting
instruction and the two thread stacks and nothing else, does not load:

```
  raise CLEInvalidBinaryError("Missing segment for loaded module: " + module.name)
cle.errors.CLEInvalidBinaryError: Missing segment for loaded module: c:\test_app.exe
```

The dumps that do load are unusable by `CFGFast`, which reads
`section.is_executable` at `angr/analyses/cfg/cfg_base.py:787`. On the fully
captured `binaries/tests/x86/windows/jusched_x86.dmp`, all 30 sections raise:

```
$ [s.is_executable for s in ld.main_object.sections]
  File "cle/backends/region.py", line 190, in is_executable
    raise NotImplementedError()
NotImplementedError
```

### Root cause

Three assumptions, each about something a dump does not have to contain.

A module's section was built only after a linear search found a segment starting
exactly at its base:

```python
for segment in segments:
    if segment.start_virtual_address == module.baseaddress:
        break
else:
    raise CLEInvalidBinaryError("Missing segment for loaded module: " + module.name)
```

The section was then a plain `Section`, whose `is_readable`, `is_writable` and
`is_executable` are abstract, and whose `filesize` is forced equal to `memsize`
-- so a module captured one page deep claimed its whole image was file-backed.

Thread setup read the segment base out of the TEB with
`self.memory.unpack_word(teb + 0x30)`, and a dump that captured a few ranges
does not include the TEB page, so a `KeyError` there lost every register in the
saved context, not just `fs`.

### Fix

A module now maps whatever prefix of its image the capture covers, walking
memory-adjacent ranges that are also file-adjacent, and a module with nothing
captured still gets a section so an analysis can attribute an address to it.
`MinidumpSection` carries `filesize` separately from `memsize`, reports
read/write/execute the way the backend's segments already do, and reports
`only_contains_uninitialized_data` when nothing was captured. The TEB reads are
individually guarded, and the register translation skips what is absent.

The same partial dump then loads with 3 segments and 13 sections,
`ntdll.dll` at `0x7c900000` with `filesize 0x0`, and the one captured code range
readable at `0x7c90eb14`.

### Testing

`test_partial_minidump` asserts the section set, that every section maps zero
file bytes, that `0x7c90eb14` reads back `ff83c4ec`, both thread ids and the
full register set for `0x0bf4`, and that no TLS thread is modeled. It fails on
the merge base with `CLEInvalidBinaryError`. `test_minidump` is extended over
`jusched_x86.dmp` with the permission and `filesize`/`memsize` assertions, which
fail there with `NotImplementedError`.

The fixture is in `angr/binaries` master, added by that repository's PR 175,
which merged on 2026-08-12.

Validation: https://github.com/angr/cle/pull/715#issuecomment-5232347970

session: sharpen

