### PR TITLE
CGC: Repair only the header bytes that are loaded

### DIFF
--- a/cle/backends/cgc/cgc.py
+++ b/cle/backends/cgc/cgc.py
@@ -21,7 +21,11 @@ class CGC(ELF):
     def __init__(self, binary, binary_stream, *args, **kwargs):
         binary_stream = PatchedStream(binary_stream, [(0, ELF_HEADER)])
         super().__init__(binary, binary_stream, *args, **kwargs)
-        self.memory.store(AT.from_raw(0, self).to_rva(), CGC_HEADER)  # repair the CGC header
+        # Repair the header bytes the substitution above reached. Nothing requires the header to be
+        # loaded, and a binary whose first PT_LOAD starts past it maps none of these bytes.
+        for offset in range(len(CGC_HEADER)):
+            if self.offset_to_addr(offset) is not None:
+                self.memory.store(AT.from_raw(offset, self).to_rva(), CGC_HEADER[offset : offset + 1])
         self.os = "cgc"
         self.execstack = True  # the stack is always executable in CGC
 

--- a/tests/test_cgc.py
+++ b/tests/test_cgc.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import io
+import os
+import struct
+
+import cle
+from cle.backends.cgc.cgc import CGC_HEADER, ELF_HEADER
+
+TESTS_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
+CGC_PATH = os.path.join(TESTS_PATH, "cgc", "CADET_00002")
+
+# Real CGC challenge binaries put their first PT_LOAD well past the 16-byte header. 8 leaves the header
+# straddling the segment boundary, which no shipped binary does but the backend still has to get right.
+UNMAPPED_OFFSET = 0xA0
+PARTIAL_OFFSET = 8
+
+
+def start_first_load_at(data: bytes, offset: int) -> bytes:
+    """
+    Rewrite the first PT_LOAD of a CGC binary to start at ``offset`` instead of file offset 0, leaving the
+    bytes it maps at the virtual addresses they had before.
+    """
+    patched = bytearray(data)
+    (e_phoff,) = struct.unpack_from("<I", patched, 0x1C)
+    e_phentsize, e_phnum = struct.unpack_from("<HH", patched, 0x2A)
+    assert e_phentsize == 32, "CGC binaries are 32-bit ELF"
+    for i in range(e_phnum):
+        entry = e_phoff + i * e_phentsize
+        p_type, p_offset, p_vaddr, p_paddr, p_filesz, p_memsz, p_flags, p_align = struct.unpack_from(
+            "<8I", patched, entry
+        )
+        if p_type == 1 and p_offset == 0:  # PT_LOAD
+            struct.pack_into(
+                "<8I",
+                patched,
+                entry,
+                p_type,
+                p_offset + offset,
+                p_vaddr + offset,
+                p_paddr + offset,
+                p_filesz - offset,
+                p_memsz - offset,
+                p_flags,
+                p_align,
+            )
+            return bytes(patched)
+    raise AssertionError("no PT_LOAD at file offset 0")
+
+
+def read_cgc() -> bytes:
+    with open(CGC_PATH, "rb") as f:
+        return f.read()
+
+
+def test_cgc_mapped_header():
+    ld = cle.Loader(CGC_PATH, auto_load_libs=False)
+    obj = ld.main_object
+    assert isinstance(obj, cle.backends.CGC)
+
+    # The ELF magic the backend substitutes into the stream is replaced by the real CGC header in memory.
+    assert ld.memory.load(obj.offset_to_addr(0), len(CGC_HEADER)) == CGC_HEADER
+
+
+def test_cgc_unmapped_header():
+    original = read_cgc()
+    ld = cle.Loader(io.BytesIO(start_first_load_at(original, UNMAPPED_OFFSET)), auto_load_libs=False)
+    obj = ld.main_object
+    assert isinstance(obj, cle.backends.CGC)
+
+    # Nothing maps the header, so none of the substituted ELF magic reaches memory.
+    assert obj.offset_to_addr(0) is None
+    assert not any(ELF_HEADER[:4] in bytes(backer) for _, backer in obj.memory.backers())
+
+    (entry,) = struct.unpack_from("<I", original, 0x18)
+    assert obj.entry == entry
+    load_addr = obj.offset_to_addr(UNMAPPED_OFFSET)
+    assert ld.memory.load(load_addr, 16) == original[UNMAPPED_OFFSET : UNMAPPED_OFFSET + 16]
+
+
+def test_cgc_partially_mapped_header():
+    ld = cle.Loader(io.BytesIO(start_first_load_at(read_cgc(), PARTIAL_OFFSET)), auto_load_libs=False)
+    obj = ld.main_object
+    assert isinstance(obj, cle.backends.CGC)
+
+    # Only the tail of the header is mapped, and that is exactly the part that gets repaired.
+    assert obj.offset_to_addr(0) is None
+    tail_addr = obj.offset_to_addr(PARTIAL_OFFSET)
+    assert ld.memory.load(tail_addr, len(CGC_HEADER) - PARTIAL_OFFSET) == CGC_HEADER[PARTIAL_OFFSET:]
+
+
+if __name__ == "__main__":
+    test_cgc_mapped_header()
+    test_cgc_unmapped_header()
+    test_cgc_partially_mapped_header()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A CGC binary whose first `PT_LOAD` starts past file offset 0 does not load. Moving that segment in a copy of `tests/cgc/CADET_00002` to offset `0xa0`, so the 16-byte header is not mapped at all:

```text
    RAISED TypeError: "unsupported operand type(s) for -: 'NoneType' and 'int'"
      | return cls(owner.offset_to_addr(raw) - (owner.mapped_base if owner._is_mapped else owner.linked_base), owner)
      | TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

The failure is in the constructor, so the whole object is lost — entry point, segments and symbols — over bytes that were never going to be in memory. Real challenge binaries with no `PT_PHDR` and a first `PT_LOAD` past the header have this shape.

### Root cause

The CGC backend substitutes an ELF magic into the stream so pyelftools will parse the file, then stores the real CGC header back into memory with one unconditional write:

```python
self.memory.store(AT.from_raw(0, self).to_rva(), CGC_HEADER)  # repair the CGC header
```

`AT.from_raw(0, self)` calls `owner.offset_to_addr(0)`, which returns `None` when no segment maps file offset 0, and the address translator then subtracts an `int` from it. Nothing in ELF requires the header to be mapped.

### Fix

The backend that makes the substitution is what has to undo it, so it now stores back only the bytes that were loaded, walking the 16 header bytes and writing each one whose file offset maps to an address. A binary mapping none of the header loads unchanged, and one whose first `PT_LOAD` begins partway into the header keeps its own bytes rather than the substituted magic. The substitution in the stream itself is untouched.

```text
--- stock binary:                 LOADED CGC entry=0x804909a  offset_to_addr(0)=0x8048000
    memory at offset 0x0: 7f43474301010143014d6572696e6f00   (== CGC_HEADER)
--- first PT_LOAD at offset 0xa0: LOADED CGC entry=0x804909a  offset_to_addr(0)=None
    ELF magic in any backer: False
--- first PT_LOAD at offset 0x8:  LOADED CGC entry=0x804909a  offset_to_addr(0)=None
    memory at offset 0x8: 014d6572696e6f000200030001000000   (== CGC_HEADER[8:] then the file's own bytes)
```

### Testing

`tests/test_cgc.py::test_cgc_mapped_header` pins the stock repair, and `::test_cgc_unmapped_header` and `::test_cgc_partially_mapped_header` move the first `PT_LOAD` of `tests/cgc/CADET_00002` in a temporary copy, keeping the bytes it maps at the addresses they had. The load-bearing assertion is `ld.memory.load(tail_addr, len(CGC_HEADER) - PARTIAL_OFFSET) == CGC_HEADER[PARTIAL_OFFSET:]`. The two moved cases fail on the merge base with the `TypeError` above, and no new fixture is needed.

Validation: https://github.com/angr/cle/pull/726#issuecomment-5234704374

session: sharpen
