### PR TITLE
ELF: Tolerate a missing dynamic string table when reading soname and RELRO

### DIFF
--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -43,7 +43,14 @@ def _get_relro(elf):
     dyn_sec = elf.get_section_by_name(".dynamic")
     if dyn_sec is None or not isinstance(dyn_sec, DynamicSection):
         return Relro.PARTIAL
-    flags = [tag for tag in dyn_sec.iter_tags() if tag.entry.d_tag == "DT_FLAGS"]
+    try:
+        flags = [tag for tag in dyn_sec.iter_tags() if tag.entry.d_tag == "DT_FLAGS"]
+    except Exception:  # pylint: disable=broad-except
+        # DT_FLAGS is a number, but pyelftools resolves the dynamic string table for every tag it
+        # yields, and an object without one cannot. Not being able to confirm BIND_NOW is what
+        # partial RELRO already means, so report that rather than failing the load over it.
+        log.debug("Could not read the dynamic table while detecting RELRO", exc_info=True)
+        return Relro.PARTIAL
     if len(flags) != 1:
         return Relro.PARTIAL
     return (
@@ -483,12 +490,18 @@ class MetaELF(Backend):
                     if seg.header.p_type == "PT_NULL":
                         break
                     elif seg.header.p_type == "PT_DYNAMIC":
-                        for tag in seg.iter_tags():
-                            if tag.entry.d_tag == "DT_SONAME":
-                                return maybedecode(tag.soname)
+                        # Ask for DT_SONAME specifically: an unfiltered iter_tags() makes pyelftools
+                        # resolve the dynamic string table for every tag, which objects with no
+                        # string table at all cannot do.
+                        for tag in seg.iter_tags("DT_SONAME"):
+                            return maybedecode(tag.soname)
                         if isinstance(path, str):
                             return os.path.basename(path)
 
-            except elftools.common.exceptions.ELFError:
-                pass
+            # This is a best-effort heuristic, so any failure to parse just means "no soname". The
+            # exception type is deliberately not narrowed: a file that names a DT_SONAME it cannot
+            # resolve makes pyelftools assert rather than raise ELFError, and which of the two a
+            # given malformed file gets has already changed once between pyelftools releases.
+            except Exception:  # pylint: disable=broad-except
+                log.debug("Could not extract a soname from %s", path, exc_info=True)
             return None

--- a/tests/test_soname.py
+++ b/tests/test_soname.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+import shutil
+import struct
+import tempfile
+
+import archinfo
+import pytest
+from elftools.elf.elffile import ELFFile
+
+import cle
+from cle.backends.elf.metaelf import MetaELF
+
+TEST_BASE = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    os.path.join("..", "..", "binaries", "tests"),
+)
+
+
+def _copy_without_dynamic_strtab(src, dst):
+    """
+    Copy an ELF file, pointing the sh_link of its .dynamic section at the SHT_NULL section.
+
+    That is how an object with no dynamic string table at all encodes it. pyelftools accepts the
+    SHT_NULL target and then asserts, rather than raising ELFError, when it is asked to resolve the
+    strings of a dynamic tag.
+    """
+    shutil.copy(src, dst)
+    with open(dst, "r+b") as f:
+        reader = ELFFile(f)
+        index = next(i for i, sec in enumerate(reader.iter_sections()) if sec["sh_type"] == "SHT_DYNAMIC")
+        sh_link_offset = 40 if reader.elfclass == 64 else 24
+        f.seek(reader["e_shoff"] + index * reader["e_shentsize"] + sh_link_offset)
+        f.write(struct.pack("<I" if reader.little_endian else ">I", 0))
+
+
+def _set_machine_none(path):
+    """Rewrite e_machine to EM_NONE, which sits at offset 18 of both the 32- and 64-bit ELF header."""
+    with open(path, "r+b") as f:
+        reader = ELFFile(f)
+        f.seek(18)
+        f.write(struct.pack("<H" if reader.little_endian else ">H", 0))
+
+
+def test_extract_soname_without_dynamic_strtab():
+    with tempfile.TemporaryDirectory() as tempdir:
+        # No DT_SONAME, so the string table is never needed and the basename stands in.
+        no_soname = os.path.join(tempdir, "cpp_qualified_symbols.so")
+        _copy_without_dynamic_strtab(os.path.join(TEST_BASE, "x86_64", "cpp_qualified_symbols.so"), no_soname)
+        assert MetaELF.extract_soname(no_soname) == "cpp_qualified_symbols.so"
+
+        # A DT_SONAME that can no longer be resolved is just an unanswerable question.
+        unresolvable = os.path.join(tempdir, "liblzma.so.5.6.1")
+        _copy_without_dynamic_strtab(os.path.join(TEST_BASE, "x86_64", "liblzma.so.5.6.1"), unresolvable)
+        assert MetaELF.extract_soname(unresolvable) is None
+
+        # Loader.find_object() runs the same heuristic on files it has never loaded.
+        loader = cle.Loader(os.path.join(TEST_BASE, "x86_64", "fauxware"), auto_load_libs=False)
+        assert loader.find_object(no_soname) is None
+        assert loader.find_object(unresolvable) is None
+
+
+def test_extract_soname_reads_dt_soname():
+    assert MetaELF.extract_soname(os.path.join(TEST_BASE, "x86_64", "liblzma.so.5.6.1")) == "liblzma.so.5"
+
+
+def test_load_without_dynamic_strtab():
+    # A dynamic object with no dynamic string table, for a machine CLE has no architecture for.
+    # It cannot be loaded, but it should fail on that rather than in the soname heuristic or the
+    # RELRO check, both of which run first and neither of which needs any string.
+    with tempfile.TemporaryDirectory() as tempdir:
+        target = os.path.join(tempdir, "no_dynstr.so")
+        _copy_without_dynamic_strtab(os.path.join(TEST_BASE, "x86_64", "cpp_qualified_symbols.so"), target)
+        _set_machine_none(target)
+        with pytest.raises(archinfo.ArchNotFound):
+            cle.Loader(target, auto_load_libs=False, main_opts={"backend": "elf"})
+
+
+if __name__ == "__main__":
+    test_extract_soname_without_dynamic_strtab()
+    test_extract_soname_reads_dt_soname()
+    test_load_without_dynamic_strtab()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

An ELF whose `.dynamic` section has `sh_link` 0 names no dynamic string table, and pyelftools reports that with a bare `assert`. The message-less `AssertionError` escapes `MetaELF.extract_soname`, so on a copy of `tests/x86_64/cpp_qualified_symbols.so` with that one header field cleared:

```text
soname(cpp_qualified_symbols.so): RAISED builtins.AssertionError:
  File ".../cle/backends/elf/metaelf.py", line 486, in extract_soname
    for tag in seg.iter_tags():
  File ".../elftools/elf/dynamic.py", line 168, in _get_stringtable
    assert isinstance(self._stringtable, _StringTable)
```

`Loader.find_object()` runs that heuristic over files it never loaded, so it dies too, and `_get_relro()` fails the same way a moment later. Both run before the architecture is resolved, so an object that is broken in some other way — here one whose `e_machine` is also `EM_NONE` — never reaches its real diagnosis.

### Root cause

`extract_soname` iterated the whole dynamic table to find one tag:

```python
for tag in seg.iter_tags():
    if tag.entry.d_tag == "DT_SONAME":
        return maybedecode(tag.soname)
```

pyelftools resolves the dynamic string table for *every* tag it yields, so an object with no string table cannot be iterated at all, even though `DT_SONAME` is the only tag here that needs a string. The surrounding handler was `except elftools.common.exceptions.ELFError`, which an `AssertionError` walks straight past. `_get_relro` has the identical shape in `[tag for tag in dyn_sec.iter_tags() if tag.entry.d_tag == "DT_FLAGS"]`, and `DT_FLAGS` is a number.

### Fix

Both are best-effort heuristics with a defined "cannot tell" answer, so they now give it. `extract_soname` asks for `seg.iter_tags("DT_SONAME")`, so no other tag's strings are resolved, and an object with no soname never needs a string table at all; `_get_relro` returns `Relro.PARTIAL`, which is what not being able to confirm `BIND_NOW` already means. The handler is widened to `except Exception` deliberately: which of `ELFError` and `AssertionError` a malformed file produces has already changed between pyelftools releases.

```text
soname(cpp_qualified_symbols.so): 'cpp_qualified_symbols.so'
soname(liblzma.so.5.6.1): None
find_object(cpp_qualified_symbols.so): None
Loader(no_dynstr.so): RAISED archinfo.arch.ArchNotFound: ... em_none ...
```

Nothing tries to recover a soname from a broken string table, and such an object still will not load, since `ELF.__register_dyn()` genuinely needs the strings — it now fails on that.

### Testing

`tests/test_soname.py::test_extract_soname_without_dynamic_strtab` asserts `MetaELF.extract_soname(no_soname) == "cpp_qualified_symbols.so"`; `::test_extract_soname_reads_dt_soname` pins the unmutated `tests/x86_64/liblzma.so.5.6.1` still answering `liblzma.so.5`; `::test_load_without_dynamic_strtab` pins that the load fails in the architecture lookup. All three build their inputs by zeroing that one header field in copies of binaries already on `angr/binaries` master, and all three fail on the merge base.

Validation: https://github.com/angr/cle/pull/731#issuecomment-5234732614

session: sharpen
