### PR TITLE
ELF: Do not decode the dynamic table out of zero-fill

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1033,6 +1033,16 @@ class ELF(MetaELF):
         """
         Parse the dynamic section for dynamically linked objects.
         """
+        # A separate debug-info file, such as the output of objcopy --only-keep-debug, turns every allocated section
+        # into SHT_NOBITS and drops the file backing of the segments that carried them. Its dynamic table has no
+        # contents anywhere, so the tags below would be decoded out of zero-fill.
+        if (
+            seg_readelf.header.p_filesz == 0
+            and next(seg_readelf.elffile.address_offsets(seg_readelf.header.p_vaddr), None) is None
+        ):
+            log.warning("The dynamic table of %s has no contents. Skipping it.", self.binary)
+            return
+
         # PATHOLOGICAL CASE
         # some elf files have a dyn with filesz = 0 but actually do contain content. this is valid. apparently.
         # this is a hack. there is certainly a better way to do this

--- a/tests/test_only_keep_debug.py
+++ b/tests/test_only_keep_debug.py
@@ -1,0 +1,57 @@
+# pylint:disable=no-self-use,missing-class-docstring
+from __future__ import annotations
+
+import os
+import unittest
+
+import cle
+
+TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries", "tests"))
+
+
+def load(*path: str, **kwargs) -> cle.backends.ELF:
+    elf = cle.Loader(os.path.join(TESTS_BASE, *path), auto_load_libs=False, **kwargs).main_object
+    assert isinstance(elf, cle.backends.ELF)
+    return elf
+
+
+class TestOnlyKeepDebug(unittest.TestCase):
+    def test_dynamic_table_without_contents(self):
+        # linked_list.debug is the objcopy --only-keep-debug output of linked_list, the kind of file
+        # /usr/lib/debug and -dbg packages are made of. Every allocated section is SHT_NOBITS, so its
+        # dynamic table has neither contents in the file nor anything behind it in the loaded image.
+        elf = load("x86_64", "linked_list.debug")
+
+        # nothing is left of the dynamic table or the dynamic symbols
+        assert elf.deps == []
+        assert elf.get_symbol("printf") is None
+
+        # but the retained .symtab is still read
+        main = elf.get_symbol("main")
+        assert main is not None
+        assert main.rebased_addr == 0x4005E9
+
+    def test_debug_info_is_preserved(self):
+        # the reason to load one of these files at all: it carries the debug info of the binary it was split from
+        stock = load("x86_64", "linked_list", load_debug_info=True)
+        debug = load("x86_64", "linked_list.debug", load_debug_info=True)
+
+        subprograms = {addr: subprogram.name for addr, subprogram in debug.functions_debug_info.items()}
+        assert subprograms == {addr: subprogram.name for addr, subprogram in stock.functions_debug_info.items()}
+        assert subprograms == {0x40057D: "sum", 0x4005B7: "alloc", 0x4005E9: "main"}
+        assert dict(stock.addr_to_line)
+        assert dict(debug.addr_to_line) == dict(stock.addr_to_line)
+
+    def test_dynamic_table_filesz_zero(self):
+        # fauxware_dynamic_filesz0 is fauxware with p_filesz cleared on PT_DYNAMIC alone, leaving the
+        # segment that carries the dynamic table backed by the file. Its dynamic table still has to be read.
+        elf = load("x86_64", "fauxware_dynamic_filesz0")
+
+        assert elf.deps == ["libc.so.6"]
+        puts = elf.get_symbol("puts")
+        assert puts is not None
+        assert puts.is_import
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A separate debug-info file — `objcopy --only-keep-debug` output, which is what `/usr/lib/debug` and `-dbg` packages contain — does not load. On `tests/x86_64/linked_list.debug`:

```text
A load linked_list.debug: RAISED AssertionError: <no message>
A load linked_list.debug:   at dynamic.py:_get_stringtable  |  assert isinstance(self._stringtable, _StringTable)
```

The message-less `AssertionError` comes out of the backend constructor, so the whole load fails and the `.symtab` and DWARF that are the only reason to open such a file go with it.

### Root cause

`ELF.__register_dyn` opens with a workaround for segments whose contents are not in the file:

```python
if seg_readelf.header.p_filesz == 0 and seg_readelf.header.p_memsz != 0:
    seg_readelf.header.p_filesz = seg_readelf.header.p_memsz
    seg_readelf.header.p_offset = AT.from_lva(seg_readelf.header.p_vaddr, self).to_rva()
```

That predicate assumes something is behind the segment in the loaded image, which holds for the pathological case it was written for. `--only-keep-debug` turns every allocated section into `SHT_NOBITS` and strips the file backing of the segments carrying them, so this file's `PT_DYNAMIC` and the `PT_LOAD` covering it both have `p_filesz == 0` and nothing backs the address either. The rewrite re-reads the table anyway, decodes a `DT_STRTAB` out of zero-fill, and the string table lookup that follows is what asserts.

### Fix

That rewrite is ours, so this is where the check belongs: `__register_dyn` logs a warning and returns early when `p_filesz` is zero and `elffile.address_offsets(p_vaddr)` yields nothing — no `PT_LOAD` backs the address with file contents — leaving `self._dynamic`, `self.deps` and the dynamic symbols empty. The rest of the file loads normally, and objects whose dynamic table really is behind a zero `p_filesz` keep the existing workaround.

```text
A load linked_list.debug: backend=ELF deps=[] dynamic tags=[]
    get_symbol('printf')=None  get_symbol('main').rebased_addr=0x4005e9
B debug info vs the stock binary: subprograms={'0x40057d': 'sum', '0x4005b7': 'alloc', '0x4005e9': 'main'}
    same_as_stock=True lines_same=True n_lines=29
C fauxware_dynamic_filesz0 (p_filesz=0 but file-backed): deps=['libc.so.6'] puts.is_import=True
```

A debug file is still loaded as an ordinary ELF rather than recognised as a separate debug object.

### Testing

`tests/test_only_keep_debug.py::TestOnlyKeepDebug::test_debug_info_is_preserved` asserts `subprograms == {addr: subprogram.name for addr, subprogram in stock.functions_debug_info.items()}` against `tests/x86_64/linked_list`; `::test_dynamic_table_without_contents` pins the empty deps and the retained `.symtab`; `::test_dynamic_table_filesz_zero` loads `tests/x86_64/fauxware_dynamic_filesz0`, a `fauxware` with `p_filesz` cleared on `PT_DYNAMIC` alone, which pins that a dynamic table with contents is still read. The first two fail on the merge base with the assertion above.

sync: angr/binaries#189

Validation: https://github.com/angr/cle/pull/723#issuecomment-5234246281

session: sharpen
