### PR TITLE
Apply R_AARCH64_PREL32 as a 32-bit store

### DIFF
--- a/cle/backends/elf/relocation/arm64.py
+++ b/cle/backends/elf/relocation/arm64.py
@@ -19,6 +19,7 @@ from .generic import (
     GenericTLSDoffsetReloc,
     GenericTLSModIdReloc,
     GenericTLSOffsetReloc,
+    RelocTruncate32Mixin,
 )
 
 log = logging.getLogger(name=__name__)
@@ -66,7 +67,7 @@ class R_AARCH64_TLSDESC(GenericTLSDescriptorReloc):
     RESOLVER_ADDR = 0xFFFF_FFFF_FFFF_FE00
 
 
-class R_AARCH64_PREL32(GenericPCRelativeAddendReloc):
+class R_AARCH64_PREL32(RelocTruncate32Mixin, GenericPCRelativeAddendReloc):
     """
     Relocation Type: 261
     Calculation: (S + A - P)

--- a/tests/test_aarch64_relocations.py
+++ b/tests/test_aarch64_relocations.py
@@ -1,9 +1,23 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
+import io
 import os
+import struct
 
 import cle
+
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests"))
+
+R_AARCH64_NONE = 0
+R_AARCH64_PREL32 = 261
+
+# sizeof(Elf64_Rela)
+RELA_ENTRY_SIZE = 0x18
+
+# A section of four-byte fields, each covered by its own relocation against the undefined symbol
+# "zero". Rewriting those relocations puts a PREL32 field at a chosen offset.
+PREL32_SECTION = ".R_AARCH64_MOVW_SABS"
 
 
 def test_aarch64_relocs():
@@ -11,7 +25,6 @@ def test_aarch64_relocs():
     Test some relocations on an AArch64 object file.
     :return:
     """
-    test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests"))
     path = os.path.join(test_location, "aarch64", "aarch64-relocs.o")
     loader = cle.Loader(path, main_opts={"base_addr": 0x210120}, auto_load_libs=True)
     relocations = loader.main_object.relocs
@@ -40,5 +53,67 @@ def test_aarch64_relocs():
     assert not expected_relocs
 
 
+def _load_with_prel32(prel32_offset):
+    """
+    Load aarch64-relocs.o with the relocations covering PREL32_SECTION rewritten: the field
+    `prel32_offset` bytes into the section gets an R_AARCH64_PREL32 with a zero addend, and every
+    other relocation becomes R_AARCH64_NONE so that it leaves its own field alone. A negative
+    offset counts back from the end of the section, as in a slice.
+
+    Returns the loader, a second loader over the same image that relocates nothing, and the
+    address of the PREL32 field.
+    """
+    path = os.path.join(test_location, "aarch64", "aarch64-relocs.o")
+    with open(path, "rb") as f:
+        image = bytearray(f.read())
+
+    probe = cle.Loader(path, main_opts={"base_addr": 0x210120}, auto_load_libs=False).main_object
+    section = probe.sections_map[PREL32_SECTION]
+    rela = probe.sections_map[".rela" + PREL32_SECTION]
+    if prel32_offset < 0:
+        prel32_offset += section.memsize
+
+    for entry in range(rela.offset, rela.offset + rela.filesize, RELA_ENTRY_SIZE):
+        r_offset, r_info = struct.unpack_from("<QQ", image, entry)
+        symbol = r_info >> 32
+        r_type = R_AARCH64_PREL32 if r_offset == prel32_offset else R_AARCH64_NONE
+        struct.pack_into("<Qq", image, entry + 8, (symbol << 32) | r_type, 0)
+
+    patched = bytes(image)
+    loader = cle.Loader(io.BytesIO(patched), main_opts={"base_addr": 0x210120}, auto_load_libs=False)
+    unrelocated = cle.Loader(
+        io.BytesIO(patched), main_opts={"base_addr": 0x210120}, auto_load_libs=False, perform_relocations=False
+    )
+    return loader, unrelocated, section.vaddr + prel32_offset
+
+
+def test_aarch64_prel32_at_section_end():
+    """
+    R_AARCH64_PREL32 covers a four-byte field, so one may sit in the last four bytes of a section.
+    CLE used to store it with the generic architecture-word-sized write, which ran off the end of
+    the section's backer and escaped the loader as a bare KeyError. Real aarch64 kernel modules hit
+    this on the last __ksymtab entry.
+    """
+    loader, _, field = _load_with_prel32(-4)
+    zero = loader.find_symbol("zero")
+    assert zero is not None
+
+    assert loader.memory.unpack_word(field, size=4) == (zero.rebased_addr - field) & 0xFFFFFFFF
+
+
+def test_aarch64_prel32_leaves_the_next_field_alone():
+    """
+    The architecture-word-sized write also overwrote the four bytes following every relocated field.
+    """
+    loader, unrelocated, field = _load_with_prel32(0)
+    zero = loader.find_symbol("zero")
+    assert zero is not None
+
+    assert loader.memory.unpack_word(field, size=4) == (zero.rebased_addr - field) & 0xFFFFFFFF
+    assert loader.memory.load(field + 4, 4) == unrelocated.memory.load(field + 4, 4)
+
+
 if __name__ == "__main__":
     test_aarch64_relocs()
+    test_aarch64_prel32_at_section_end()
+    test_aarch64_prel32_leaves_the_next_field_alone()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

R_AARCH64_PREL32 covers four bytes but was a plain `GenericPCRelativeAddendReloc`, so the generic applier stored S + A - P at the architecture word size — an eight-byte write into a four-byte field. It clobbered the following four bytes, and where the field ended a section the write ran past that section's backer and left `Loader.__init__` as a bare `KeyError`. Aarch64 kernel modules hit that on the last `__ksymtab` entry.

Width belongs to the relocation type, so it now goes through `RelocTruncate32Mixin` like the amd64 32-bit relocations. Its overflow check stays off; AAELF64 specifies one, but enforcing it would reject loads that succeed today.

The regression tests rewrite one section of `tests/aarch64/aarch64-relocs.o` into PREL32 entries, at the section end and ahead of an untouched field.

Validation: https://github.com/angr/cle/pull/719#issuecomment-5233513217
