### PR TITLE
Probe UEFI compatibility without assuming a file object

### DIFF
--- a/cle/backends/uefi_firmware.py
+++ b/cle/backends/uefi_firmware.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import logging
 import mmap
+import os
 from dataclasses import dataclass
 from typing import cast
 from uuid import UUID
@@ -37,16 +38,24 @@ class UefiFirmware(Backend):
     is_default = True
 
     @classmethod
-    def _to_bytes(cls, fileobj: io.IOBase):
+    def _to_bytes(cls, fileobj) -> bytes | mmap.mmap:
+        """
+        Get the whole contents of a stream as a bytes-like object.
+
+        The loader only promises that a stream supports ``read`` and ``seek``, and ``is_compatible`` is offered
+        streams that belong to some other backend entirely, so nothing richer may be assumed here.
+        """
+        # mmap maps the whole file behind a descriptor, so it is the contents of the stream only when the stream
+        # spans that file. An archive member shares its container's descriptor and does not, and there is
+        # nothing to map in an empty file, so check both before taking the shortcut.
         try:
             fileno = fileobj.fileno()
-        except io.UnsupportedOperation:
+            size = os.fstat(fileno).st_size
+            fileobj.seek(0, io.SEEK_END)
+            if size > 0 and fileobj.tell() == size:
+                return mmap.mmap(fileno, 0, access=mmap.ACCESS_READ)
+        except (AttributeError, OSError, ValueError):
             pass
-        else:
-            return mmap.mmap(fileno, 0, access=mmap.ACCESS_READ)
-
-        if isinstance(fileobj, io.BytesIO):
-            return fileobj.getbuffer()
 
         # fuck it, we'll do it live
         fileobj.seek(0)

--- a/tests/test_uefi_firmware.py
+++ b/tests/test_uefi_firmware.py
@@ -9,6 +9,11 @@ from pathlib import Path
 import arpy
 import pytest
 
+try:
+    import uefi_firmware
+except ImportError:
+    uefi_firmware = None
+
 import cle
 from cle.backends import ALL_BACKENDS
 from cle.backends.uefi_firmware import UefiFirmware, UefiModuleMixin
@@ -127,6 +132,7 @@ def test_load_a_read_seek_stream_no_backend_claims():
         cle.Loader(MinimalStream(symbol_index), auto_load_libs=False)  # type: ignore[arg-type]
 
 
+@pytest.mark.skipif(uefi_firmware is None, reason="uefi_firmware not installed")
 @pytest.mark.parametrize("kind", ["path", "file", "bytesio", "stream"])
 def test_load_firmware_volume(kind):
     """

--- a/tests/test_uefi_firmware.py
+++ b/tests/test_uefi_firmware.py
@@ -11,7 +11,7 @@ import pytest
 
 import cle
 from cle.backends import ALL_BACKENDS
-from cle.backends.uefi_firmware import UefiFirmware
+from cle.backends.uefi_firmware import UefiFirmware, UefiModuleMixin
 
 TESTS_BASE = Path(__file__).resolve().parent.parent.parent / "binaries" / "tests"
 
@@ -123,8 +123,12 @@ def test_load_firmware_volume(kind):
 
     assert isinstance(ld.main_object, UefiFirmware)
     # The drivers live in the compressed section, so reaching them is what says the whole volume was parsed
-    # rather than only recognized.
-    names = {child.user_interface_name for child in ld.main_object.child_objects}
+    # rather than only recognized. Every child a volume produces is a UEFI module, which is what carries
+    # the name the firmware gave the driver.
+    names = set()
+    for child in ld.main_object.child_objects:
+        assert isinstance(child, UefiModuleMixin)
+        names.add(child.user_interface_name)
     assert {"ArmGicDxe", "BdsDxe", "VariableRuntimeDxe"} <= names
     assert ld.main_object.arch.name == "AARCH64"
 

--- a/tests/test_uefi_firmware.py
+++ b/tests/test_uefi_firmware.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 
 import mmap
 import os
-import struct
-import tempfile
-import uuid
 from io import BytesIO
+from pathlib import Path
 
 import arpy
 import pytest
@@ -15,9 +13,18 @@ import cle
 from cle.backends import ALL_BACKENDS
 from cle.backends.uefi_firmware import UefiFirmware
 
-FFS2_GUID = uuid.UUID("8c8ce578-8a3d-4f1c-9935-896185c32dd3").bytes_le
-LZMA_GUID = uuid.UUID("ee4e5898-3914-4259-9d6e-dc7bd79403cf").bytes_le
-FILE_GUID = uuid.UUID("f8a35c0e-1d20-4a1f-9c3c-6a2e0b7d5e41").bytes_le
+TESTS_BASE = Path(__file__).resolve().parent.parent.parent / "binaries" / "tests"
+
+# A static library in the BSD flavor, so its first member is a ``__.SYMDEF`` symbol index rather than an
+# object file. That member is not an object file, so it is offered to every backend in turn before the
+# load gives up, which is how the UEFI probe comes to see an archive member at all.
+BSD_ARCHIVE = TESTS_BASE / "aarch64" / "bsd_symdef_archive.a"
+
+# Debian's edk2 build of the ArmVirtQemu platform. It is a single firmware volume holding one file whose
+# payload is an LZMA-compressed section; inside that are the 93 AArch64 PE drivers the loader reports as
+# child objects. The compression matters: ``uefi_firmware`` joins a compressed section's preamble to its
+# body before decompressing, so anything ``_to_bytes`` returns has to support concatenation.
+FIRMWARE_VOLUME = TESTS_BASE / "aarch64" / "edk2_armvirtqemu.fd"
 
 
 class MinimalStream:
@@ -46,7 +53,10 @@ class MinimalStream:
 
 class SliceOfFileStream(MinimalStream):
     """
-    A stream over part of a file that shares the file's descriptor, the way an archive member does.
+    A stream over part of a file that shares the file's descriptor.
+
+    An archive member is this shape; ``arpy.ArchiveFileData`` withholds ``fileno``, so this adds it to
+    describe the case a member proxy would present if it ever offered one.
     """
 
     def __init__(self, file, start: int, size: int):
@@ -61,48 +71,10 @@ class SliceOfFileStream(MinimalStream):
         return self._pos
 
 
-def _firmware_volume() -> bytes:
-    """
-    Build the smallest UEFI firmware volume that carries an LZMA-compressed section.
-
-    A compressed section is what makes this worth building: ``uefi_firmware`` joins the section's preamble to
-    its body before decompressing it, and a memoryview of the loader's stream cannot be joined to anything.
-    """
-    payload = b"\x5d" + b"\x00" * 64
-    # EFI_GUID_DEFINED_SECTION: the GUID, the offset of the body from the start of the section, attributes.
-    section_body = LZMA_GUID + struct.pack("<HH", 0x1C, 0x01) + payload
-    section = struct.pack("<3sB", (len(section_body) + 4).to_bytes(3, "little"), 0x02) + section_body
-
-    file_size = 0x18 + len(section)
-    file = struct.pack("<16sHBB3sB", FILE_GUID, 0, 0x02, 0, file_size.to_bytes(3, "little"), 0xF8) + section
-
-    header_size = 0x48
-    volume_size = header_size + len(file)
-    header = struct.pack(
-        "<16s16sQ4sIHHHsB", b"\x00" * 16, FFS2_GUID, volume_size, b"_FVH", 0, header_size, 0, 0, b"\x00", 2
-    )
-    block_map = struct.pack("<IIII", 1, volume_size, 0, 0)
-    return header + block_map + file
-
-
-def _bsd_archive(members: list[tuple[bytes, bytes]]) -> bytes:
-    """
-    Build a static archive in the BSD flavor, which stores member names in the member data.
-    """
-    out = b"!<arch>\n"
-    for name, data in members:
-        padded_name = name + b"\x00" * (-len(name) % 8)
-        payload = padded_name + data
-        header = b"%-16s%-12d%-6d%-6d%-8o%-10d\x60\n" % (
-            b"#1/%d" % len(padded_name),
-            0,
-            0,
-            0,
-            0o100644,
-            len(payload),
-        )
-        out += header + payload + (b"\n" if len(payload) % 2 else b"")
-    return out
+def _archive_members(path):
+    archive = arpy.Archive(str(path))
+    archive.read_all_headers()
+    return archive, list(archive.archived_files.values())
 
 
 @pytest.mark.parametrize("backend", [b for b in ALL_BACKENDS.values() if b.is_default], ids=lambda b: b.__name__)
@@ -111,18 +83,20 @@ def test_default_backends_probe_a_read_seek_stream(backend):
     Backend detection offers every default backend every stream, so ``is_compatible`` has to answer for a stream
     that is not a file object rather than raising.
     """
-    assert backend.is_compatible(MinimalStream(b"\x00" * 64)) is False
+    archive, members = _archive_members(BSD_ARCHIVE)
+    symbol_index = members[0].read()
+    archive.close()
+    assert backend.is_compatible(MinimalStream(symbol_index)) is False
 
 
 def test_is_compatible_with_an_archive_member():
     """
     A BSD symbol index is not an object file, so it is offered to every backend before the load gives up.
     """
-    ar = arpy.Archive(fileobj=BytesIO(_bsd_archive([(b"__.SYMDEF SORTED", struct.pack("<I", 0))])))
-    ar.read_all_headers()
-    members = list(ar.archived_files.values())
-    assert len(members) == 1
+    archive, members = _archive_members(BSD_ARCHIVE)
+    assert members[0].header.name.rstrip(b"\0") == b"__.SYMDEF SORTED"
     assert UefiFirmware.is_compatible(members[0]) is False
+    archive.close()
 
 
 def test_load_archive_with_a_symbol_index():
@@ -130,12 +104,8 @@ def test_load_archive_with_a_symbol_index():
     The symbol index still has no backend that will take it, so the archive does not load. The loader should be
     the one saying so, rather than a probe raising on the way there.
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = os.path.join(tmpdir, "libsymdef.a")
-        with open(path, "wb") as fp:
-            fp.write(_bsd_archive([(b"__.SYMDEF SORTED", struct.pack("<I", 0))]))
-        with pytest.raises(cle.CLECompatibilityError):
-            cle.Loader(path, auto_load_libs=False)
+    with pytest.raises(cle.CLECompatibilityError, match="Unable to find a loader backend"):
+        cle.Loader(str(BSD_ARCHIVE), auto_load_libs=False)
 
 
 @pytest.mark.parametrize("kind", ["path", "file", "bytesio", "stream"])
@@ -143,19 +113,20 @@ def test_load_firmware_volume(kind):
     """
     A firmware volume loads the same way however the loader was given it.
     """
-    data = _firmware_volume()
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = os.path.join(tmpdir, "firmware.fd")
-        with open(path, "wb") as fp:
-            fp.write(data)
+    data = FIRMWARE_VOLUME.read_bytes()
+    if kind == "file":
+        with open(FIRMWARE_VOLUME, "rb") as fp:
+            ld = cle.Loader(fp, auto_load_libs=False)
+    else:
+        spec = {"path": str(FIRMWARE_VOLUME), "bytesio": BytesIO(data), "stream": MinimalStream(data)}[kind]
+        ld = cle.Loader(spec, auto_load_libs=False)
 
-        if kind == "file":
-            with open(path, "rb") as fp:
-                ld = cle.Loader(fp, auto_load_libs=False)
-        else:
-            spec = {"path": path, "bytesio": BytesIO(data), "stream": MinimalStream(data)}[kind]
-            ld = cle.Loader(spec, auto_load_libs=False)
-        assert isinstance(ld.main_object, UefiFirmware)
+    assert isinstance(ld.main_object, UefiFirmware)
+    # The drivers live in the compressed section, so reaching them is what says the whole volume was parsed
+    # rather than only recognized.
+    names = {child.user_interface_name for child in ld.main_object.child_objects}
+    assert {"ArmGicDxe", "BdsDxe", "VariableRuntimeDxe"} <= names
+    assert ld.main_object.arch.name == "AARCH64"
 
 
 def test_to_bytes_maps_a_whole_file_only():
@@ -163,39 +134,30 @@ def test_to_bytes_maps_a_whole_file_only():
     A stream may share a descriptor with a larger file, in which case mapping the file behind the descriptor
     would hand the parser the wrong bytes.
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = os.path.join(tmpdir, "container")
-        with open(path, "wb") as fp:
-            fp.write(b"headerBODYtrailer")
-        with open(path, "rb") as fp:
-            whole = UefiFirmware._to_bytes(fp)
-            assert isinstance(whole, mmap.mmap)
-            with whole:
-                assert whole[:] == b"headerBODYtrailer"
-            assert UefiFirmware._to_bytes(SliceOfFileStream(fp, 6, 4))[:] == b"BODY"
+    archive, members = _archive_members(BSD_ARCHIVE)
+    header = members[1].header
+    member = members[1].read()
+    archive.close()
+
+    with open(BSD_ARCHIVE, "rb") as fp:
+        whole = UefiFirmware._to_bytes(fp)
+        assert isinstance(whole, mmap.mmap)
+        with whole:
+            assert whole[:] == BSD_ARCHIVE.read_bytes()
+        assert UefiFirmware._to_bytes(SliceOfFileStream(fp, header.file_offset, header.size))[:] == member
 
 
-def test_empty_file_is_not_firmware():
+def test_empty_file_is_not_firmware(tmp_path):
     """
     There is nothing to map in an empty file, which is an answer the probe has to give rather than an error.
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = os.path.join(tmpdir, "empty")
-        with open(path, "wb"):
-            pass
-        with open(path, "rb") as fp:
-            assert UefiFirmware.is_compatible(fp) is False
-        with pytest.raises(cle.CLECompatibilityError):
-            cle.Loader(path, auto_load_libs=False)
+    path = tmp_path / "empty"
+    path.write_bytes(b"")
+    with open(path, "rb") as fp:
+        assert UefiFirmware.is_compatible(fp) is False
+    with pytest.raises(cle.CLECompatibilityError):
+        cle.Loader(str(path), auto_load_libs=False)
 
 
 if __name__ == "__main__":
-    for cls in ALL_BACKENDS.values():
-        if cls.is_default:
-            test_default_backends_probe_a_read_seek_stream(cls)
-    test_is_compatible_with_an_archive_member()
-    test_load_archive_with_a_symbol_index()
-    for _kind in ["path", "file", "bytesio", "stream"]:
-        test_load_firmware_volume(_kind)
-    test_to_bytes_maps_a_whole_file_only()
-    test_empty_file_is_not_firmware()
+    pytest.main([__file__])

--- a/tests/test_uefi_firmware.py
+++ b/tests/test_uefi_firmware.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import mmap
+import os
+import struct
+import tempfile
+import uuid
+from io import BytesIO
+
+import arpy
+import pytest
+
+import cle
+from cle.backends import ALL_BACKENDS
+from cle.backends.uefi_firmware import UefiFirmware
+
+FFS2_GUID = uuid.UUID("8c8ce578-8a3d-4f1c-9935-896185c32dd3").bytes_le
+LZMA_GUID = uuid.UUID("ee4e5898-3914-4259-9d6e-dc7bd79403cf").bytes_le
+FILE_GUID = uuid.UUID("f8a35c0e-1d20-4a1f-9c3c-6a2e0b7d5e41").bytes_le
+
+
+class MinimalStream:
+    """
+    A stream offering exactly what the loader asks of a binary specification: ``read`` and ``seek``.
+    """
+
+    def __init__(self, data: bytes):
+        self._data = data
+        self._pos = 0
+
+    def read(self, size=None):
+        end = len(self._data) if size is None else self._pos + size
+        chunk = self._data[self._pos : end]
+        self._pos += len(chunk)
+        return chunk
+
+    def seek(self, offset, whence=os.SEEK_SET):
+        if whence == os.SEEK_SET:
+            self._pos = offset
+        elif whence == os.SEEK_CUR:
+            self._pos += offset
+        else:
+            self._pos = len(self._data) + offset
+
+
+class SliceOfFileStream(MinimalStream):
+    """
+    A stream over part of a file that shares the file's descriptor, the way an archive member does.
+    """
+
+    def __init__(self, file, start: int, size: int):
+        file.seek(start)
+        super().__init__(file.read(size))
+        self._file = file
+
+    def fileno(self):
+        return self._file.fileno()
+
+    def tell(self):
+        return self._pos
+
+
+def _firmware_volume() -> bytes:
+    """
+    Build the smallest UEFI firmware volume that carries an LZMA-compressed section.
+
+    A compressed section is what makes this worth building: ``uefi_firmware`` joins the section's preamble to
+    its body before decompressing it, and a memoryview of the loader's stream cannot be joined to anything.
+    """
+    payload = b"\x5d" + b"\x00" * 64
+    # EFI_GUID_DEFINED_SECTION: the GUID, the offset of the body from the start of the section, attributes.
+    section_body = LZMA_GUID + struct.pack("<HH", 0x1C, 0x01) + payload
+    section = struct.pack("<3sB", (len(section_body) + 4).to_bytes(3, "little"), 0x02) + section_body
+
+    file_size = 0x18 + len(section)
+    file = struct.pack("<16sHBB3sB", FILE_GUID, 0, 0x02, 0, file_size.to_bytes(3, "little"), 0xF8) + section
+
+    header_size = 0x48
+    volume_size = header_size + len(file)
+    header = struct.pack(
+        "<16s16sQ4sIHHHsB", b"\x00" * 16, FFS2_GUID, volume_size, b"_FVH", 0, header_size, 0, 0, b"\x00", 2
+    )
+    block_map = struct.pack("<IIII", 1, volume_size, 0, 0)
+    return header + block_map + file
+
+
+def _bsd_archive(members: list[tuple[bytes, bytes]]) -> bytes:
+    """
+    Build a static archive in the BSD flavor, which stores member names in the member data.
+    """
+    out = b"!<arch>\n"
+    for name, data in members:
+        padded_name = name + b"\x00" * (-len(name) % 8)
+        payload = padded_name + data
+        header = b"%-16s%-12d%-6d%-6d%-8o%-10d\x60\n" % (
+            b"#1/%d" % len(padded_name),
+            0,
+            0,
+            0,
+            0o100644,
+            len(payload),
+        )
+        out += header + payload + (b"\n" if len(payload) % 2 else b"")
+    return out
+
+
+@pytest.mark.parametrize("backend", [b for b in ALL_BACKENDS.values() if b.is_default], ids=lambda b: b.__name__)
+def test_default_backends_probe_a_read_seek_stream(backend):
+    """
+    Backend detection offers every default backend every stream, so ``is_compatible`` has to answer for a stream
+    that is not a file object rather than raising.
+    """
+    assert backend.is_compatible(MinimalStream(b"\x00" * 64)) is False
+
+
+def test_is_compatible_with_an_archive_member():
+    """
+    A BSD symbol index is not an object file, so it is offered to every backend before the load gives up.
+    """
+    ar = arpy.Archive(fileobj=BytesIO(_bsd_archive([(b"__.SYMDEF SORTED", struct.pack("<I", 0))])))
+    ar.read_all_headers()
+    members = list(ar.archived_files.values())
+    assert len(members) == 1
+    assert UefiFirmware.is_compatible(members[0]) is False
+
+
+def test_load_archive_with_a_symbol_index():
+    """
+    The symbol index still has no backend that will take it, so the archive does not load. The loader should be
+    the one saying so, rather than a probe raising on the way there.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "libsymdef.a")
+        with open(path, "wb") as fp:
+            fp.write(_bsd_archive([(b"__.SYMDEF SORTED", struct.pack("<I", 0))]))
+        with pytest.raises(cle.CLECompatibilityError):
+            cle.Loader(path, auto_load_libs=False)
+
+
+@pytest.mark.parametrize("kind", ["path", "file", "bytesio", "stream"])
+def test_load_firmware_volume(kind):
+    """
+    A firmware volume loads the same way however the loader was given it.
+    """
+    data = _firmware_volume()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "firmware.fd")
+        with open(path, "wb") as fp:
+            fp.write(data)
+
+        if kind == "file":
+            with open(path, "rb") as fp:
+                ld = cle.Loader(fp, auto_load_libs=False)
+        else:
+            spec = {"path": path, "bytesio": BytesIO(data), "stream": MinimalStream(data)}[kind]
+            ld = cle.Loader(spec, auto_load_libs=False)
+        assert isinstance(ld.main_object, UefiFirmware)
+
+
+def test_to_bytes_maps_a_whole_file_only():
+    """
+    A stream may share a descriptor with a larger file, in which case mapping the file behind the descriptor
+    would hand the parser the wrong bytes.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "container")
+        with open(path, "wb") as fp:
+            fp.write(b"headerBODYtrailer")
+        with open(path, "rb") as fp:
+            whole = UefiFirmware._to_bytes(fp)
+            assert isinstance(whole, mmap.mmap)
+            with whole:
+                assert whole[:] == b"headerBODYtrailer"
+            assert UefiFirmware._to_bytes(SliceOfFileStream(fp, 6, 4))[:] == b"BODY"
+
+
+def test_empty_file_is_not_firmware():
+    """
+    There is nothing to map in an empty file, which is an answer the probe has to give rather than an error.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "empty")
+        with open(path, "wb"):
+            pass
+        with open(path, "rb") as fp:
+            assert UefiFirmware.is_compatible(fp) is False
+        with pytest.raises(cle.CLECompatibilityError):
+            cle.Loader(path, auto_load_libs=False)
+
+
+if __name__ == "__main__":
+    for cls in ALL_BACKENDS.values():
+        if cls.is_default:
+            test_default_backends_probe_a_read_seek_stream(cls)
+    test_is_compatible_with_an_archive_member()
+    test_load_archive_with_a_symbol_index()
+    for _kind in ["path", "file", "bytesio", "stream"]:
+        test_load_firmware_volume(_kind)
+    test_to_bytes_maps_a_whole_file_only()
+    test_empty_file_is_not_firmware()

--- a/tests/test_uefi_firmware.py
+++ b/tests/test_uefi_firmware.py
@@ -108,6 +108,25 @@ def test_load_archive_with_a_symbol_index():
         cle.Loader(str(BSD_ARCHIVE), auto_load_libs=False)
 
 
+def test_load_a_read_seek_stream_no_backend_claims():
+    """
+    The same answer when the loader is handed the stream itself rather than a path.
+
+    ``Loader._load_object_isolated`` dispatches on ``read``/``seek``, which is a wider set than the ``BinaryIO``
+    annotation describes, so every default probe sees a stream with no file descriptor. Carrying bytes that
+    nothing claims, it has to come back as "no backend matched" rather than as whatever the probe raised on the
+    way there. From #778, which reported the bug in this end-to-end shape.
+    """
+    archive, members = _archive_members(BSD_ARCHIVE)
+    symbol_index = members[0].read()
+    archive.close()
+
+    with pytest.raises(cle.CLECompatibilityError, match="Unable to find a loader backend"):
+        # the ignore is the mismatch itself: the annotation says BinaryIO, the dispatch asks only for
+        # read and seek, and cle hands itself streams from the wider set
+        cle.Loader(MinimalStream(symbol_index), auto_load_libs=False)  # type: ignore[arg-type]
+
+
 @pytest.mark.parametrize("kind", ["path", "file", "bytesio", "stream"])
 def test_load_firmware_volume(kind):
     """


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Loading `tests/aarch64/bsd_symdef_archive.a` dies inside backend detection, before any backend has claimed the stream:

```text
C Loader(bsd_symdef_archive.a): RAISED AttributeError: 'ArchiveFileData' object has no attribute 'fileno'
C Loader(bsd_symdef_archive.a):   at uefi_firmware.py:_to_bytes  |  fileno = fileobj.fileno()
```

Detection offers every stream to every default backend, and the loader promises a backend only `read` and `seek`, so this is not confined to archives: any such stream aborts the load rather than being declined, an empty file raises `ValueError: cannot mmap an empty file` from the same probe, and a firmware volume handed in as a `BytesIO` — which is how the CARTFile backend delivers unpacked contents — fails with `TypeError: unsupported operand type(s) for +: 'memoryview' and 'memoryview'`.

### Root cause

`UefiFirmware._to_bytes` assumed a real file object, and caught only the exception one raises:

```python
try:
    fileno = fileobj.fileno()
except io.UnsupportedOperation:
    pass
else:
    return mmap.mmap(fileno, 0, access=mmap.ACCESS_READ)

if isinstance(fileobj, io.BytesIO):
    return fileobj.getbuffer()
```

A stream with no `fileno` at all raises `AttributeError` through both arms. Where a descriptor does exist, mapping it is right only if the stream spans that file: an archive member shares its container's descriptor, so the probe read the whole 20456-byte archive where the member is 7688 bytes. And `getbuffer()` returns a `memoryview`, which `uefi_firmware` cannot concatenate when it joins a compressed section's preamble to its body.

### Fix

The probe has to answer for whatever stream it is handed, so it now reads the stream, taking the mmap shortcut only when the descriptor's file is non-empty and the stream seeks to exactly that size, and catching `AttributeError`, `OSError` and `ValueError`. The `BytesIO` special case is dropped so every non-mappable stream comes back as real `bytes`.

```text
A is_compatible(archive member proxy): False
C Loader(bsd_symdef_archive.a): RAISED CLECompatibilityError: Unable to find a loader backend
F _to_bytes(slice of file): bytes, len=7688 (want 7688), equals member = True
G is_compatible(empty file): False
H load firmware volume as bytesio: UefiFirmware arch=AARCH64 children=93
```

Such an archive still does not load — its symbol index reaches the loader as though it were an object file — but it now fails with a `CLEError` saying so.

### Testing

`tests/test_uefi_firmware.py` loads `tests/aarch64/edk2_armvirtqemu.fd` by path, file object, `BytesIO` and a bare read/seek stream, and probes an `arpy` archive member, a minimal stream and an empty file. The load-bearing assertion is `assert UefiFirmware._to_bytes(SliceOfFileStream(fp, header.file_offset, header.size))[:] == member`, which on the merge base compares the whole container against one member. Both fixtures are on `angr/binaries` master.

Validation: https://github.com/angr/cle/pull/720#issuecomment-5233532108

session: sharpen
