### PR TITLE
Mach-O: Read the LC_UNIXTHREAD entry point per cputype

### DIFF
--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -189,15 +189,25 @@ class MachO(Backend):
             # Note that this should be customized for Apple ABI (TODO)
             self.set_arch(archinfo.arch_from_id(arch_ident, endness="lsb" if self.struct_byteorder == "<" else "msb"))
 
+            # Start reading load commands
+            lc_offset = (7 if self.arch.bits == 32 else 8) * 4
+
             # Determine the base address the binary was linked against
             # and set the values for the Backend and Loader accordingly
             if self.pic and self.filetype == MachoFiletype.MH_EXECUTE:
                 assert self.is_main_bin, "An file of type MH_EXECUTE should be the main bin, this should not happen"
                 # a Position Independent Main binary would later be loaded at 0x400000, which isn't legal for Mach-O
-                # Also, its segment vaddrs are relative to 0x100000000, so we set this as the linked base
-                # and the MachO Backend code uses the AdressTranslator to translate linked addresses to relative ones
+                # An executable is linked at the address of its __TEXT segment: that is where the mach header
+                # itself ends up, and what __mh_execute_header resolves to. ld64 puts it at 0x100000000 on 64 bit
+                # and 0x4000 on 32 bit, but that is a default and not a property of the format -- Go's linker
+                # links darwin/amd64 executables at 0x1000000 -- so read it instead of assuming it, and fall back
+                # to the ld64 default for a binary that declares no __TEXT.
+                # The MachO Backend code uses the AddressTranslator to translate linked addresses to relative ones.
                 # In theory this is the place where the slide for rebasing should be added, but this isn't supported yet
-                if self.arch.bits == 64:
+                text_vmaddr = self._text_segment_vmaddr(lc_offset)
+                if text_vmaddr:
+                    self.linked_base = self.mapped_base = text_vmaddr
+                elif self.arch.bits == 64:
                     self.linked_base = self.mapped_base = 2**32
                 elif self.arch.bits == 32:
                     self.linked_base = self.mapped_base = 0x4000
@@ -232,9 +242,6 @@ class MachO(Backend):
                     f"Unsupported Mach-O file type: {MachoFiletype(self.filetype)}. "
                     "Please open an issue if you need support for this"
                 )
-
-            # Start reading load commands
-            lc_offset = (7 if self.arch.bits == 32 else 8) * 4
 
             self._parse_load_commands(lc_offset)
 
@@ -306,6 +313,30 @@ class MachO(Backend):
     def check_compatibility(cls, spec, obj):
         # TODO: Check properly, but for now libs are just used via force load libs anyway
         return True
+
+    def _text_segment_vmaddr(self, lc_offset: int) -> int | None:
+        """
+        The address __TEXT is linked at, read straight from the load commands before they are parsed
+        properly, because the base address the rest of the parse works against depends on it.
+
+        :return: the vmaddr of the __TEXT segment, or None if the binary declares no __TEXT segment.
+        """
+        binary_file = self._binary_stream
+        count = 0
+        offset = lc_offset
+        # Bounded the same way _parse_load_commands bounds itself, so a header that lies about either
+        # ncmds or sizeofcmds cannot walk this loop off the end of the commands
+        while count < self.ncmds and (offset - lc_offset) < self.sizeofcmds:
+            count += 1
+            cmd, size = self._unpack("2I", binary_file, offset, 8)
+            if cmd in (LC.LC_SEGMENT, LC.LC_SEGMENT_64):
+                segname = self._read(binary_file, offset + 8, 16).rstrip(b"\0")
+                if segname == b"__TEXT":
+                    if cmd == LC.LC_SEGMENT_64:
+                        return self._unpack("Q", binary_file, offset + 24, 8)[0]
+                    return self._unpack("I", binary_file, offset + 24, 4)[0]
+            offset += size
+        return None
 
     def _parse_load_commands(self, lc_offset):
         # Possible optimization: Remove all unnecessary calls to seek()

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -22,8 +22,8 @@ from cle.backends.symbol import Symbol
 from cle.errors import CLECompatibilityError, CLEInvalidBinaryError, CLEOperationError
 
 from .encrypted_sentinel_backer import CryptSentinel
+from .macho_enums import ARMThreadFlavor, CPUType, MachoFiletype, MH_flags, X86ThreadFlavor
 from .macho_enums import LoadCommands as LC
-from .macho_enums import MachoFiletype, MH_flags
 from .section import TYPE_MASK, ZEROFILL_SECTION_TYPES, MachOSection
 from .segment import MachOSegment
 from .structs import (
@@ -42,6 +42,16 @@ from .symbol import AbstractMachOSymbol, DyldBoundSymbol, SymbolTableSymbol
 log = logging.getLogger(name=__name__)
 
 __all__ = ("MachO", "MachOSection", "MachOSegment", "SymbolList")
+
+# Layout of the thread states LC_UNIXTHREAD can carry, keyed by (cputype, flavor) because a flavor number
+# only identifies a thread state together with the cputype it belongs to. Every format string stops at the
+# program counter, so the last field it unpacks is the entry point.
+UNIXTHREAD_PC_FORMATS = {
+    (CPUType.CPU_TYPE_X86, X86ThreadFlavor.x86_THREAD_STATE32): "11I",  # __eip
+    (CPUType.CPU_TYPE_X86_64, X86ThreadFlavor.x86_THREAD_STATE64): "17Q",  # __rip
+    (CPUType.CPU_TYPE_ARM, ARMThreadFlavor.ARM_THREAD_STATE): "16I",  # __pc
+    (CPUType.CPU_TYPE_ARM64, ARMThreadFlavor.ARM_THREAD_STATE64): "33Q",  # __pc
+}
 
 
 # pylint: disable=abstract-method
@@ -750,10 +760,10 @@ class MachO(Backend):
         try:
             arch_lookup = {
                 # contains all supported architectures. Note that apple deviates from standard ABI, see Apple docs
-                0x100000C: "aarch64",
-                0xC: "arm",
-                0x7: "x86",
-                0x1000007: "x64",
+                CPUType.CPU_TYPE_ARM64: "aarch64",
+                CPUType.CPU_TYPE_ARM: "arm",
+                CPUType.CPU_TYPE_X86: "x86",
+                CPUType.CPU_TYPE_X86_64: "x64",
             }
             return arch_lookup[self.cputype]  # subtype currently not needed
         except KeyError:
@@ -824,21 +834,32 @@ class MachO(Backend):
             )
 
         # parse basic structure
-        # _, cmdsize, flavor, long_count
-        _, _, flavor, _ = self._unpack("4I", f, offset, 16)
+        # _, cmdsize, flavor, count
+        _, _, flavor, count = self._unpack("4I", f, offset, 16)
 
-        # we only support 4 different types of thread state atm
-        # TODO: This is the place to add x86 and x86_64 thread states
-        if flavor == 1 and self.arch.bits != 64:  # ARM_THREAD_STATE or ARM_UNIFIED_THREAD_STATE or ARM_THREAD_STATE32
-            blob = self._unpack("16I", f, offset + 16, 64)  # parses only until __pc
-        elif flavor == 1 and self.arch.bits == 64 or flavor == 6:
-            # ARM_THREAD_STATE or ARM_UNIFIED_THREAD_STATE or ARM_THREAD_STATE64
-            blob = self._unpack("33Q", f, offset + 16, 264)  # parses only until __pc
-        else:
-            log.error("Unknown thread flavor: %d", flavor)
-            raise CLECompatibilityError()
+        # Nothing below can abort the load: the entry point is all LC_UNIXTHREAD contributes, and
+        # _resolve_entry already reports a binary that has no entry point at all.
+        fmt = UNIXTHREAD_PC_FORMATS.get((self.cputype, flavor))
+        if fmt is None:
+            # Without a known layout there is no telling where the program counter sits in the thread state.
+            log.warning("Unsupported thread state flavor %d for cputype %#x", flavor, self.cputype)
+            return
 
-        self.unixthread_pc = blob[-1]
+        # "=" asks for the standard sizes, which is what both byteorder prefixes select, so the size
+        # of the thread state does not depend on which one this binary needs.
+        size = struct.calcsize("=" + fmt)
+        if count * 4 < size:
+            # count is the length of the thread state in 32 bit words. Unpacking more than the command
+            # declares would read whatever follows it rather than the program counter.
+            log.warning("LC_UNIXTHREAD declares %d words of thread state, too few for flavor %d", count, flavor)
+            return
+
+        state = self._read(f, offset + 16, size)
+        if len(state) < size:
+            log.warning("File ends inside the LC_UNIXTHREAD thread state")
+            return
+
+        self.unixthread_pc = self._unpack_with_byteorder(fmt, state)[-1]
         log.debug("LC_UNIXTHREAD: __pc=%#x", self.unixthread_pc)
 
     def _load_dylib_info(self, f, offset):

--- a/cle/backends/macho/macho_enums.py
+++ b/cle/backends/macho/macho_enums.py
@@ -229,6 +229,43 @@ class MH_flags(IntEnum):
     MH_DYLIB_IN_CACHE = 0x80000000
 
 
+class CPUType(IntEnum):
+    """
+    from mach/machine.h
+
+    Values for the cputype field of the mach_header, limited to the architectures cle supports
+    """
+
+    CPU_TYPE_X86 = 0x7
+    CPU_TYPE_X86_64 = 0x1000007
+    CPU_TYPE_ARM = 0xC
+    CPU_TYPE_ARM64 = 0x100000C
+
+
+class X86ThreadFlavor(IntEnum):
+    """
+    from mach/i386/thread_status.h
+
+    Flavors of the thread state carried by LC_UNIXTHREAD on CPU_TYPE_X86 and CPU_TYPE_X86_64.
+    A flavor number only identifies a thread state together with the cputype it belongs to.
+    """
+
+    x86_THREAD_STATE32 = 1
+    x86_THREAD_STATE64 = 4
+
+
+class ARMThreadFlavor(IntEnum):
+    """
+    from mach/arm/thread_status.h
+
+    Flavors of the thread state carried by LC_UNIXTHREAD on CPU_TYPE_ARM and CPU_TYPE_ARM64.
+    A flavor number only identifies a thread state together with the cputype it belongs to.
+    """
+
+    ARM_THREAD_STATE = 1
+    ARM_THREAD_STATE64 = 6
+
+
 class RebaseType(IntEnum):
     """
     from mach-o/loader.h

--- a/tests/test_macho_unixthread.py
+++ b/tests/test_macho_unixthread.py
@@ -1,157 +1,89 @@
 #!/usr/bin/env python
 from __future__ import annotations
 
-import io
 import logging
 import struct
+import tempfile
+from pathlib import Path
 
 import cle
+from cle.backends.macho.macho_enums import LoadCommands as LC
 
-# Constants are spelled out here rather than imported from cle so that the expected layouts come
-# from the Apple headers and not from the table under test.
-MH_MAGIC = 0xFEEDFACE
-MH_MAGIC_64 = 0xFEEDFACF
-CPU_ARCH_ABI64 = 0x1000000
-CPU_TYPE_X86 = 0x7
-CPU_TYPE_X86_64 = CPU_TYPE_X86 | CPU_ARCH_ABI64
-CPU_TYPE_ARM = 0xC
-CPU_TYPE_ARM64 = CPU_TYPE_ARM | CPU_ARCH_ABI64
-MH_EXECUTE = 2
-MH_TWOLEVEL = 0x80
-MH_PIE = 0x200000
-LC_SEGMENT = 0x1
-LC_SEGMENT_64 = 0x19
-LC_SYMTAB = 0x2
-LC_UNIXTHREAD = 0x5
+TEST_BASE = Path(__file__).resolve().parent.parent.parent / "binaries"
 
-# thread state flavors, from mach/i386/thread_status.h and mach/arm/thread_status.h
-x86_THREAD_STATE32 = 1
-x86_THREAD_STATE64 = 4
-x86_FLOAT_STATE64 = 5
-ARM_THREAD_STATE = 1
-ARM_THREAD_STATE64 = 6
+# `terramate` out of the official Homebrew bottle for tenv 4.15.1, x86_64 macOS. Go's internal linker is
+# the toolchain still shipping LC_UNIXTHREAD instead of LC_MAIN, and it stores an x86_THREAD_STATE64
+# whose __rip is the entry point. `otool -l` puts the command at file offset 0x650, command 6 of 14.
+FIXTURE = TEST_BASE / "tests" / "x86_64" / "terramate.macho"
+UNIXTHREAD_OFFSET = 0x650
+FLAVOR_FIELD = 8
+COUNT_FIELD = 12
+ENTRY = 0x1081180
+SEGMENTS = ["__PAGEZERO", "__TEXT", "__DATA_CONST", "__DATA", "__LINKEDIT"]
 
-PAGE_SIZE = 0x1000
+# x86_FLOAT_STATE64 from mach/i386/thread_status.h. A thread state LC_UNIXTHREAD is allowed to carry,
+# but one with no program counter in it, so there is nothing for the loader to take an entry point from.
+X86_FLOAT_STATE64 = 5
 
 
-def build_unixthread_executable(cputype: int, flavor: int, thread_state: bytes, text_vaddr: int) -> bytes:
-    """
-    Assemble a minimal Mach-O executable that takes its entry point from an LC_UNIXTHREAD command.
-
-    :param cputype:         Value for the cputype field of the mach header.
-    :param flavor:          Thread state flavor the LC_UNIXTHREAD command announces.
-    :param thread_state:    The register block the command carries, laid out as ``cputype`` defines it.
-    :param text_vaddr:      Address the __TEXT segment is linked at, __PAGEZERO covers everything below it.
-    """
-    is64 = bool(cputype & CPU_ARCH_ABI64)
-
-    def segment(segname: bytes, vmaddr: int, vmsize: int, fileoff: int, filesize: int) -> bytes:
-        if is64:
-            return struct.pack("<2I16s4Q4I", LC_SEGMENT_64, 72, segname, vmaddr, vmsize, fileoff, filesize, 7, 5, 0, 0)
-        return struct.pack("<2I16s8I", LC_SEGMENT, 56, segname, vmaddr, vmsize, fileoff, filesize, 7, 5, 0, 0)
-
-    commands = b"".join(
-        [
-            segment(b"__PAGEZERO", 0, text_vaddr, 0, 0),
-            segment(b"__TEXT", text_vaddr, PAGE_SIZE, 0, PAGE_SIZE),
-            struct.pack("<6I", LC_SYMTAB, 24, 0, 0, 0, 0),
-            unixthread_command(flavor, thread_state),
-            thread_state,
-        ]
-    )
-    header = struct.pack(
-        "<8I" if is64 else "<7I",
-        MH_MAGIC_64 if is64 else MH_MAGIC,
-        cputype,
-        3,
-        MH_EXECUTE,
-        4,
-        len(commands),
-        MH_TWOLEVEL | MH_PIE,
-        *([0] if is64 else []),
-    )
-    return (header + commands).ljust(PAGE_SIZE, b"\0")
-
-
-def unixthread_command(flavor: int, thread_state: bytes) -> bytes:
-    """The 16 byte LC_UNIXTHREAD header, whose count field is the length of the thread state in 32 bit words."""
-    return struct.pack("<4I", LC_UNIXTHREAD, 16 + len(thread_state), flavor, len(thread_state) // 4)
-
-
-def load(cputype: int, flavor: int, thread_state: bytes, text_vaddr: int) -> cle.MachO:
-    return load_blob(build_unixthread_executable(cputype, flavor, thread_state, text_vaddr))
-
-
-def load_blob(blob: bytes) -> cle.MachO:
-    ld = cle.Loader(io.BytesIO(blob), main_opts={"backend": "mach-o"})
+def load(path: Path | str) -> cle.MachO:
+    ld = cle.Loader(str(path), main_opts={"backend": "mach-o"}, auto_load_libs=False)
     assert isinstance(ld.main_object, cle.MachO)
     return ld.main_object
 
 
-def test_x86_64_thread_state():
-    # _STRUCT_X86_THREAD_STATE64 keeps __rip at index 16 of its 21 64 bit fields
-    state = [0] * 21
-    state[16] = 0x100000F00
-    obj = load(CPU_TYPE_X86_64, x86_THREAD_STATE64, struct.pack("<21Q", *state), 0x100000000)
-    assert obj.entry == 0x100000F00
+def patch_unixthread(field: int, value: int) -> Path:
+    """
+    A copy of the fixture with one 32 bit field of its LC_UNIXTHREAD command overwritten.
+
+    :param field:   Offset of the field within the command.
+    :param value:   Value to write there.
+    """
+    data = bytearray(FIXTURE.read_bytes())
+    command, _cmdsize = struct.unpack_from("<2I", data, UNIXTHREAD_OFFSET)
+    assert command == LC.LC_UNIXTHREAD, "the fixture's thread command moved, update UNIXTHREAD_OFFSET"
+    struct.pack_into("<I", data, UNIXTHREAD_OFFSET + field, value)
+    handle = tempfile.NamedTemporaryFile(suffix=".macho", delete=False)
+    with handle:
+        handle.write(data)
+    return Path(handle.name)
 
 
-def test_x86_thread_state():
-    # _STRUCT_X86_THREAD_STATE32 keeps __eip at index 10 of its 16 32 bit fields and __gs last, so a
-    # reader that takes the last field it unpacks as the program counter comes back with __gs
-    state = [0] * 16
-    state[10] = 0x4F00
-    state[15] = 0xDEADBEEF
-    obj = load(CPU_TYPE_X86, x86_THREAD_STATE32, struct.pack("<16I", *state), 0x4000)
-    assert obj.entry == 0x4F00
-
-
-def test_arm64_thread_state():
-    # _STRUCT_ARM_THREAD_STATE64 keeps __pc at index 32 of its 33 64 bit fields, __cpsr and __pad follow
-    state = [0] * 33
-    state[32] = 0x100000F00
-    obj = load(CPU_TYPE_ARM64, ARM_THREAD_STATE64, struct.pack("<33Q2I", *state, 0, 0), 0x100000000)
-    assert obj.entry == 0x100000F00
-
-
-def test_arm_thread_state():
-    # _STRUCT_ARM_THREAD_STATE keeps __pc at index 15 of its 17 32 bit fields, __cpsr follows
-    state = [0] * 17
-    state[15] = 0x4F00
-    obj = load(CPU_TYPE_ARM, ARM_THREAD_STATE, struct.pack("<17I", *state), 0x4000)
-    assert obj.entry == 0x4F00
+def test_entry_point_comes_from_the_thread_state():
+    # Read as an ARM thread state this comes back with the last of the 16 words the command declares
+    # rather than __rip, and dispatching on the flavor alone used to refuse the binary outright.
+    obj = load(FIXTURE)
+    assert obj.arch.name == "AMD64"
+    assert obj.unixthread_pc == ENTRY
+    assert obj.entry == ENTRY
 
 
 def test_flavor_without_a_known_layout_still_loads():
-    # x86_FLOAT_STATE64 carries no program counter, so the binary loads without an entry point instead of failing
-    obj = load(CPU_TYPE_X86_64, x86_FLOAT_STATE64, b"\0" * 168, 0x100000000)
+    path = patch_unixthread(FLAVOR_FIELD, X86_FLOAT_STATE64)
+    try:
+        obj = load(path)
+    finally:
+        path.unlink()
+    # The entry point is all the command contributes, so the rest of the binary still loads without it
+    assert obj.unixthread_pc is None
     assert obj.entry == 0
+    assert [segment.segname for segment in obj.segments] == SEGMENTS
 
 
 def test_thread_state_shorter_than_its_flavor_still_loads():
-    # Two words is nowhere near an x86_thread_state64_t, so there is no __rip to read behind the command
-    obj = load(CPU_TYPE_X86_64, x86_THREAD_STATE64, struct.pack("<2I", 0, 0), 0x100000000)
-    assert obj.entry == 0
+    # Two words is nowhere near an x86_thread_state64_t, so reading one would run past the command
+    path = patch_unixthread(COUNT_FIELD, 2)
+    try:
+        obj = load(path)
+    finally:
+        path.unlink()
     assert obj.unixthread_pc is None
-
-
-def test_thread_state_running_past_the_end_of_the_file_still_loads():
-    state = [0] * 21
-    state[16] = 0x100000F00
-    thread_state = struct.pack("<21Q", *state)
-    blob = build_unixthread_executable(CPU_TYPE_X86_64, x86_THREAD_STATE64, thread_state, 0x100000000)
-    command = unixthread_command(x86_THREAD_STATE64, thread_state)
-    obj = load_blob(blob[: blob.index(command) + len(command) + 8])
     assert obj.entry == 0
-    assert obj.unixthread_pc is None
+    assert [segment.segname for segment in obj.segments] == SEGMENTS
 
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
-    test_x86_64_thread_state()
-    test_x86_thread_state()
-    test_arm64_thread_state()
-    test_arm_thread_state()
+    test_entry_point_comes_from_the_thread_state()
     test_flavor_without_a_known_layout_still_loads()
     test_thread_state_shorter_than_its_flavor_still_loads()
-    test_thread_state_running_past_the_end_of_the_file_still_loads()

--- a/tests/test_macho_unixthread.py
+++ b/tests/test_macho_unixthread.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import io
+import logging
+import struct
+
+import cle
+
+# Constants are spelled out here rather than imported from cle so that the expected layouts come
+# from the Apple headers and not from the table under test.
+MH_MAGIC = 0xFEEDFACE
+MH_MAGIC_64 = 0xFEEDFACF
+CPU_ARCH_ABI64 = 0x1000000
+CPU_TYPE_X86 = 0x7
+CPU_TYPE_X86_64 = CPU_TYPE_X86 | CPU_ARCH_ABI64
+CPU_TYPE_ARM = 0xC
+CPU_TYPE_ARM64 = CPU_TYPE_ARM | CPU_ARCH_ABI64
+MH_EXECUTE = 2
+MH_TWOLEVEL = 0x80
+MH_PIE = 0x200000
+LC_SEGMENT = 0x1
+LC_SEGMENT_64 = 0x19
+LC_SYMTAB = 0x2
+LC_UNIXTHREAD = 0x5
+
+# thread state flavors, from mach/i386/thread_status.h and mach/arm/thread_status.h
+x86_THREAD_STATE32 = 1
+x86_THREAD_STATE64 = 4
+x86_FLOAT_STATE64 = 5
+ARM_THREAD_STATE = 1
+ARM_THREAD_STATE64 = 6
+
+PAGE_SIZE = 0x1000
+
+
+def build_unixthread_executable(cputype: int, flavor: int, thread_state: bytes, text_vaddr: int) -> bytes:
+    """
+    Assemble a minimal Mach-O executable that takes its entry point from an LC_UNIXTHREAD command.
+
+    :param cputype:         Value for the cputype field of the mach header.
+    :param flavor:          Thread state flavor the LC_UNIXTHREAD command announces.
+    :param thread_state:    The register block the command carries, laid out as ``cputype`` defines it.
+    :param text_vaddr:      Address the __TEXT segment is linked at, __PAGEZERO covers everything below it.
+    """
+    is64 = bool(cputype & CPU_ARCH_ABI64)
+
+    def segment(segname: bytes, vmaddr: int, vmsize: int, fileoff: int, filesize: int) -> bytes:
+        if is64:
+            return struct.pack("<2I16s4Q4I", LC_SEGMENT_64, 72, segname, vmaddr, vmsize, fileoff, filesize, 7, 5, 0, 0)
+        return struct.pack("<2I16s8I", LC_SEGMENT, 56, segname, vmaddr, vmsize, fileoff, filesize, 7, 5, 0, 0)
+
+    commands = b"".join(
+        [
+            segment(b"__PAGEZERO", 0, text_vaddr, 0, 0),
+            segment(b"__TEXT", text_vaddr, PAGE_SIZE, 0, PAGE_SIZE),
+            struct.pack("<6I", LC_SYMTAB, 24, 0, 0, 0, 0),
+            unixthread_command(flavor, thread_state),
+            thread_state,
+        ]
+    )
+    header = struct.pack(
+        "<8I" if is64 else "<7I",
+        MH_MAGIC_64 if is64 else MH_MAGIC,
+        cputype,
+        3,
+        MH_EXECUTE,
+        4,
+        len(commands),
+        MH_TWOLEVEL | MH_PIE,
+        *([0] if is64 else []),
+    )
+    return (header + commands).ljust(PAGE_SIZE, b"\0")
+
+
+def unixthread_command(flavor: int, thread_state: bytes) -> bytes:
+    """The 16 byte LC_UNIXTHREAD header, whose count field is the length of the thread state in 32 bit words."""
+    return struct.pack("<4I", LC_UNIXTHREAD, 16 + len(thread_state), flavor, len(thread_state) // 4)
+
+
+def load(cputype: int, flavor: int, thread_state: bytes, text_vaddr: int) -> cle.MachO:
+    return load_blob(build_unixthread_executable(cputype, flavor, thread_state, text_vaddr))
+
+
+def load_blob(blob: bytes) -> cle.MachO:
+    ld = cle.Loader(io.BytesIO(blob), main_opts={"backend": "mach-o"})
+    assert isinstance(ld.main_object, cle.MachO)
+    return ld.main_object
+
+
+def test_x86_64_thread_state():
+    # _STRUCT_X86_THREAD_STATE64 keeps __rip at index 16 of its 21 64 bit fields
+    state = [0] * 21
+    state[16] = 0x100000F00
+    obj = load(CPU_TYPE_X86_64, x86_THREAD_STATE64, struct.pack("<21Q", *state), 0x100000000)
+    assert obj.entry == 0x100000F00
+
+
+def test_x86_thread_state():
+    # _STRUCT_X86_THREAD_STATE32 keeps __eip at index 10 of its 16 32 bit fields and __gs last, so a
+    # reader that takes the last field it unpacks as the program counter comes back with __gs
+    state = [0] * 16
+    state[10] = 0x4F00
+    state[15] = 0xDEADBEEF
+    obj = load(CPU_TYPE_X86, x86_THREAD_STATE32, struct.pack("<16I", *state), 0x4000)
+    assert obj.entry == 0x4F00
+
+
+def test_arm64_thread_state():
+    # _STRUCT_ARM_THREAD_STATE64 keeps __pc at index 32 of its 33 64 bit fields, __cpsr and __pad follow
+    state = [0] * 33
+    state[32] = 0x100000F00
+    obj = load(CPU_TYPE_ARM64, ARM_THREAD_STATE64, struct.pack("<33Q2I", *state, 0, 0), 0x100000000)
+    assert obj.entry == 0x100000F00
+
+
+def test_arm_thread_state():
+    # _STRUCT_ARM_THREAD_STATE keeps __pc at index 15 of its 17 32 bit fields, __cpsr follows
+    state = [0] * 17
+    state[15] = 0x4F00
+    obj = load(CPU_TYPE_ARM, ARM_THREAD_STATE, struct.pack("<17I", *state), 0x4000)
+    assert obj.entry == 0x4F00
+
+
+def test_flavor_without_a_known_layout_still_loads():
+    # x86_FLOAT_STATE64 carries no program counter, so the binary loads without an entry point instead of failing
+    obj = load(CPU_TYPE_X86_64, x86_FLOAT_STATE64, b"\0" * 168, 0x100000000)
+    assert obj.entry == 0
+
+
+def test_thread_state_shorter_than_its_flavor_still_loads():
+    # Two words is nowhere near an x86_thread_state64_t, so there is no __rip to read behind the command
+    obj = load(CPU_TYPE_X86_64, x86_THREAD_STATE64, struct.pack("<2I", 0, 0), 0x100000000)
+    assert obj.entry == 0
+    assert obj.unixthread_pc is None
+
+
+def test_thread_state_running_past_the_end_of_the_file_still_loads():
+    state = [0] * 21
+    state[16] = 0x100000F00
+    thread_state = struct.pack("<21Q", *state)
+    blob = build_unixthread_executable(CPU_TYPE_X86_64, x86_THREAD_STATE64, thread_state, 0x100000000)
+    command = unixthread_command(x86_THREAD_STATE64, thread_state)
+    obj = load_blob(blob[: blob.index(command) + len(command) + 8])
+    assert obj.entry == 0
+    assert obj.unixthread_pc is None
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    test_x86_64_thread_state()
+    test_x86_thread_state()
+    test_arm64_thread_state()
+    test_arm_thread_state()
+    test_flavor_without_a_known_layout_still_loads()
+    test_thread_state_shorter_than_its_flavor_still_loads()
+    test_thread_state_running_past_the_end_of_the_file_still_loads()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

An x86_64 executable that carries its entry point in `LC_UNIXTHREAD` is refused outright, with an exception carrying no message. `tests/x86_64/terramate.macho` is a Go binary, and Go's internal linker still emits `LC_UNIXTHREAD` rather than `LC_MAIN`:

```text
stock LC_UNIXTHREAD at 0x650: cmdsize=184 flavor=4 count=42
--- stock fixture (x86_THREAD_STATE64, flavor 4)
    RAISED CLECompatibilityError: ''
      | File "cle/backends/macho/macho.py", line 813, in _load_lc_unixthread
      | raise CLECompatibilityError()
```

The raise sits inside load-command parsing, so nothing else about the binary is parsed either — its five segments, its sections and its symbol table are all lost with the entry point.

**terramate is not one fixture.** In a corpus sweep against cle master `0e77ade3`, every
x86_64 Mach-O built by Go that the sweep reached failed at this frame and **none of them
loaded**, while Rust binaries for x86_64 and Go binaries for arm64 in the same corpus reached
the loader with no load-stage failure at all. Same compiler and a different cputype, same
cputype and a different compiler: that is the mechanism below, measured rather than argued.
The corpus holds 1,620 objects of this shape.

The raise also carries no argument, so the error text a scan records is empty and the class
is findable only by frame. At `0e77ade3` it is the only `raise CLECompatibilityError()`
without an argument left in the Mach-O backend, out of five raises of that class in the file;
the cle change that replaced the message-less raises there merged on 2026-08-28 and took them
from three to one. This change deletes the last one.

### Root cause

`MachO._load_lc_unixthread` chose the thread state layout from the flavor field alone:

```python
if flavor == 1 and self.arch.bits != 64:  # ARM_THREAD_STATE or ARM_UNIFIED_THREAD_STATE or ARM_THREAD_STATE32
    ...
elif flavor == 1 and self.arch.bits == 64 or flavor == 6:
    ...
else:
    log.error("Unknown thread flavor: %d", flavor)
    raise CLECompatibilityError()
```

Mach-O flavor numbers are only unique within a cputype. Flavor 4 is `x86_THREAD_STATE64`, which matches neither arm, so terramate takes the `else`. The same predicate reads flavor 1 on 32-bit x86 — `x86_THREAD_STATE32` — as `ARM_THREAD_STATE`, which would report `__gs` rather than `__eip`; no fixture here exercises that path.

### Fix

The layouts are keyed on `(cputype, flavor)`, with `CPUType`, `X86ThreadFlavor` and `ARMThreadFlavor` enums in `macho_enums.py`, and the state is bounded by the declared word count and the end of the file. A layout cle does not know, a count too small for its flavor, or a truncated file logs a warning and leaves `unixthread_pc` unset rather than aborting: the entry point is all this command contributes, and `_resolve_entry` already reports a binary that has none.

It also reads `linked_base` from the vmaddr of `__TEXT` for a position-independent `MH_EXECUTE` rather than the ld64 default, because Go links darwin/amd64 at `0x1000000` and the load would otherwise abort in `Loader._map_object` once the entry point is read correctly.

```text
--- stock fixture:            LOADED MachO arch=AMD64 cputype=0x1000007
    unixthread_pc=0x1081180 entry=0x1081180 linked_base=0x1000000 mapped_base=0x1000000
    segments=['__PAGEZERO', '__TEXT', '__DATA_CONST', '__DATA', '__LINKEDIT']
--- flavor patched to 5:      LOADED  unixthread_pc=None entry=0x0   (same segments, same span)
--- count patched to 2:       LOADED  unixthread_pc=None entry=0x0   (same segments, same span)
```

### Testing

`tests/test_macho_unixthread.py::test_entry_point_comes_from_the_thread_state` asserts `obj.entry == 0x1081180` on the stock fixture; `::test_flavor_without_a_known_layout_still_loads` and `::test_thread_state_shorter_than_its_flavor_still_loads` patch one 32-bit field of the command in a temporary copy and pin that the rest of the binary still loads. All three fail on the merge base, where even the stock fixture is refused. The fixture is on `angr/binaries` master.

Validation: https://github.com/angr/cle/pull/727#issuecomment-5234710661

session: sharpen
