### PR TITLE
Cover object placement in an address space narrower than a granule

### DIFF
--- a/tests/test_rebase.py
+++ b/tests/test_rebase.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import io
 import os
+
+import archinfo
+import pytest
 
 import cle
 
@@ -69,7 +73,58 @@ def test_rebase_granularity_is_not_a_hard_object_limit():
         assert ld.find_object_containing(obj.min_addr) is obj
 
 
+def load_narrow_blob(size):
+    """
+    Load a blob of ``size`` bytes as a z80 image. The whole 16-bit address space is smaller than a
+    single default granule, so every placement in it has to ignore the granularity.
+    """
+    pytest.importorskip("pypcode")
+    arch = archinfo.ArchPcode("z80:LE:16:default")
+    ld = cle.Loader(
+        io.BytesIO(b"\0" * size),
+        main_opts={"backend": "blob", "base_addr": 0, "entry_point": 0, "arch": arch},
+    )
+    assert (ld.main_object.min_addr, ld.main_object.max_addr) == (0, size - 1)
+    return ld
+
+
+def test_address_space_narrower_than_the_granularity():
+    """
+    Aligning to the granularity in a 16-bit address space puts the extern object past the end of
+    memory, and the load fails with "Ran out of room in address space".
+    """
+    ld = load_narrow_blob(0x1500)
+
+    extern = ld.extern_object
+    assert extern.min_addr > ld.main_object.max_addr
+    assert extern.max_addr < 2**ld.main_object.arch.bits
+    ld.memory.unpack_word(extern.min_addr)
+
+
+def test_narrow_address_space_holds_more_objects_than_granules():
+    """
+    A 16-bit address space does not contain even one default granule, so it holds no object at all
+    if the granularity is treated as a constraint.
+    """
+    ld = load_narrow_blob(0x1500)
+
+    objects = []
+    for _ in range(24):
+        obj = MockBackend(0x100, arch=ld.main_object.arch)
+        ld.dynamic_load(obj)
+        objects.append(obj)
+
+    placed = sorted(objects, key=lambda o: o.min_addr)
+    assert placed[-1].max_addr < 2**ld.main_object.arch.bits
+    for lower, upper in zip(placed, placed[1:]):
+        assert lower.max_addr < upper.min_addr
+    for obj in objects:
+        assert ld.find_object_containing(obj.min_addr) is obj
+
+
 if __name__ == "__main__":
     test_sparse_main_object()
     test_sparse_main_object_unsorted_program_headers()
     test_rebase_granularity_is_not_a_hard_object_limit()
+    test_address_space_narrower_than_the_granularity()
+    test_narrow_address_space_holds_more_objects_than_granules()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A 16-bit p-code architecture has a 64 KiB address space, narrower than the
default 1 MiB rebase granularity, so `Loader._find_safe_rebase_addr` aligned the
extern object past the end of memory and a z80 blob did not load at all. Against
`45c6509~1`, the commit before #735:

```
$ cle.Loader(BytesIO(b'\0' * 0x1500), main_opts={'backend': 'blob', 'base_addr': 0,
                                                 'entry_point': 0, 'arch': ArchPcode('z80:LE:16:default')})
  File "cle/loader.py", line 1097, in _find_safe_rebase_addr
    raise CLEOperationError("Ran out of room in address space")
cle.errors.CLEOperationError: Ran out of room in address space
```

#735 has since fixed that, so this branch no longer changes `cle/loader.py` and
only the coverage is left. What is missing is a guard: nothing else in the suite
loads an architecture narrower than 32 bits.

### Root cause

#735 replaced the single granule-aligned placement with an alignment ladder that
falls back when a gap is too tight:

```python
alignments = [self._rebase_granularity]
alignments += [a for a in (0x1000, 1) if a < self._rebase_granularity]
```

A 16-bit space is the extreme case of that: it does not contain even one default
granule, so it holds no object at all unless the ladder reaches the bottom rung.
This branch's earlier one-byte special case for `arch.bits < 32` was dropped
rather than rebased, because the ladder subsumes it.

### Fix

Two tests in `tests/test_rebase.py`. `test_address_space_narrower_than_the_granularity`
loads a 0x1500-byte z80 blob and asserts the extern object lands above the image
and below `2**16`. `test_narrow_address_space_holds_more_objects_than_granules`
then `dynamic_load`s 24 further objects into the same 64 KiB, asserting they are
disjoint, in bounds, and each findable by `find_object_containing`. At the merge
base both pass:

```
main_object  = [0x0:0x14ff]
extern_object= [0x2000:0x21ff]   (address space ends at 0xffff)
```

### Testing

Delete the one-byte rung from the ladder and master's `tests/test_rebase.py`
stays green at 3 passed, while this branch's file reports 1 failed, 4 passed --
`test_narrow_address_space_holds_more_objects_than_granules`, with
`CLEOperationError: Ran out of room in address space` at `cle/loader.py:1095`.
That one test is the whole guard; the other four, including everything #735
added, cannot see the removal. Against `45c6509~1` all five fail.

angr/angr#6793 works around this with `rebase_granularity=0x100` and can drop it.

Validation: https://github.com/angr/cle/pull/717#issuecomment-5232369085

sync: angr/angr#6793

session: sharpen