### PR TITLE
Load minidumps whose writer left out a stream

### DIFF
--- a/cle/backends/minidump/__init__.py
+++ b/cle/backends/minidump/__init__.py
@@ -12,9 +12,13 @@ from cle.backends.region import Section, Segment
 from cle.errors import CLEError, CLEInvalidBinaryError
 
 
-class MinidumpMissingStreamError(Exception):
+class MinidumpMissingStreamError(CLEError):
+    """
+    Error raised when a minidump does not contain a stream that the backend cannot do without.
+    """
+
     def __init__(self, stream, message=None):
-        super().__init__()
+        super().__init__(f"{stream}Stream is missing. {message}" if message else f"{stream}Stream is missing")
         self.message = message
         self.stream = stream
 
@@ -33,12 +37,18 @@ class Minidump(Backend):
 
         self.wow64 = False
 
+        # A minidump holds only the streams its writer chose to emit; the header and the stream directory are the
+        # only mandatory parts of the file. A dump with no module or thread list says nothing about the process's
+        # images or its threads, which is not the same thing as being invalid.
+        modules = self._mdf.modules.modules if self._mdf.modules is not None else []
+        threads = self._mdf.threads.threads if self._mdf.threads is not None else []
+
         if self._arch is None:
             if getattr(self._mdf, "sysinfo", None) is None:
                 raise MinidumpMissingStreamError("SystemInfo", "The architecture was not specified")
             arch = self._mdf.sysinfo.ProcessorArchitecture
             if arch == SystemInfoStream.PROCESSOR_ARCHITECTURE.AMD64:
-                if any(module.name.endswith("wow64.dll") for module in self._mdf.modules.modules):
+                if any(module.name.endswith("wow64.dll") for module in modules):
                     self.wow64 = True
                     self.set_arch(archinfo.ArchX86())
                 else:
@@ -54,7 +64,8 @@ class Minidump(Backend):
         elif self._mdf.memory_segments is not None:
             segments = self._mdf.memory_segments.memory_segments
         else:
-            raise MinidumpMissingStreamError("MemoryList", "The memory segments were not defined")
+            # neither memory list stream is present, so the dump captured no memory at all
+            segments = []
 
         for segment in segments:
             data = segment.read(segment.start_virtual_address, segment.size, self._mdf.file_handle)
@@ -63,7 +74,7 @@ class Minidump(Backend):
             )
             self.memory.add_backer(segment.start_virtual_address, data)
 
-        for module in self._mdf.modules.modules:
+        for module in modules:
             for segment in segments:
                 if segment.start_virtual_address == module.baseaddress:
                     break
@@ -75,7 +86,7 @@ class Minidump(Backend):
 
         self._thread_data = {}
 
-        for thread in self._mdf.threads.threads:
+        for thread in threads:
             tid = thread.ThreadId
             teb = thread.Teb
             self._binary_stream.seek(thread.ThreadContext.Rva)  # pylint: disable=undefined-loop-variable

--- a/tests/test_minidump.py
+++ b/tests/test_minidump.py
@@ -1,19 +1,60 @@
 from __future__ import annotations
 
+import io
 import os
-import unittest
+import struct
+from collections.abc import Iterable
 
 import archinfo
+import pytest
 
 import cle
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
+# A 32-bit Windows dump of the Java update scheduler, with modules, threads and its memory in a Memory64List.
+JUSCHED = os.path.join(TEST_BASE, "tests", "x86", "windows", "jusched_x86.dmp")
+# A 64-bit Windows dump of a crashing test program, from Breakpad's processor test data.
+TINY_EXE = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "breakpad", "tiny-exe-with-cet-xsave.dmp")
 
-@unittest.skipIf(cle.backends.minidump.minidumpfile is None, "minidump not available")
+UNUSED_STREAM = 0
+THREAD_LIST_STREAM = 3
+MODULE_LIST_STREAM = 4
+MEMORY_LIST_STREAM = 5
+SYSTEM_INFO_STREAM = 7
+
+MINIDUMP_DIRECTORY_ENTRY_SIZE = 12
+
+
+def without_streams(path: str, stream_types: Iterable[int]) -> io.BytesIO:
+    """
+    Read the dump at `path` and mark the given streams unused in its stream directory.
+
+    A minidump holds only the streams its writer collected, and a writer that reserved a directory entry for a
+    stream it did not write leaves that entry's type as UnusedStream; every dump used here already carries such
+    entries. Striking a stream out of the directory of a real dump is how the cases below get a dump that never
+    recorded its modules, its threads or its memory.
+    """
+
+    struck_out = set()
+    wanted = set(stream_types)
+    with open(path, "rb") as dump:
+        data = bytearray(dump.read())
+    # the signature and the version take the first eight bytes of the header, the stream count and the file
+    # offset of the directory the next eight
+    number_of_streams, directory_rva = struct.unpack_from("<II", data, 8)
+    for index in range(number_of_streams):
+        entry = directory_rva + MINIDUMP_DIRECTORY_ENTRY_SIZE * index
+        (stream_type,) = struct.unpack_from("<I", data, entry)
+        if stream_type in wanted:
+            struct.pack_into("<I", data, entry, UNUSED_STREAM)
+            struck_out.add(stream_type)
+    assert struck_out == wanted, f"{path} lists no stream of type {sorted(wanted - struck_out)}"
+    return io.BytesIO(bytes(data))
+
+
 def test_minidump():
-    exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "jusched_x86.dmp")
-    ld = cle.Loader(exe, auto_load_libs=False)
+    ld = cle.Loader(JUSCHED, auto_load_libs=False)
     assert isinstance(ld.main_object, cle.Minidump)
     assert isinstance(ld.main_object.arch, archinfo.ArchX86)
     assert ld.main_object.os == "windows"
@@ -44,5 +85,65 @@ def test_minidump():
     }
 
 
+def test_minidump_without_module_list():
+    # A dump without a ModuleListStream says nothing about which images were loaded, but its memory and its
+    # threads are still there to be used. On AMD64 the architecture is decided by looking through the module list
+    # for wow64.dll, and here there is no module list to look through.
+    ld = cle.Loader(without_streams(TINY_EXE, [MODULE_LIST_STREAM]), auto_load_libs=False)
+
+    assert isinstance(ld.main_object, cle.Minidump)
+    assert isinstance(ld.main_object.arch, archinfo.ArchAMD64)
+    assert not ld.main_object.wow64
+    assert len(ld.main_object.segments) == 65
+    assert len(ld.main_object.sections) == 0
+    assert ld.main_object.sections_map == {}
+
+    assert ld.main_object.threads == [0x5BC]
+    registers = ld.main_object.thread_registers(0x5BC)
+    assert registers["rip"] == 0x7FF9111E39E4
+    assert registers["rsp"] == 0xCBC82FF448
+    assert len(ld.tls.threads) == 1
+
+
+def test_minidump_without_thread_list():
+    # A dump without a ThreadListStream has no register state, and its modules and memory still load.
+    ld = cle.Loader(without_streams(JUSCHED, [THREAD_LIST_STREAM]), auto_load_libs=False)
+
+    assert len(ld.main_object.segments) == 173
+    assert len(ld.main_object.sections) == 30
+    assert "jusched.exe" in ld.main_object.sections_map
+    assert ld.main_object.threads == []
+    assert ld.tls.threads == []
+
+
+def test_minidump_without_captured_memory():
+    # A dump that captured no memory is not an invalid dump; it just has nothing to map. Without memory there is
+    # no image to attach a module to and no TEB to read a thread's registers through, so this is a dump whose
+    # writer recorded none of the three.
+    ld = cle.Loader(
+        without_streams(TINY_EXE, [MEMORY_LIST_STREAM, MODULE_LIST_STREAM, THREAD_LIST_STREAM]), auto_load_libs=False
+    )
+
+    assert isinstance(ld.main_object, cle.Minidump)
+    assert isinstance(ld.main_object.arch, archinfo.ArchAMD64)
+    assert len(ld.main_object.segments) == 0
+    assert len(ld.main_object.sections) == 0
+    assert ld.main_object.threads == []
+    assert ld.tls.threads == []
+
+
+def test_minidump_without_system_info():
+    # The architecture is the one thing the backend cannot do without, and the error saying so has to be a CLEError
+    # that carries its explanation.
+    dump = without_streams(TINY_EXE, [SYSTEM_INFO_STREAM])
+    with pytest.raises(cle.CLEError, match="SystemInfoStream is missing") as excinfo:
+        cle.Loader(dump, auto_load_libs=False)
+    assert isinstance(excinfo.value, cle.backends.minidump.MinidumpMissingStreamError)
+
+
 if __name__ == "__main__":
     test_minidump()
+    test_minidump_without_module_list()
+    test_minidump_without_thread_list()
+    test_minidump_without_captured_memory()
+    test_minidump_without_system_info()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A minidump's directory lists only the streams its writer emitted, and the backend could not cope when one was absent. Striking `ModuleListStream` out of the directory of `tests/x86_64/windows/breakpad/tiny-exe-with-cet-xsave.dmp` — which is exactly what a reader sees when the writer never collected it:

```text
    RAISED AttributeError: str(e)="'NoneType' object has no attribute 'modules'"
    isinstance(cle.CLEError) = False
      | if any(module.name.endswith("wow64.dll") for module in self._mdf.modules.modules):
```

The whole load goes with it: the memory the dump *did* capture, the register state of the threads it did record, and the section table built from its modules. And the one deliberate rejection was unusable — a missing `SystemInfoStream` raised `MinidumpMissingStreamError` with `str(e)=''` and `isinstance(cle.CLEError) = False`.

### Root cause

`Minidump.__init__` reaches into stream objects the `minidump` package leaves as `None`, at three sites — the `wow64.dll` scan above, `for module in self._mdf.modules.modules:` and `for thread in self._mdf.threads.threads:` — and a fourth treats a dump that captured no memory as invalid outright:

```python
raise MinidumpMissingStreamError("MemoryList", "The memory segments were not defined")
```

A minidump's only mandatory parts are its header and its stream directory, so each of these fires on a real dump. The error class compounded it: `class MinidumpMissingStreamError(Exception)` calling `super().__init__()` with no arguments, so the explanation was stashed on an attribute `str()` never reached and the exception sat outside the `CLEError` hierarchy.

### Fix

`modules` and `threads` are read once and default to `[]` when the stream is absent, so such a dump loads with no sections or no threads, and a dump with no memory list loads with `segments = []`. `MinidumpMissingStreamError` derives from `CLEError` and passes its explanation to the base class.

```text
--- no ModuleListStream:      LOADED Minidump arch=AMD64 segments=65 threads=['0x5bc'] rip=0x7ff9111e39e4
--- no ThreadListStream:      LOADED Minidump arch=X86 segments=173 sections=30 threads=[]
--- no captured memory:       LOADED Minidump arch=AMD64 segments=0 threads=[]
--- no SystemInfoStream:      RAISED MinidumpMissingStreamError:
    str(e)='SystemInfoStream is missing. The architecture was not specified'
    isinstance(cle.CLEError) = True
```

A missing `SystemInfoStream` still raises, because the architecture is the one thing the backend cannot infer, and a module whose image the dump did not capture is still rejected a few lines below.

### Testing

`tests/test_minidump.py` gains a test per absent stream: `test_minidump_without_module_list` asserts `ld.main_object.threads == [0x5BC]` on a dump whose module list is gone, `test_minidump_without_thread_list` pins the 30 sections that survive on `tests/x86/windows/jusched_x86.dmp`, `test_minidump_without_captured_memory` pins the empty segment list, and `test_minidump_without_system_info` pins the message and the `CLEError` base. Each takes a real dump and strikes a stream out of its directory in a temporary copy; both fixtures are on `angr/binaries` master. #715 reworks the same function, so whichever lands second needs a rebase.

Validation: https://github.com/angr/cle/pull/725#issuecomment-5234694843

session: sharpen
