### PR TITLE
Mach-O: Do not back a segment that occupies no memory

### DIFF
--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -1041,11 +1041,18 @@ class MachO(Backend):
             # It would allocate 4GB of unneeded memory and also break rebasing
             # because now there is a segment that must be at address 0, while the other segments should be slid
             log.info("Found PAGEZERO, skipping backer for memory conservation")
+        elif seg.memsize == 0:
+            # A segment with vmsize 0 occupies no address space, so it must not be backed no matter how much file
+            # content it has. Debug info kept in the executable rather than a .dSYM is emitted like this: __DWARF has
+            # vmsize 0 and shares its vmaddr with the segment that follows it, so backing it would map the debug info
+            # over that segment.
+            log.info("Segment %r is not mapped at runtime, skipping backer", segname)
         elif seg.filesize > 0:
-            # Append segment data to memory
-            blob = self._read(f, seg.offset, seg.filesize)
-            if seg.filesize < seg.memsize:
-                blob += b"\0" * (seg.memsize - seg.filesize)  # padding
+            # Append segment data to memory. A segment maps memsize bytes and the file contributes at most that many
+            # of them, so anything the file has beyond memsize is not part of the mapping.
+            blob = self._read(f, seg.offset, min(seg.filesize, seg.memsize))
+            if len(blob) < seg.memsize:
+                blob += b"\0" * (seg.memsize - len(blob))  # padding
 
             # The memory of the Backend itself should start at 0, where 0 is the lowest meaningful address
             # In our case this would be the Mach header magic

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -3,12 +3,18 @@ from __future__ import annotations
 
 import logging
 import os
+import struct
+from io import BytesIO
 
 import cle
 from cle import MachO
+from cle.backends.macho.macho_enums import LoadCommands
 from cle.backends.macho.section import MachOSection
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
+
+SEGMENT_COMMAND_64 = "<2I16s4Q4I"
+SEGMENT_COMMAND_64_SIZE = struct.calcsize(SEGMENT_COMMAND_64)
 
 
 def test_fauxware():
@@ -239,6 +245,110 @@ def test_find_symbol():
     assert sym.rebased_addr == 0x100100028
 
 
+def _find_segment_command(image: bytes, segname: bytes) -> int:
+    """
+    Offset of the LC_SEGMENT_64 command for the given segment
+    """
+    ncmds = struct.unpack_from("<I", image, 16)[0]
+    offset = 32
+    for _ in range(ncmds):
+        cmd, cmdsize = struct.unpack_from("<2I", image, offset)
+        if (
+            cmd == LoadCommands.LC_SEGMENT_64
+            and struct.unpack_from("<16s", image, offset + 8)[0].rstrip(b"\0") == segname
+        ):
+            return offset
+        offset += cmdsize
+    raise AssertionError(f"No {segname!r} segment")
+
+
+def _insert_segment_command(
+    image: bytes, offset: int, segname: bytes, vmaddr: int, vmsize: int, fileoff: int, filesize: int
+) -> bytes:
+    """
+    Splice a sectionless LC_SEGMENT_64 into a 64 bit Mach-O image at the given load command offset. The command takes
+    the place of padding that follows the load commands, so the image keeps its length and every file offset in it
+    stays valid.
+    """
+    ncmds, sizeofcmds = struct.unpack_from("<2I", image, 16)
+    command = struct.pack(
+        SEGMENT_COMMAND_64,
+        LoadCommands.LC_SEGMENT_64,
+        SEGMENT_COMMAND_64_SIZE,
+        segname,
+        vmaddr,
+        vmsize,
+        fileoff,
+        filesize,
+        7,  # maxprot: rwx
+        1,  # initprot: r
+        0,  # nsects
+        0,  # flags
+    )
+    padding = 32 + sizeofcmds
+    assert set(image[padding : padding + SEGMENT_COMMAND_64_SIZE]) == {0}, "not enough padding to hold a segment"
+
+    patched = bytearray(image)
+    patched[offset:offset] = command
+    del patched[padding + SEGMENT_COMMAND_64_SIZE : padding + 2 * SEGMENT_COMMAND_64_SIZE]
+    struct.pack_into("<2I", patched, 16, ncmds + 1, sizeofcmds + SEGMENT_COMMAND_64_SIZE)
+    return bytes(patched)
+
+
+def test_zero_vmsize_segment():
+    """
+    A segment with vmsize 0 occupies no memory, so the linker gives the segment that follows it the same vmaddr. This
+    is how debug info that stays in the executable is emitted: __DWARF has vmsize 0 and the full debug info as its file
+    content, directly in front of __LINKEDIT. Backing such a segment with its file content maps it over __LINKEDIT.
+    """
+    with open(os.path.join(TEST_BASE, "tests", "x86_64", "fauxware.macho"), "rb") as fp:
+        image = fp.read()
+
+    patched = _insert_segment_command(
+        image,
+        _find_segment_command(image, b"__LINKEDIT"),
+        b"__DWARF",
+        vmaddr=0x100002000,  # the address of __LINKEDIT
+        vmsize=0,
+        fileoff=0xCC0,  # the file range of __text, standing in for debug info
+        filesize=0x340,
+    )
+
+    ld = cle.Loader(BytesIO(patched), auto_load_libs=False, main_opts={"backend": "mach-o"})
+    assert isinstance(ld.main_object, cle.MachO)
+    macho: MachO = ld.main_object
+    assert [seg.segname for seg in macho.segments] == ["__PAGEZERO", "__TEXT", "__DATA", "__DWARF", "__LINKEDIT"]
+
+    # __DWARF contributed nothing, so __LINKEDIT is intact and the backers are the ones the unpatched binary has
+    backers = [(start, len(backer)) for start, backer in macho.memory.backers()]
+    assert backers == [(0, 0x1000), (0x1000, 0x1000), (0x2000, 0x1000)]
+    assert ld.memory.load(0x100002000, 16) == image[0x2000:0x2010]
+
+
+def test_filesize_larger_than_vmsize():
+    """
+    A segment maps vmsize bytes, so anything its file range holds beyond that is not part of the mapping.
+    """
+    with open(os.path.join(TEST_BASE, "tests", "x86_64", "fauxware.macho"), "rb") as fp:
+        image = fp.read()
+
+    patched = _insert_segment_command(
+        image,
+        _find_segment_command(image, b"__LINKEDIT"),
+        b"__OVERSIZED",
+        vmaddr=0x100003000,  # past the end of the binary
+        vmsize=0x1000,
+        fileoff=0,
+        filesize=0x2000,
+    )
+
+    ld = cle.Loader(BytesIO(patched), auto_load_libs=False, main_opts={"backend": "mach-o"})
+    assert isinstance(ld.main_object, cle.MachO)
+    macho: MachO = ld.main_object
+    assert dict(macho.memory.backers())[0x3000] == patched[:0x1000]
+    assert macho.max_addr == 0x100003FFF
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     test_dummy()
@@ -248,3 +358,5 @@ if __name__ == "__main__":
     test_find_region_containing()
     test_describe_addr()
     test_find_symbol()
+    test_zero_vmsize_segment()
+    test_filesize_larger_than_vmsize()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Unstripped Mach-O executables that keep their debug info in a `__DWARF` segment rather than a separate `.dSYM` fail to load with `ValueError: Address 0x... is already backed!`. `__DWARF` has `vmsize` 0, so it occupies no address space and the linker gives `__LINKEDIT` the same `vmaddr`, but `_load_segment` sized the backer from `filesize` alone and dropped hundreds of kilobytes of debug info exactly where `__LINKEDIT` belongs.

A segment maps `vmsize` bytes and the file contributes at most that many, which is this backend's invariant to keep: leave a segment that maps nothing unbacked, and clamp the rest to `memsize`.

Reproduced on `repomapper` from the Homebrew `reposurgeon` 5.9 arm64_sonoma bottle. The regression splices the same segment shape into an existing fixture, so it needs no new binary.

Validation: https://github.com/angr/cle/pull/729#issuecomment-5234725392

