### PR TITLE
Load ARM64 and ARMNT COFF objects

### DIFF
--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -11,6 +11,7 @@ from enum import IntEnum, IntFlag
 
 import archinfo
 
+from cle.errors import CLECompatibilityError, CLEOperationError
 from cle.utils import extract_null_terminated_bytestr
 
 from .backend import Backend, register_backend
@@ -27,7 +28,17 @@ class IMAGE_FILE_MACHINE(IntEnum):
     """
 
     I386 = 0x14C
+    ARMNT = 0x1C4
     AMD64 = 0x8664
+    ARM64 = 0xAA64
+
+
+COFF_MACHINE_TO_ARCH_NAME = {
+    IMAGE_FILE_MACHINE.I386: "x86",
+    IMAGE_FILE_MACHINE.ARMNT: "ARMEL",
+    IMAGE_FILE_MACHINE.AMD64: "AMD64",
+    IMAGE_FILE_MACHINE.ARM64: "AARCH64",
+}
 
 
 class CoffFileHeader(ctypes.LittleEndianStructure):
@@ -133,6 +144,37 @@ class IMAGE_REL_AMD64(IntEnum):
     SECREL = 0x000B
 
 
+class IMAGE_REL_ARM(IntEnum):
+    """
+    ARM Relocation Types
+    """
+
+    ADDR32 = 0x0001
+    ADDR32NB = 0x0002
+    REL32 = 0x000A
+    SECTION = 0x000E
+    SECREL = 0x000F
+    MOV32T = 0x0011
+    BRANCH24T = 0x0014
+
+
+class IMAGE_REL_ARM64(IntEnum):
+    """
+    ARM64 Relocation Types
+    """
+
+    ADDR32 = 0x0001
+    ADDR32NB = 0x0002
+    BRANCH26 = 0x0003
+    PAGEBASE_REL21 = 0x0004
+    PAGEOFFSET_12A = 0x0006
+    PAGEOFFSET_12L = 0x0007
+    SECREL = 0x0008
+    SECTION = 0x000D
+    ADDR64 = 0x000E
+    REL32 = 0x0011
+
+
 class CoffRelocationTableEntry(ctypes.LittleEndianStructure):
     """
     COFF Relocations
@@ -175,11 +217,8 @@ class CoffParser:
 
     def _parse(self) -> None:
         self.header = CoffFileHeader.from_buffer_copy(self.data)
-        if self.header.Machine not in {
-            IMAGE_FILE_MACHINE.I386,
-            IMAGE_FILE_MACHINE.AMD64,
-        }:
-            raise NotImplementedError("Unsupported machine type")
+        if self.header.Machine not in COFF_MACHINE_TO_ARCH_NAME:
+            raise CLECompatibilityError(f"Unsupported machine type {self.header.Machine:#06x}")
 
         strings_offset = (
             self.header.PointerToSymbolTable + ctypes.sizeof(CoffSymbolTableEntry) * self.header.NumberOfSymbols
@@ -357,7 +396,7 @@ class CoffRelocationDIR32NB(CoffRelocation):
 
 class CoffRelocationADDR32NB(CoffRelocation):
     """
-    Relocation for IMAGE_REL_AMD64_ADDR32NB
+    Relocation for IMAGE_REL_*_ADDR32NB
     """
 
     __slots__ = ()
@@ -365,12 +404,14 @@ class CoffRelocationADDR32NB(CoffRelocation):
     @property
     def value(self) -> int:
         assert self.resolvedby is not None
-        return self.resolvedby.relative_addr
+        org_bytes = self.owner.memory.load(self.relative_addr, 4)
+        org_value = struct.unpack("<I", org_bytes)[0]
+        return org_value + self.resolvedby.relative_addr
 
 
 class CoffRelocationADDR64(CoffRelocation):
     """
-    Relocation for IMAGE_REL_AMD64_ADDR64
+    Relocation for IMAGE_REL_*_ADDR64
     """
 
     __slots__ = ()
@@ -380,7 +421,9 @@ class CoffRelocationADDR64(CoffRelocation):
     @property
     def value(self):
         assert self.resolvedby is not None
-        return self.resolvedby.rebased_addr
+        org_bytes = self.owner.memory.load(self.relative_addr, 8)
+        org_value = struct.unpack("<Q", org_bytes)[0]
+        return org_value + self.resolvedby.rebased_addr
 
 
 class CoffRelocationSECTION(CoffRelocation):
@@ -413,6 +456,212 @@ class CoffRelocationSECREL(CoffRelocation):
         return offset_to_symbol
 
 
+def _sign_extend(value: int, bits: int) -> int:
+    """
+    Interpret the low `bits` bits of `value` as a two's complement signed integer.
+    """
+    sign_bit = 1 << (bits - 1)
+    return (value & (sign_bit - 1)) - (value & sign_bit)
+
+
+class CoffRelocationARM64(CoffRelocation):
+    """
+    Base class for ARM64 relocations that patch an immediate field of a single instruction. `value` is the whole
+    patched instruction word.
+    """
+
+    __slots__ = ()
+
+    PACK_FORMAT = "<I"
+
+    @property
+    def instruction(self) -> int:
+        return struct.unpack("<I", self.owner.memory.load(self.relative_addr, 4))[0]
+
+
+class CoffRelocationARM64BRANCH26(CoffRelocationARM64):
+    """
+    Relocation for IMAGE_REL_ARM64_BRANCH26, the imm26 displacement of a B or BL instruction.
+    """
+
+    __slots__ = ()
+
+    @property
+    def value(self):
+        assert self.resolvedby is not None
+        instruction = self.instruction
+        addend = _sign_extend(instruction, 26) * 4
+        offset = self.resolvedby.rebased_addr + addend - self.rebased_addr
+        return (instruction & 0xFC000000) | ((offset >> 2) & 0x03FFFFFF)
+
+
+class CoffRelocationARM64PAGEBASE_REL21(CoffRelocationARM64):
+    """
+    Relocation for IMAGE_REL_ARM64_PAGEBASE_REL21, the 4KiB page displacement of an ADRP instruction. Its immediate
+    is split into immlo, bits 30:29, and immhi, bits 23:5.
+    """
+
+    __slots__ = ()
+
+    IMMEDIATE_MASK = 0x60FFFFE0
+
+    @property
+    def value(self):
+        assert self.resolvedby is not None
+        instruction = self.instruction
+        addend = _sign_extend(((instruction >> 29) & 0x3) | ((instruction >> 3) & 0x1FFFFC), 21)
+        pages = ((self.resolvedby.rebased_addr + addend) >> 12) - (self.rebased_addr >> 12)
+        return (instruction & ~self.IMMEDIATE_MASK) | ((pages & 0x3) << 29) | ((pages & 0x1FFFFC) << 3)
+
+
+class CoffRelocationARM64PAGEOFFSET_12A(CoffRelocationARM64):
+    """
+    Relocation for IMAGE_REL_ARM64_PAGEOFFSET_12A, the target's offset within its 4KiB page, in the imm12 field of
+    an ADD or ADDS instruction.
+    """
+
+    __slots__ = ()
+
+    @property
+    def value(self):
+        assert self.resolvedby is not None
+        instruction = self.instruction
+        addend = (instruction >> 10) & 0xFFF
+        offset = (self.resolvedby.rebased_addr & 0xFFF) + addend
+        return (instruction & ~(0xFFF << 10)) | ((offset & 0xFFF) << 10)
+
+
+class CoffRelocationARM64PAGEOFFSET_12L(CoffRelocationARM64):
+    """
+    Relocation for IMAGE_REL_ARM64_PAGEOFFSET_12L, the target's offset within its 4KiB page, in the imm12 field of a
+    load or store with an unsigned immediate offset. That field is scaled by the access size.
+    """
+
+    __slots__ = ()
+
+    @property
+    def value(self):
+        assert self.resolvedby is not None
+        instruction = self.instruction
+        scale = instruction >> 30
+        if scale == 0 and (instruction & 0x04800000) == 0x04800000:
+            # 128 bit vector accesses encode size 0 with the high opc bit set.
+            scale = 4
+        addend = (instruction >> 10) & 0xFFF
+        offset = ((self.resolvedby.rebased_addr & 0xFFF) >> scale) + addend
+        return (instruction & ~(0xFFF << 10)) | ((offset & 0xFFF) << 10)
+
+
+class CoffRelocationARMAbsolute(CoffRelocation):
+    """
+    Base class for ARMNT relocations that write the absolute address of their target. ARMNT code is Thumb-2 only, so
+    a target typed as a function is Thumb code and its address carries the Thumb bit.
+    """
+
+    __slots__ = ()
+
+    def resolve_symbol(self, solist, thumb=False, extern_object=None, **kwargs):
+        if self.symbol is not None and self.symbol.type == SymbolType.TYPE_FUNCTION:
+            thumb = True
+        super().resolve_symbol(solist, thumb=thumb, extern_object=extern_object, **kwargs)
+
+
+class CoffRelocationARMADDR32(CoffRelocationARMAbsolute, CoffRelocationDIR32):
+    """
+    Relocation for IMAGE_REL_ARM_ADDR32.
+    """
+
+    __slots__ = ()
+
+
+class CoffRelocationARMBRANCH24T(CoffRelocation):
+    """
+    Relocation for IMAGE_REL_ARM_BRANCH24T, the displacement of a Thumb-2 B.W or BL instruction. `value` is both
+    halfwords, each little-endian, so packing them as one little-endian word writes them back in order.
+    """
+
+    __slots__ = ()
+
+    PACK_FORMAT = "<I"
+
+    def resolve_symbol(self, solist, thumb=False, extern_object=None, **kwargs):  # pylint: disable=unused-argument
+        # The target is always Thumb code, whatever the caller assumed.
+        super().resolve_symbol(solist, thumb=True, extern_object=extern_object, **kwargs)
+
+    @property
+    def value(self):
+        assert self.resolvedby is not None
+        hw0, hw1 = struct.unpack("<HH", self.owner.memory.load(self.relative_addr, 4))
+
+        # imm25 is S:I1:I2:imm10:imm11:0, where I1 is NOT(J1 EOR S) and I2 is NOT(J2 EOR S).
+        sign = (hw0 >> 10) & 1
+        addend = _sign_extend(
+            (sign << 24)
+            | ((((hw1 >> 13) & 1) ^ sign ^ 1) << 23)
+            | ((((hw1 >> 11) & 1) ^ sign ^ 1) << 22)
+            | ((hw0 & 0x3FF) << 12)
+            | ((hw1 & 0x7FF) << 1),
+            25,
+        )
+
+        # The Thumb program counter reads four bytes ahead.
+        offset = self.resolvedby.rebased_addr + addend - (self.rebased_addr + 4)
+        if not -(1 << 24) <= offset < (1 << 24):
+            raise CLEOperationError(
+                f"Jump target out of range for relocation IMAGE_REL_ARM_BRANCH24T (+- 2^24) at "
+                f"{self.rebased_addr:#x}. This may be due to the extern object being allocated outside the jump "
+                f"range. If you believe this is the case, set 'rebase_granularity'=0x1000 in the load options."
+            )
+
+        sign = (offset >> 24) & 1
+        hw0 = (hw0 & 0xF800) | (sign << 10) | ((offset >> 12) & 0x3FF)
+        hw1 = (
+            (hw1 & 0xD000)
+            | ((((offset >> 23) & 1) ^ sign ^ 1) << 13)
+            | ((((offset >> 22) & 1) ^ sign ^ 1) << 11)
+            | ((offset >> 1) & 0x7FF)
+        )
+        return hw0 | (hw1 << 16)
+
+
+def _read_thumb_mov_imm16(hw0: int, hw1: int) -> int:
+    """
+    Extract the 16 bit immediate imm4:i:imm3:imm8 of a Thumb-2 MOVW or MOVT instruction from its two halfwords.
+    """
+    return ((hw0 & 0xF) << 12) | ((hw0 & 0x400) << 1) | ((hw1 & 0x7000) >> 4) | (hw1 & 0xFF)
+
+
+def _write_thumb_mov_imm16(hw0: int, hw1: int, imm: int) -> tuple[int, int]:
+    """
+    Replace the 16 bit immediate of a Thumb-2 MOVW or MOVT instruction, returning its two patched halfwords.
+    """
+    return (
+        (hw0 & 0xFBF0) | ((imm & 0x800) >> 1) | ((imm >> 12) & 0xF),
+        (hw1 & 0x8F00) | ((imm & 0x700) << 4) | (imm & 0xFF),
+    )
+
+
+class CoffRelocationARMMOV32T(CoffRelocationARMAbsolute):
+    """
+    Relocation for IMAGE_REL_ARM_MOV32T, the 32 bit address of the target split across a consecutive Thumb-2 MOVW
+    and MOVT pair.
+    """
+
+    __slots__ = ()
+
+    PACK_FORMAT = "<Q"
+
+    @property
+    def value(self):
+        assert self.resolvedby is not None
+        movw_hw0, movw_hw1, movt_hw0, movt_hw1 = struct.unpack("<HHHH", self.owner.memory.load(self.relative_addr, 8))
+        addend = _read_thumb_mov_imm16(movw_hw0, movw_hw1) | (_read_thumb_mov_imm16(movt_hw0, movt_hw1) << 16)
+        target = (self.resolvedby.rebased_addr + addend) & 0xFFFFFFFF
+        movw_hw0, movw_hw1 = _write_thumb_mov_imm16(movw_hw0, movw_hw1, target & 0xFFFF)
+        movt_hw0, movt_hw1 = _write_thumb_mov_imm16(movt_hw0, movt_hw1, target >> 16)
+        return movw_hw0 | (movw_hw1 << 16) | (movt_hw0 << 32) | (movt_hw1 << 48)
+
+
 RELOC_CLASSES: dict[IntEnum, dict[IntEnum, type[Relocation]]] = {
     IMAGE_FILE_MACHINE.I386: {
         IMAGE_REL_I386.REL32: CoffRelocationREL32,
@@ -428,11 +677,27 @@ RELOC_CLASSES: dict[IntEnum, dict[IntEnum, type[Relocation]]] = {
         IMAGE_REL_AMD64.SECTION: CoffRelocationSECTION,
         IMAGE_REL_AMD64.SECREL: CoffRelocationSECREL,
     },
-}
-
-COFF_MACHINE_TO_ARCH_NAME = {
-    IMAGE_FILE_MACHINE.I386: "x86",
-    IMAGE_FILE_MACHINE.AMD64: "AMD64",
+    IMAGE_FILE_MACHINE.ARMNT: {
+        IMAGE_REL_ARM.ADDR32: CoffRelocationARMADDR32,
+        IMAGE_REL_ARM.ADDR32NB: CoffRelocationADDR32NB,
+        IMAGE_REL_ARM.REL32: CoffRelocationREL32,
+        IMAGE_REL_ARM.SECTION: CoffRelocationSECTION,
+        IMAGE_REL_ARM.SECREL: CoffRelocationSECREL,
+        IMAGE_REL_ARM.MOV32T: CoffRelocationARMMOV32T,
+        IMAGE_REL_ARM.BRANCH24T: CoffRelocationARMBRANCH24T,
+    },
+    IMAGE_FILE_MACHINE.ARM64: {
+        IMAGE_REL_ARM64.ADDR32: CoffRelocationDIR32,
+        IMAGE_REL_ARM64.ADDR32NB: CoffRelocationADDR32NB,
+        IMAGE_REL_ARM64.BRANCH26: CoffRelocationARM64BRANCH26,
+        IMAGE_REL_ARM64.PAGEBASE_REL21: CoffRelocationARM64PAGEBASE_REL21,
+        IMAGE_REL_ARM64.PAGEOFFSET_12A: CoffRelocationARM64PAGEOFFSET_12A,
+        IMAGE_REL_ARM64.PAGEOFFSET_12L: CoffRelocationARM64PAGEOFFSET_12L,
+        IMAGE_REL_ARM64.SECREL: CoffRelocationSECREL,
+        IMAGE_REL_ARM64.SECTION: CoffRelocationSECTION,
+        IMAGE_REL_ARM64.ADDR64: CoffRelocationADDR64,
+        IMAGE_REL_ARM64.REL32: CoffRelocationREL32,
+    },
 }
 
 
@@ -525,7 +790,7 @@ class Coff(Backend):
         stream.seek(0)
         identstring = stream.read(2)
         stream.seek(0)
-        return int.from_bytes(identstring, "little") in (IMAGE_FILE_MACHINE.I386, IMAGE_FILE_MACHINE.AMD64)
+        return int.from_bytes(identstring, "little") in COFF_MACHINE_TO_ARCH_NAME
 
     def get_symbol(self, name: str, produce_extern_symbols: bool = False) -> Symbol | None:
         if name not in self._coff.symbol_name_to_idx:
@@ -543,6 +808,9 @@ class Coff(Backend):
             symbol_type = SymbolType.TYPE_FUNCTION if sym.Type == 0x20 else SymbolType.TYPE_OTHER
             if sym.SectionNumber > 0:
                 sym_addr = self._coff.sections[sym.SectionNumber - 1].PointerToRawData + sym.Value
+                if symbol_type == SymbolType.TYPE_FUNCTION and self._coff.header.Machine == IMAGE_FILE_MACHINE.ARMNT:
+                    # ARMNT code is always Thumb-2.
+                    sym_addr |= 1
                 return Symbol(self, name, sym_addr, 1, symbol_type)
             elif sym.SectionNumber == 0:
                 if produce_extern_symbols:

--- a/tests/test_coff.py
+++ b/tests/test_coff.py
@@ -10,6 +10,14 @@ import cle
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
 
+def addr_of(symbol: cle.Symbol | None) -> int:
+    """
+    Return the rebased address of a symbol lookup, failing the test if the lookup found nothing.
+    """
+    assert symbol is not None
+    return symbol.rebased_addr
+
+
 def section_vaddr(obj, name: str) -> int:
     return next(section.vaddr for section in obj.sections if section.name == name)
 
@@ -73,6 +81,98 @@ class TestCoff(unittest.TestCase):
         ld = cle.Loader(exe, auto_load_libs=False)
         field_addr = section_vaddr(ld.main_object, ".text") + field_offset
         assert ld.memory.load(field_addr, 4) == struct.pack("<i", expected)
+
+    def test_x86_64_pdata_addends(self):
+        # A .pdata RUNTIME_FUNCTION holds its function's bounds as two ADDR32NB relocations against the same section
+        # symbol, told apart only by their in-place addends. Dropping those left every record an empty range.
+        exe = os.path.join(TEST_BASE, "tests", "x86_64", "fauxware.obj")
+        ld = cle.Loader(exe, auto_load_libs=True)
+
+        pdata = next(section for section in ld.main_object.sections if section.name.startswith(".pdata"))
+        assert pdata.filesize > 0 and pdata.filesize % 12 == 0
+        for record in range(pdata.filesize // 12):
+            address = pdata.vaddr + record * 12
+            begin, end, _unwind = struct.unpack("<3I", ld.memory.load(address, 12))
+            assert begin < end
+
+    def test_unsupported_machine(self):
+        exe = os.path.join(TEST_BASE, "tests", "mips", "coff_r4000.obj")
+
+        # Autodetection does not pick the COFF backend for it at all.
+        with self.assertRaises(cle.CLECompatibilityError):
+            cle.Loader(exe, auto_load_libs=False)
+
+        # Asking for the backend by name reports the machine type that was rejected.
+        with self.assertRaises(cle.CLECompatibilityError) as cm:
+            cle.Loader(exe, auto_load_libs=False, main_opts={"backend": "COFF"})
+        assert "0x0166" in str(cm.exception)
+
+    def test_arm64(self):
+        exe = os.path.join(TEST_BASE, "tests", "aarch64", "coff_reloc_arm64.obj")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        assert type(ld.main_object).__name__ == "Coff"
+        assert ld.main_object.arch.name == "AARCH64"
+
+        target = addr_of(ld.main_object.get_symbol("target"))
+        aligned = addr_of(ld.main_object.get_symbol("aligned"))
+        ext_fn = addr_of(ld.find_symbol("ext_fn"))
+        text = section_vaddr(ld.main_object, ".text")
+        assert aligned % 16 == 0
+        branch, adrp, add, ldr, add_addend, ldr_vector = struct.unpack("<6I", ld.memory.load(text, 24))
+
+        # imm26 is in units of four bytes, relative to the branch itself.
+        assert text + _sign_extend(branch, 26) * 4 == ext_fn
+        # ADRP forms the target's 4KiB page base; the instructions after it the offset within that page.
+        page = (text + 4 + (_sign_extend(((adrp >> 29) & 0x3) | ((adrp >> 3) & 0x1FFFFC), 21) << 12)) & ~0xFFF
+        assert page + ((add >> 10) & 0xFFF) == target
+        # A load scales its immediate by the access size: four bytes here, sixteen for a vector register.
+        assert page + ((ldr >> 10) & 0xFFF) * 4 == target
+        assert page + ((ldr_vector >> 10) & 0xFFF) * 16 == aligned
+        assert page + ((add_addend >> 10) & 0xFFF) == target + 4
+        assert struct.unpack("<Q", ld.memory.load(text + 0x20, 8))[0] == target + 8
+        assert struct.unpack("<I", ld.memory.load(text + 0x28, 4))[0] == target - ld.main_object.mapped_base + 4
+
+    def test_armnt(self):
+        exe = os.path.join(TEST_BASE, "tests", "armel", "coff_reloc_armnt.obj")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        assert type(ld.main_object).__name__ == "Coff"
+        assert ld.main_object.arch.name == "ARMEL"
+
+        # ARMNT code is Thumb-2 only, so function symbols carry the Thumb bit.
+        thumbfn = addr_of(ld.main_object.get_symbol("thumbfn"))
+        text = section_vaddr(ld.main_object, ".text")
+        assert thumbfn == text + 1
+
+        halfwords = struct.unpack("<10H", ld.memory.load(text, 20))
+        movw_hw0, movw_hw1, movt_hw0, movt_hw1, bl_hw0, bl_hw1 = halfwords[:6]
+        assert _read_mov_imm16(movw_hw0, movw_hw1) | (_read_mov_imm16(movt_hw0, movt_hw1) << 16) == thumbfn
+        assert _read_mov_imm16(*halfwords[6:8]) | (_read_mov_imm16(*halfwords[8:10]) << 16) == thumbfn + 4
+
+        sign = (bl_hw0 >> 10) & 1
+        displacement = _sign_extend(
+            (sign << 24)
+            | ((((bl_hw1 >> 13) & 1) ^ sign ^ 1) << 23)
+            | ((((bl_hw1 >> 11) & 1) ^ sign ^ 1) << 22)
+            | ((bl_hw0 & 0x3FF) << 12)
+            | ((bl_hw1 & 0x7FF) << 1),
+            25,
+        )
+        # The Thumb program counter reads four bytes ahead, and the branch drops its target's Thumb bit.
+        assert text + 8 + 4 + displacement == addr_of(ld.find_symbol("ext_fn")) - 1
+
+        # A function whose address is only taken is Thumb code too.
+        ext_ptr = addr_of(ld.find_symbol("ext_ptr"))
+        assert ext_ptr % 2 == 1
+        assert struct.unpack("<I", ld.memory.load(text + 0x18, 4))[0] == ext_ptr
+
+
+def _sign_extend(value: int, bits: int) -> int:
+    sign_bit = 1 << (bits - 1)
+    return (value & (sign_bit - 1)) - (value & sign_bit)
+
+
+def _read_mov_imm16(hw0: int, hw1: int) -> int:
+    return ((hw0 & 0xF) << 12) | ((hw0 & 0x400) << 1) | ((hw1 & 0x7000) >> 4) | (hw1 & 0xFF)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

An ARM64 or ARMNT COFF object fails autodetection, and naming the backend raises something a caller cannot catch as a `CLEError` and that does not say what it saw:

```text
D aarch64/coff_reloc_arm64.obj: RAISED CLECompatibilityError: Unable to find a loader backend
C mips/coff_r4000.obj with backend=COFF: RAISED NotImplementedError: Unsupported machine type
```

The addend defect underneath it is silent, and reaches x86-64 too. A `.pdata` `RUNTIME_FUNCTION` is two `ADDR32NB` relocations against the same section symbol, told apart only by the addends left in the patched fields, so on `tests/x86_64/fauxware.obj` every record collapses to a zero-length range:

```text
A x86_64/fauxware.obj .pdata ADDR32NB in-place addends: 1 RUNTIME_FUNCTION records, all begin<end = False
    ['[0x14e8,0x14e8) len=0x0']
```

That is the table the unwinder and any exception-handling analysis reads.

### Root cause

`CoffParser._parse` gated the whole backend on two machines, and `Coff.is_compatible` repeated the pair independently:

```python
if self.header.Machine not in {IMAGE_FILE_MACHINE.I386, IMAGE_FILE_MACHINE.AMD64}:
    raise NotImplementedError("Unsupported machine type")
```

Separately, `CoffRelocationADDR32NB.value` was `return self.resolvedby.relative_addr` and `CoffRelocationADDR64.value` was `return self.resolvedby.rebased_addr`. Neither reads the field it is about to overwrite, so the producer's addend is discarded.

### Fix

`COFF_MACHINE_TO_ARCH_NAME` becomes the one machine table `_parse` and `is_compatible` both consult, gaining ARMNT and ARM64, and an unsupported machine raises `CLECompatibilityError` naming it. `ADDR32NB` and `ADDR64` add the resolved address to the field's existing contents. New relocation classes cover the ARM64 `BRANCH26`/`PAGEBASE_REL21`/`PAGEOFFSET_12A`/`PAGEOFFSET_12L` set and the ARMNT `ADDR32`/`MOV32T`/`BRANCH24T` set; ARMNT code is Thumb-2 only, so its function symbols and extern stubs carry the Thumb bit.

```text
A .pdata: 1 RUNTIME_FUNCTION records, all begin<end = True   ['[0x14e8,0x1506) len=0x1e']
C mips/coff_r4000.obj with backend=COFF: CLECompatibilityError: Unsupported machine type 0x0166
D aarch64/coff_reloc_arm64.obj: backend=Coff arch=AARCH64
    BRANCH26 reaches ext_fn: True   PAGEOFFSET_12L(ldr q, scale 16) == aligned: True
    PAGEOFFSET_12A with addend == target+4: True   ADDR64 == target+8: True
E armel/coff_reloc_armnt.obj: backend=Coff arch=ARMEL
    thumbfn == .text+1 (Thumb bit): True   MOV32T with addend == thumbfn+4: True
```

The ARM64 relocation types the fixtures do not carry stay unimplemented, and `BRANCH24T` raises rather than synthesising a veneer for an out-of-range target.

### Testing

`tests/test_coff.py::TestCoff::test_x86_64_pdata_addends` asserts `begin < end` on every `.pdata` record; `::test_arm64` and `::test_armnt` load `tests/aarch64/coff_reloc_arm64.obj` and `tests/armel/coff_reloc_armnt.obj` and check each relocation's patched word against the symbol it names; `::test_unsupported_machine` pins the new error on `tests/mips/coff_r4000.obj`. All four fixtures are on `angr/binaries` master, so nothing here waits on a fixture change. `angr.Project` on these objects additionally needs a Win32 syscall convention angr lacks for AArch64 and ARM; that gap is not addressed here and `cle.Loader` is unaffected.

Validation: https://github.com/angr/cle/pull/724#issuecomment-5234251267

session: sharpen
