### PR TITLE
Encode R_ARM_THM_CALL over its full 25-bit displacement

### DIFF
--- a/cle/backends/elf/relocation/arm.py
+++ b/cle/backends/elf/relocation/arm.py
@@ -7,8 +7,6 @@ from __future__ import annotations
 
 import logging
 
-from cle.errors import CLEOperationError
-
 from .elfreloc import ELFReloc
 from .generic import (
     GenericAbsoluteAddendReloc,
@@ -284,6 +282,10 @@ class R_ARM_THM_CALL(ELFReloc):
         https://github.com/angr/vex/blob/6d1252c7ce8fe8376318b8f8bb8034058454c841/priv/guest_arm_toIR.c#L19219 )
 
       - Implementation appears correct with the bits placed into offset[23:22]
+
+      - The encoded displacement is offset[24:1] sign extended, so the branch reaches +- 16 MiB.
+        CLE does not synthesize veneers, so a wider displacement is encoded truncated and warned
+        about.
     """
 
     __slots__ = ("_insn_bytes",)
@@ -336,24 +338,25 @@ class R_ARM_THM_CALL(ELFReloc):
             A |= J1 << 23  # A[23] = J1
             A |= J2 << 22  # A[22] = J2
 
-            A &= 0x7FFFFF
-
             if sign_bit:
-                A |= 0xFF800000
+                A |= 0xFF000000  # A[24:1] is a signed 25-bit displacement; sign extend to 32 bits
 
         # Compute X, the new offset, from the symbol addr, S, the addend, A,
         #  the thumb flag, T, and PC, P.
 
         x = (((S + A) | T) - P) & 0xFFFFFFFF  # Also mask to 32 bits
 
-        # Ensure jump is in range
+        # Ensure jump is in range. The encoding below writes x[24:1] with x[24] as the sign, so
+        # x[31:25] must match x[24] for the displacement to survive the round trip.
 
-        if x & 0xFF800000 != 0 and x & 0xFF800000 != 0xFF800000:
-            raise CLEOperationError(
-                "Jump target out of range for reloc R_ARM_THM_CALL (+- 2^23). "
-                "This may be due to SimProcedures being allocated outside the jump range. "
-                "If you believe this is the case, set 'rebase_granularity'=0x1000 in the "
-                "load options."
+        if x & 0xFF000000 not in (0, 0xFF000000):
+            log.warning(
+                "%s at %#x: branch target %#x is out of range (+- 16 MiB) and will be encoded "
+                "truncated. If it is an extern stub or a SimProcedure placed out of reach, pass a "
+                "smaller 'rebase_granularity' to cle.Loader.",
+                type(self).__name__,
+                P,
+                S,
             )
 
         # Rebuild the instruction, first clearing out any previously set offset bits

--- a/tests/test_arm_relocations.py
+++ b/tests/test_arm_relocations.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from typing import NamedTuple
 
 from elftools.elf.elffile import ELFFile
 from elftools.elf.enums import ENUM_RELOC_TYPE_ARM
@@ -15,20 +16,37 @@ import cle
 from cle.backends import Symbol
 from cle.backends.elf.relocation.arm import R_ARM_THM_CALL
 
-# An ET_REL ARM object holding 51 R_ARM_THM_CALL and 11 R_ARM_THM_JUMP24 relocations, all REL,
-# so the addends come out of the instructions themselves.
-TEST_FILE = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)),
-    os.path.join("..", "..", "binaries", "tests"),
-    os.path.join("armel", "i2c_api.o"),
+BINARIES = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
+
+# The mbed GCC ARM build for the Nucleo L152RE, the same build that produced
+# tests/armel/i2c_api.o, ships this 43-member static library. Every member is a Thumb ET_REL
+# object whose calls into the mbed HAL are REL R_ARM_THM_CALL and R_ARM_THM_JUMP24 relocations, so
+# the addends come out of the instructions themselves. CLE gives each member its own
+# rebase_granularity boundary and maps the extern object after all of them, which leaves the calls
+# to the extern stubs anywhere from a few hundred KiB to 42 MiB away -- both sides of a Thumb
+# branch's reach in a single load.
+ARCHIVE = os.path.join(
+    BINARIES,
+    os.path.join("tests_src", "i2c_master_read-nucleol152re", "mbed", "TARGET_NUCLEO_L152RE", "TOOLCHAIN_GCC_ARM"),
+    "libmbed.a",
 )
+
+# One object out of that same build, holding 51 R_ARM_THM_CALL and 11 R_ARM_THM_JUMP24
+# relocations, all REL.
+OBJECT = os.path.join(BINARIES, os.path.join("tests", "armel"), "i2c_api.o")
 
 THM_BRANCH_RELOC_TYPES = (
     ENUM_RELOC_TYPE_ARM["R_ARM_THM_CALL"],
     ENUM_RELOC_TYPE_ARM["R_ARM_THM_JUMP24"],
 )
 
-MIB = 1024 * 1024
+#: A 32-bit Thumb BL/B.W carries a signed 25-bit byte displacement from PC, so it reaches
+#: [-16 MiB, 16 MiB).
+THM_BRANCH_REACH = 1 << 24
+
+#: The reach CLE used to permit, having sign extended the displacement from bit 23 rather than
+#: bit 24.
+NARROW_THM_BRANCH_REACH = 1 << 23
 
 
 def decode_thm_branch(data: bytes, addr: int) -> int:
@@ -62,27 +80,13 @@ def encode_thm_branch(data: bytes, imm: int) -> bytes:
     return bytes((hi & 0xFF, hi >> 8, lo & 0xFF, lo >> 8))
 
 
-def write_static_archive(path: str, member: str, count: int) -> None:
-    """
-    Write an ``ar`` archive holding ``count`` copies of the object file ``member``.
-    """
-    with open(member, "rb") as f:
-        data = f.read()
-    with open(path, "wb") as f:
-        f.write(b"!<arch>\n")
-        for i in range(count):
-            name = f"m{i:02d}.o/".encode().ljust(16)
-            f.write(name + b"0".ljust(12) + b"0".ljust(6) + b"0".ljust(6))
-            f.write(b"100644".ljust(8) + str(len(data)).encode().ljust(10) + b"`\n")
-            f.write(data)
-            if len(data) % 2:
-                f.write(b"\n")
-
-
 def rewrite_undefined_branch_addends(src: str, dst: str, addend: int) -> None:
     """
     Copy the object at ``src`` to ``dst``, giving every Thumb branch against an undefined symbol
     an implicit addend of ``addend``.
+
+    Only the four instruction bytes at each relocation site change; the container, its sections,
+    its symbols and its relocations are the ones the toolchain emitted.
     """
     shutil.copyfile(src, dst)
 
@@ -111,10 +115,26 @@ def rewrite_undefined_branch_addends(src: str, dst: str, addend: int) -> None:
             f.write(encode_thm_branch(data, addend & 0x1FFFFFF))
 
 
-def thm_branches(ld: cle.Loader) -> list[tuple[Symbol, int, int]]:
+class Branch(NamedTuple):
+    symbol: Symbol
+    #: The displacement from the branch's PC to the symbol, which is what has to be encoded.
+    displacement: int
+    #: The branch target CLE actually encoded.
+    target: int
+
+    @property
+    def in_reach(self) -> bool:
+        return -THM_BRANCH_REACH <= self.displacement < THM_BRANCH_REACH
+
+    @property
+    def lands_on_symbol(self) -> bool:
+        return self.target == self.symbol.rebased_addr & ~1
+
+
+def thm_branches(ld: cle.Loader) -> list[Branch]:
     """
-    For every resolved Thumb branch relocation in the loader: the symbol it resolved to, the
-    distance CLE had to encode, and the branch target it actually encoded.
+    Every resolved Thumb branch relocation in the loader, with the displacement it had to encode
+    and the target it ended up encoding.
     """
     branches = []
     for obj in ld.all_objects:
@@ -122,62 +142,60 @@ def thm_branches(ld: cle.Loader) -> list[tuple[Symbol, int, int]]:
             resolved = reloc.resolvedby
             if not isinstance(reloc, R_ARM_THM_CALL) or resolved is None:
                 continue
-            reach = abs(resolved.rebased_addr - reloc.rebased_addr)
-            target = decode_thm_branch(ld.memory.load(reloc.rebased_addr, 4), reloc.rebased_addr)
-            branches.append((resolved, reach, target))
+            place = reloc.rebased_addr
+            branches.append(
+                Branch(
+                    resolved,
+                    (resolved.rebased_addr & ~1) - (place + 4),
+                    decode_thm_branch(ld.memory.load(place, 4), place),
+                )
+            )
     return branches
 
 
 class TestArmRelocations(unittest.TestCase):
     @staticmethod
     def test_archive_calls_past_8mb():
-        # CLE gives every archive member its own rebase_granularity boundary and maps the extern
-        # object after all of them, so a dozen members put the calls to the extern stubs more than
-        # 8 MiB away. That is past a signed 24-bit displacement but well inside the signed 25-bit
-        # field a Thumb BL actually carries.
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = os.path.join(tmpdir, "libthm.a")
-            write_static_archive(path, TEST_FILE, 14)
-            ld = cle.Loader(path, auto_load_libs=False)
+        # Spread over 43 archive members, plenty of the calls to the extern stubs land past
+        # 8 MiB. That is beyond a signed 24-bit displacement but well inside the signed 25-bit
+        # field a Thumb BL actually carries, so they have to be encoded, not rejected.
+        ld = cle.Loader(ARCHIVE, auto_load_libs=False)
 
-            branches = thm_branches(ld)
-            assert branches
-            assert max(reach for _, reach, _ in branches) > 8 * MIB
-            for symbol, _, target in branches:
-                assert target == symbol.rebased_addr & ~1
+        in_reach = [branch for branch in thm_branches(ld) if branch.in_reach]
+        assert in_reach
+        assert any(abs(branch.displacement) > NARROW_THM_BRANCH_REACH for branch in in_reach)
+        for branch in in_reach:
+            assert branch.lands_on_symbol
 
     def test_archive_calls_out_of_reach_are_not_fatal(self):
-        # Enough members and the extern object lands past even a 25-bit displacement. Those calls
-        # cannot be encoded, but that must not cost the caller the rest of the archive, and it must
-        # not disturb the calls that are still in reach.
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = os.path.join(tmpdir, "libthm.a")
-            write_static_archive(path, TEST_FILE, 24)
-            with self.assertLogs("cle.backends.elf.relocation.arm", level="WARNING") as logs:
-                ld = cle.Loader(path, auto_load_libs=False)
+        # The far end of the same archive is past even a 25-bit displacement. Those calls cannot
+        # be encoded, but that must not cost the caller the rest of the archive, and it must not
+        # disturb the calls that are still in reach.
+        with self.assertLogs("cle.backends.elf.relocation.arm", level="WARNING") as logs:
+            ld = cle.Loader(ARCHIVE, auto_load_libs=False)
 
-            branches = thm_branches(ld)
-            assert branches
-            assert max(reach for _, reach, _ in branches) > 16 * MIB
-            assert any("out of range" in record.getMessage() for record in logs.records)
-            for symbol, reach, target in branches:
-                if reach <= 8 * MIB:
-                    assert target == symbol.rebased_addr & ~1
+        branches = thm_branches(ld)
+        assert any(not branch.in_reach for branch in branches)
+        assert any("out of range" in record.getMessage() for record in logs.records)
+        assert all(branch.lands_on_symbol for branch in branches if branch.in_reach)
 
     @staticmethod
     def test_wide_implicit_addend():
         # An implicit addend of at least 8 MiB only survives if the whole 25-bit displacement is
-        # read back out of the instruction.
+        # read back out of the instruction. No fixture carries one: a toolchain leaves a branch
+        # that wide only when it relocates against a section symbol in a section that big. So the
+        # case is made by rewriting the displacements of a real object's branches, which changes
+        # four bytes per branch and leaves its sections, symbols and relocations alone.
         addend = -0x800004
         with tempfile.TemporaryDirectory() as tmpdir:
-            path = os.path.join(tmpdir, "i2c_api.o")
-            rewrite_undefined_branch_addends(TEST_FILE, path, addend)
+            path = os.path.join(tmpdir, os.path.basename(OBJECT))
+            rewrite_undefined_branch_addends(OBJECT, path, addend)
             ld = cle.Loader(path, auto_load_libs=False, main_opts={"base_addr": 0x1000000})
 
-            branches = [b for b in thm_branches(ld) if b[0].owner is ld.extern_object]
+            branches = [b for b in thm_branches(ld) if b.symbol.owner is ld.extern_object]
             assert branches
-            for symbol, _, target in branches:
-                assert target == (symbol.rebased_addr + addend + 4) & ~1
+            for branch in branches:
+                assert branch.target == (branch.symbol.rebased_addr + addend + 4) & ~1
 
 
 if __name__ == "__main__":

--- a/tests/test_arm_relocations.py
+++ b/tests/test_arm_relocations.py
@@ -1,0 +1,184 @@
+# pylint: disable=missing-class-docstring
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from elftools.elf.elffile import ELFFile
+from elftools.elf.enums import ENUM_RELOC_TYPE_ARM
+from elftools.elf.relocation import RelocationSection
+from elftools.elf.sections import SymbolTableSection
+
+import cle
+from cle.backends import Symbol
+from cle.backends.elf.relocation.arm import R_ARM_THM_CALL
+
+# An ET_REL ARM object holding 51 R_ARM_THM_CALL and 11 R_ARM_THM_JUMP24 relocations, all REL,
+# so the addends come out of the instructions themselves.
+TEST_FILE = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    os.path.join("..", "..", "binaries", "tests"),
+    os.path.join("armel", "i2c_api.o"),
+)
+
+THM_BRANCH_RELOC_TYPES = (
+    ENUM_RELOC_TYPE_ARM["R_ARM_THM_CALL"],
+    ENUM_RELOC_TYPE_ARM["R_ARM_THM_JUMP24"],
+)
+
+MIB = 1024 * 1024
+
+
+def decode_thm_branch(data: bytes, addr: int) -> int:
+    """
+    Decode the branch target of the 32-bit Thumb BL/B.W made of the four bytes ``data`` and
+    placed at ``addr``.
+    """
+    hi = data[0] | (data[1] << 8)
+    lo = data[2] | (data[3] << 8)
+    sign = (hi >> 10) & 1
+    i1 = 1 - (((lo >> 13) & 1) ^ sign)
+    i2 = 1 - (((lo >> 11) & 1) ^ sign)
+    imm = (sign << 24) | (i1 << 23) | (i2 << 22) | ((hi & 0x3FF) << 12) | ((lo & 0x7FF) << 1)
+    if sign:
+        imm -= 1 << 25
+    return addr + 4 + imm
+
+
+def encode_thm_branch(data: bytes, imm: int) -> bytes:
+    """
+    Rewrite the displacement of the 32-bit Thumb BL/B.W made of the four bytes ``data``, leaving
+    the rest of the encoding alone.
+    """
+    hi = data[0] | (data[1] << 8)
+    lo = data[2] | (data[3] << 8)
+    sign = (imm >> 24) & 1
+    j1 = 1 - (((imm >> 23) & 1) ^ sign)
+    j2 = 1 - (((imm >> 22) & 1) ^ sign)
+    hi = (hi & ~0x7FF) | (sign << 10) | ((imm >> 12) & 0x3FF)
+    lo = (lo & ~0x2FFF) | (j1 << 13) | (j2 << 11) | ((imm >> 1) & 0x7FF)
+    return bytes((hi & 0xFF, hi >> 8, lo & 0xFF, lo >> 8))
+
+
+def write_static_archive(path: str, member: str, count: int) -> None:
+    """
+    Write an ``ar`` archive holding ``count`` copies of the object file ``member``.
+    """
+    with open(member, "rb") as f:
+        data = f.read()
+    with open(path, "wb") as f:
+        f.write(b"!<arch>\n")
+        for i in range(count):
+            name = f"m{i:02d}.o/".encode().ljust(16)
+            f.write(name + b"0".ljust(12) + b"0".ljust(6) + b"0".ljust(6))
+            f.write(b"100644".ljust(8) + str(len(data)).encode().ljust(10) + b"`\n")
+            f.write(data)
+            if len(data) % 2:
+                f.write(b"\n")
+
+
+def rewrite_undefined_branch_addends(src: str, dst: str, addend: int) -> None:
+    """
+    Copy the object at ``src`` to ``dst``, giving every Thumb branch against an undefined symbol
+    an implicit addend of ``addend``.
+    """
+    shutil.copyfile(src, dst)
+
+    offsets = []
+    with open(dst, "rb") as f:
+        elf = ELFFile(f)
+        for section in elf.iter_sections():
+            if not isinstance(section, RelocationSection):
+                continue
+            symtab = elf.get_section(section["sh_link"])
+            assert isinstance(symtab, SymbolTableSection)
+            target = elf.get_section(section["sh_info"])
+            for reloc in section.iter_relocations():
+                if reloc["r_info_type"] not in THM_BRANCH_RELOC_TYPES:
+                    continue
+                if symtab.get_symbol(reloc["r_info_sym"])["st_shndx"] != "SHN_UNDEF":
+                    continue
+                offsets.append(target["sh_offset"] + reloc["r_offset"])
+
+    assert offsets
+    with open(dst, "r+b") as f:
+        for offset in offsets:
+            f.seek(offset)
+            data = f.read(4)
+            f.seek(offset)
+            f.write(encode_thm_branch(data, addend & 0x1FFFFFF))
+
+
+def thm_branches(ld: cle.Loader) -> list[tuple[Symbol, int, int]]:
+    """
+    For every resolved Thumb branch relocation in the loader: the symbol it resolved to, the
+    distance CLE had to encode, and the branch target it actually encoded.
+    """
+    branches = []
+    for obj in ld.all_objects:
+        for reloc in obj.relocs:
+            resolved = reloc.resolvedby
+            if not isinstance(reloc, R_ARM_THM_CALL) or resolved is None:
+                continue
+            reach = abs(resolved.rebased_addr - reloc.rebased_addr)
+            target = decode_thm_branch(ld.memory.load(reloc.rebased_addr, 4), reloc.rebased_addr)
+            branches.append((resolved, reach, target))
+    return branches
+
+
+class TestArmRelocations(unittest.TestCase):
+    @staticmethod
+    def test_archive_calls_past_8mb():
+        # CLE gives every archive member its own rebase_granularity boundary and maps the extern
+        # object after all of them, so a dozen members put the calls to the extern stubs more than
+        # 8 MiB away. That is past a signed 24-bit displacement but well inside the signed 25-bit
+        # field a Thumb BL actually carries.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "libthm.a")
+            write_static_archive(path, TEST_FILE, 14)
+            ld = cle.Loader(path, auto_load_libs=False)
+
+            branches = thm_branches(ld)
+            assert branches
+            assert max(reach for _, reach, _ in branches) > 8 * MIB
+            for symbol, _, target in branches:
+                assert target == symbol.rebased_addr & ~1
+
+    def test_archive_calls_out_of_reach_are_not_fatal(self):
+        # Enough members and the extern object lands past even a 25-bit displacement. Those calls
+        # cannot be encoded, but that must not cost the caller the rest of the archive, and it must
+        # not disturb the calls that are still in reach.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "libthm.a")
+            write_static_archive(path, TEST_FILE, 24)
+            with self.assertLogs("cle.backends.elf.relocation.arm", level="WARNING") as logs:
+                ld = cle.Loader(path, auto_load_libs=False)
+
+            branches = thm_branches(ld)
+            assert branches
+            assert max(reach for _, reach, _ in branches) > 16 * MIB
+            assert any("out of range" in record.getMessage() for record in logs.records)
+            for symbol, reach, target in branches:
+                if reach <= 8 * MIB:
+                    assert target == symbol.rebased_addr & ~1
+
+    @staticmethod
+    def test_wide_implicit_addend():
+        # An implicit addend of at least 8 MiB only survives if the whole 25-bit displacement is
+        # read back out of the instruction.
+        addend = -0x800004
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "i2c_api.o")
+            rewrite_undefined_branch_addends(TEST_FILE, path, addend)
+            ld = cle.Loader(path, auto_load_libs=False, main_opts={"base_addr": 0x1000000})
+
+            branches = [b for b in thm_branches(ld) if b[0].owner is ld.extern_object]
+            assert branches
+            for symbol, _, target in branches:
+                assert target == (symbol.rebased_addr + addend + 4) & ~1
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Loading the mbed GCC ARM static library at `tests_src/i2c_master_read-nucleol152re/mbed/TARGET_NUCLEO_L152RE/TOOLCHAIN_GCC_ARM/libmbed.a` aborts, and nothing loads at all:

```text
  File "cle/backends/elf/relocation/arm.py", line 352, in value
    raise CLEOperationError(
cle.errors.CLEOperationError: Jump target out of range for reloc R_ARM_THM_CALL (+- 2^23).
```

Each archive member is mapped on its own `rebase_granularity` boundary with the extern object last, so even a modest archive puts the stubs beyond that range. Because the relocation raises rather than warns, one unreachable call to an extern stub costs the caller the whole archive — the 251 branches that were in range, and every member after the failing one.

### Root cause

`R_ARM_THM_CALL.value` decodes the implicit addend from 24 bits and range-checks against 24:

```python
A &= 0x7FFFFF
if sign_bit:
    A |= 0xFF800000
...
if x & 0xFF800000 != 0 and x & 0xFF800000 != 0xFF800000:
    raise CLEOperationError(
```

A 32-bit Thumb `BL`/`B.W` encodes a signed byte displacement in `offset[24:1]`, so the sign is at bit 24, not bit 23. Masking to 23 bits drops bit 24 and re-signs from the wrong place, and the same off-by-one bit rejects any branch between 8 and 16 MiB, which the instruction encodes perfectly well. On an object whose Thumb branches carry an implicit addend of `-0x800004`, every one of the 43 sites came out `0x800000` high — exactly the discarded bit:

```text
Loader(i2c_api.o): 43 extern branches; 0/43 encode symbol+addend; target-expected deltas=['0x800000']
```

### Fix

Both are widened to the 25 bits the encoder below already writes: the addend is sign-extended from bit 24 with no prior mask, and the check becomes `if x & 0xFF000000 not in (0, 0xFF000000):`. A displacement that genuinely does not fit is a `log.warning` naming the relocation, its PC and its target, and is encoded truncated, matching `R_AARCH64_CALL26`.

```text
Loader(libmbed.a): loaded 45 objects; 470 resolved R_ARM_THM_CALL; 251 in reach
  (57 of them past the old +-8 MiB limit), 219 out of reach;
  in-reach branches landing on their symbol: 251/251
Loader(i2c_api.o): 43 extern branches; 43/43 encode symbol+addend; target-expected deltas=['0x0']
```

cle deliberately does not synthesize veneers, so a branch past +-16 MiB is still wrong; it just no longer costs the caller the rest of the load. Mapping the extern object within reach would also avoid the truncation, but that is a loader-wide layout change.

### Testing

`tests/test_arm_relocations.py::TestArmRelocations::test_archive_calls_past_8mb` asserts `any(abs(branch.displacement) > NARROW_THM_BRANCH_REACH for branch in in_reach)` and that every in-reach branch lands on its symbol; `::test_archive_calls_out_of_reach_are_not_fatal` pins that the unreachable ones warn instead of raising; `::test_wide_implicit_addend` pins the decode against the rewritten object. All three fail on the merge base, the first two on the `CLEOperationError` above. The archive is already on `angr/binaries` master, so no fixture change accompanies this.

Validation: https://github.com/angr/cle/pull/733#issuecomment-5234731420

session: sharpen
