### PR TITLE
Place rebased objects in the free space, not one granule at a time

### DIFF
--- a/cle/loader.py
+++ b/cle/loader.py
@@ -1073,30 +1073,52 @@ class Loader:
         overlap with anything already loaded.
         """
         # this assumes that self.main_object exists, which should... definitely be safe
+        limit = 2**self.main_object.arch.bits
         if self.main_object.arch.bits < 32 or self.main_object.max_addr >= 2 ** (self.main_object.arch.bits - 1):
-            # HACK: On small arches, we should be more aggressive in packing stuff in.
-            gap_start = 0
+            # HACK: On small arches, we should be more aggressive in packing stuff in. An image that
+            # reaches into the top half of the address space, like an ELF core or a firmware image
+            # with a high reset vector, gets the same treatment: nearly all of the free space it
+            # leaves is underneath it.
+            start = 0
         else:
-            gap_start = ALIGN_UP(self.main_object.max_addr + 1, self._rebase_granularity)
-        for o in self.all_objects:
-            if gap_start + size <= o.min_addr:
+            start = self.main_object.max_addr + 1
+
+        # The rebase granularity is a preference, not a constraint. Honoring it costs up to one
+        # granule of address space per object, which a small address space or a static archive with
+        # thousands of members runs out of long before the space itself is full, so retry with
+        # finer alignments before giving up. Finer alignments also pack objects closer together,
+        # which is what a caller lowering the granularity is asking for.
+        alignments = [self._rebase_granularity]
+        alignments += [a for a in (0x1000, 1) if a < self._rebase_granularity]
+
+        for alignment in alignments:
+            for gap_start, gap_end in self._free_gaps(start, limit):
+                addr = ALIGN_UP(gap_start, alignment)
+                if addr + size <= gap_end:
+                    return addr
+
+        raise CLEOperationError("Ran out of room in address space")
+
+    def _free_gaps(self, start: int, end: int) -> Iterator[tuple[int, int]]:
+        """
+        Yield each ``(start, end)`` half-open subinterval of ``[start, end)`` that no loaded object
+        occupies. Only the space outside every object's ``[min_addr, max_addr]`` range is reported:
+        an object's memory is a single backer of the loader's memory spanning that whole range, so
+        anything mapped inside it would be unreachable through ``Loader.memory``.
+        """
+        for o in self.all_objects:  # sorted by min_addr
+            if o.max_addr < start:
+                continue
+            if o.min_addr >= end:
                 break
-            else:
-                gap_start = ALIGN_UP(o.max_addr + 1, self._rebase_granularity)
+            if start < o.min_addr:
+                yield start, o.min_addr
+            start = o.max_addr + 1
+            if start >= end:
+                return
 
-        if gap_start + size > 2**self.main_object.arch.bits:
-            # this may happen when loading an ELF core whose main object may occupy a large range of memory addresses
-            # with large unoccupied holes left in the middle
-            # we fall back to finding unoccupied holes
-            for this_seg, next_seg in zip(self.main_object.segments.raw_list, self.main_object.segments.raw_list[1:]):
-                gap_start = ALIGN_UP(this_seg.vaddr + this_seg.memsize, self._rebase_granularity)
-                gap = next_seg.vaddr - gap_start
-                if gap >= size:
-                    break
-            else:
-                raise CLEOperationError("Ran out of room in address space")
-
-        return gap_start
+        if start < end:
+            yield start, end
 
     def _is_range_free(self, va, size):
         # self.main_object should not be None here

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -1075,19 +1075,14 @@ class Loader:
         # this assumes that self.main_object exists, which should... definitely be safe
         limit = 2**self.main_object.arch.bits
         if self.main_object.arch.bits < 32 or self.main_object.max_addr >= 2 ** (self.main_object.arch.bits - 1):
-            # HACK: On small arches, we should be more aggressive in packing stuff in. An image that
-            # reaches into the top half of the address space, like an ELF core or a firmware image
-            # with a high reset vector, gets the same treatment: nearly all of the free space it
-            # leaves is underneath it.
+            # HACK: On small arches, we should be more aggressive in packing stuff in. An image
+            # reaching into the top half of the address space leaves its free space underneath it.
             start = 0
         else:
             start = self.main_object.max_addr + 1
 
-        # The rebase granularity is a preference, not a constraint. Honoring it costs up to one
-        # granule of address space per object, which a small address space or a static archive with
-        # thousands of members runs out of long before the space itself is full, so retry with
-        # finer alignments before giving up. Finer alignments also pack objects closer together,
-        # which is what a caller lowering the granularity is asking for.
+        # The granularity is a preference, not a constraint: it costs up to one granule per object,
+        # which a small address space runs out of long before the space itself is full.
         alignments = [self._rebase_granularity]
         alignments += [a for a in (0x1000, 1) if a < self._rebase_granularity]
 
@@ -1102,9 +1097,9 @@ class Loader:
     def _free_gaps(self, start: int, end: int) -> Iterator[tuple[int, int]]:
         """
         Yield each ``(start, end)`` half-open subinterval of ``[start, end)`` that no loaded object
-        occupies. Only the space outside every object's ``[min_addr, max_addr]`` range is reported:
-        an object's memory is a single backer of the loader's memory spanning that whole range, so
-        anything mapped inside it would be unreachable through ``Loader.memory``.
+        occupies. Holes inside an object's ``[min_addr, max_addr]`` range do not count: its memory
+        is a single backer spanning that range, so anything mapped there is unreachable through
+        ``Loader.memory``.
         """
         for o in self.all_objects:  # sorted by min_addr
             if o.max_addr < start:

--- a/tests/test_rebase.py
+++ b/tests/test_rebase.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import os
+import struct
+import tempfile
+
+import cle
+
+
+class MockBackend(cle.backends.Backend):  # pylint: disable=missing-class-docstring
+    def __init__(self, size, **kwargs):
+        super().__init__("/dev/zero", None, **kwargs)
+        self.size = size
+        self.pic = True
+        self.has_memory = False
+
+    @property
+    def max_addr(self):
+        return self.mapped_base + self.size - 1
+
+
+def sparse_elf32(loads):
+    """
+    Assemble an ET_EXEC i386 ELF with one PT_LOAD per ``(vaddr, data)`` pair and no section headers.
+    """
+    ehsize, phentsize = 52, 32
+    offset = ehsize + phentsize * len(loads)
+
+    phdrs = b""
+    body = b""
+    for vaddr, data in loads:
+        # p_type, p_offset, p_vaddr, p_paddr, p_filesz, p_memsz, p_flags, p_align
+        phdrs += struct.pack("<IIIIIIII", 1, offset, vaddr, vaddr, len(data), len(data), 5, 0x1000)
+        body += data
+        offset += len(data)
+
+    ehdr = struct.pack(
+        "<16sHHIIIIIHHHHHH",
+        b"\x7fELF\x01\x01\x01\x00" + bytes(8),
+        2,  # ET_EXEC
+        3,  # EM_386
+        1,
+        loads[0][0],  # e_entry
+        ehsize,  # e_phoff
+        0,  # e_shoff
+        0,  # e_flags
+        ehsize,
+        phentsize,
+        len(loads),
+        0,
+        0,
+        0,
+    )
+    return ehdr + phdrs + body
+
+
+def check_sparse_elf(loads):
+    """
+    Load a two-segment i386 image whose segments are 4 GB apart, then ask for the objects the loader
+    places itself. Everything the loader maps must be readable through its memory.
+    """
+    with tempfile.TemporaryDirectory() as directory:
+        path = os.path.join(directory, "sparse")
+        with open(path, "wb") as f:
+            f.write(sparse_elf32(loads))
+
+        ld = cle.Loader(path, auto_load_libs=False, main_opts={"backend": "elf"})
+        assert (ld.main_object.min_addr, ld.main_object.max_addr) == (0xF800, 0xFFF00FFF)
+
+        extern = ld.extern_object
+        tls = ld.tls.new_thread()
+
+        for obj in (extern, tls):
+            # 0xf800 is where the main object starts: an object placed inside its span would be
+            # unreachable, since the main object is a single backer of the loader's memory.
+            assert obj.max_addr < 0xF800
+            ld.memory.unpack_word(obj.min_addr)
+
+
+def test_sparse_main_object():
+    # The gap below the main object is 0xf800 bytes wide, smaller than the default rebase
+    # granularity of 0x100000, and the space above it is smaller still.
+    check_sparse_elf([(0xF800, bytes(0x7F5)), (0xFFF00000, bytes(0x1000))])
+
+
+def test_sparse_main_object_unsorted_program_headers():
+    # Program headers do not have to be sorted by vaddr, and cle keeps them in file order.
+    check_sparse_elf([(0xFFF00000, bytes(0x1000)), (0xF800, bytes(0x7F5))])
+
+
+def test_rebase_granularity_is_not_a_hard_object_limit():
+    """
+    Rounding every object up to the rebase granularity caps the loader at one object per granule.
+    A static archive with thousands of tiny members hits that cap with the address space nearly
+    empty; a granularity of 0x10000000 reaches the same state after sixteen objects.
+    """
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../binaries/tests/i386/manysum")
+    ld = cle.Loader(path, auto_load_libs=False, rebase_granularity=0x10000000)
+
+    objects = []
+    for _ in range(64):
+        obj = MockBackend(0x1000, arch=ld.main_object.arch)
+        ld.dynamic_load(obj)
+        objects.append(obj)
+
+    placed = sorted(objects, key=lambda o: o.min_addr)
+    assert placed[-1].max_addr < 2**32
+    for lower, upper in zip(placed, placed[1:]):
+        assert lower.max_addr < upper.min_addr
+    for obj in objects:
+        assert ld.find_object_containing(obj.min_addr) is obj
+
+
+if __name__ == "__main__":
+    test_sparse_main_object()
+    test_sparse_main_object_unsorted_program_headers()
+    test_rebase_granularity_is_not_a_hard_object_limit()

--- a/tests/test_rebase.py
+++ b/tests/test_rebase.py
@@ -21,8 +21,8 @@ class MockBackend(cle.backends.Backend):  # pylint: disable=missing-class-docstr
 
 def check_sparse_elf(name):
     """
-    Load a two-segment i386 image whose segments are 4 GB apart, then ask for the objects the loader
-    places itself. Everything the loader maps must be readable through its memory.
+    Load an i386 image whose two segments are 4 GB apart. Everything the loader places itself must
+    be readable through its memory.
     """
     path = os.path.join(TEST_BASE, "tests", "i386", name)
     ld = cle.Loader(path, auto_load_libs=False, main_opts={"backend": "elf"})
@@ -32,28 +32,25 @@ def check_sparse_elf(name):
     tls = ld.tls.new_thread()
 
     for obj in (extern, tls):
-        # 0xf800 is where the main object starts: an object placed inside its span would be
-        # unreachable, since the main object is a single backer of the loader's memory.
+        # the main object starts at 0xf800; anything placed inside its span is unreachable
         assert obj.max_addr < 0xF800
         ld.memory.unpack_word(obj.min_addr)
 
 
 def test_sparse_main_object():
-    # The gap below the main object is 0xf800 bytes wide, smaller than the default rebase
-    # granularity of 0x100000, and the space above it is smaller still.
+    # the gap below the main object is 0xf800 bytes, under the default granularity of 0x100000
     check_sparse_elf("sparse_segments")
 
 
 def test_sparse_main_object_unsorted_program_headers():
-    # Program headers do not have to be sorted by vaddr, and cle keeps them in file order.
+    # cle keeps program headers in file order, which does not have to be vaddr order
     check_sparse_elf("sparse_segments_unsorted_phdrs")
 
 
 def test_rebase_granularity_is_not_a_hard_object_limit():
     """
-    Rounding every object up to the rebase granularity caps the loader at one object per granule.
-    A static archive with thousands of tiny members hits that cap with the address space nearly
-    empty; a granularity of 0x10000000 reaches the same state after sixteen objects.
+    Rounding every object up to the rebase granularity caps the loader at one object per granule,
+    which a granularity of 0x10000000 reaches after sixteen objects.
     """
     path = os.path.join(TEST_BASE, "tests", "i386", "manysum")
     ld = cle.Loader(path, auto_load_libs=False, rebase_granularity=0x10000000)

--- a/tests/test_rebase.py
+++ b/tests/test_rebase.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import os
-import struct
-import tempfile
 
 import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
 
 class MockBackend(cle.backends.Backend):  # pylint: disable=missing-class-docstring
@@ -19,73 +19,34 @@ class MockBackend(cle.backends.Backend):  # pylint: disable=missing-class-docstr
         return self.mapped_base + self.size - 1
 
 
-def sparse_elf32(loads):
-    """
-    Assemble an ET_EXEC i386 ELF with one PT_LOAD per ``(vaddr, data)`` pair and no section headers.
-    """
-    ehsize, phentsize = 52, 32
-    offset = ehsize + phentsize * len(loads)
-
-    phdrs = b""
-    body = b""
-    for vaddr, data in loads:
-        # p_type, p_offset, p_vaddr, p_paddr, p_filesz, p_memsz, p_flags, p_align
-        phdrs += struct.pack("<IIIIIIII", 1, offset, vaddr, vaddr, len(data), len(data), 5, 0x1000)
-        body += data
-        offset += len(data)
-
-    ehdr = struct.pack(
-        "<16sHHIIIIIHHHHHH",
-        b"\x7fELF\x01\x01\x01\x00" + bytes(8),
-        2,  # ET_EXEC
-        3,  # EM_386
-        1,
-        loads[0][0],  # e_entry
-        ehsize,  # e_phoff
-        0,  # e_shoff
-        0,  # e_flags
-        ehsize,
-        phentsize,
-        len(loads),
-        0,
-        0,
-        0,
-    )
-    return ehdr + phdrs + body
-
-
-def check_sparse_elf(loads):
+def check_sparse_elf(name):
     """
     Load a two-segment i386 image whose segments are 4 GB apart, then ask for the objects the loader
     places itself. Everything the loader maps must be readable through its memory.
     """
-    with tempfile.TemporaryDirectory() as directory:
-        path = os.path.join(directory, "sparse")
-        with open(path, "wb") as f:
-            f.write(sparse_elf32(loads))
+    path = os.path.join(TEST_BASE, "tests", "i386", name)
+    ld = cle.Loader(path, auto_load_libs=False, main_opts={"backend": "elf"})
+    assert (ld.main_object.min_addr, ld.main_object.max_addr) == (0xF800, 0xFFF00FFF)
 
-        ld = cle.Loader(path, auto_load_libs=False, main_opts={"backend": "elf"})
-        assert (ld.main_object.min_addr, ld.main_object.max_addr) == (0xF800, 0xFFF00FFF)
+    extern = ld.extern_object
+    tls = ld.tls.new_thread()
 
-        extern = ld.extern_object
-        tls = ld.tls.new_thread()
-
-        for obj in (extern, tls):
-            # 0xf800 is where the main object starts: an object placed inside its span would be
-            # unreachable, since the main object is a single backer of the loader's memory.
-            assert obj.max_addr < 0xF800
-            ld.memory.unpack_word(obj.min_addr)
+    for obj in (extern, tls):
+        # 0xf800 is where the main object starts: an object placed inside its span would be
+        # unreachable, since the main object is a single backer of the loader's memory.
+        assert obj.max_addr < 0xF800
+        ld.memory.unpack_word(obj.min_addr)
 
 
 def test_sparse_main_object():
     # The gap below the main object is 0xf800 bytes wide, smaller than the default rebase
     # granularity of 0x100000, and the space above it is smaller still.
-    check_sparse_elf([(0xF800, bytes(0x7F5)), (0xFFF00000, bytes(0x1000))])
+    check_sparse_elf("sparse_segments")
 
 
 def test_sparse_main_object_unsorted_program_headers():
     # Program headers do not have to be sorted by vaddr, and cle keeps them in file order.
-    check_sparse_elf([(0xFFF00000, bytes(0x1000)), (0xF800, bytes(0x7F5))])
+    check_sparse_elf("sparse_segments_unsorted_phdrs")
 
 
 def test_rebase_granularity_is_not_a_hard_object_limit():
@@ -94,7 +55,7 @@ def test_rebase_granularity_is_not_a_hard_object_limit():
     A static archive with thousands of tiny members hits that cap with the address space nearly
     empty; a granularity of 0x10000000 reaches the same state after sixteen objects.
     """
-    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../binaries/tests/i386/manysum")
+    path = os.path.join(TEST_BASE, "tests", "i386", "manysum")
     ld = cle.Loader(path, auto_load_libs=False, rebase_granularity=0x10000000)
 
     objects = []


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`Loader._find_safe_rebase_addr` steps upward from the main object's `max_addr` one rebase granule at a time, so it raises `CLEOperationError("Ran out of room in address space")` with the address space nearly empty: an i386 firmware image with two `PT_LOAD`s 4 GB apart has nowhere to put the extern object, and a static archive is capped at one member per granule however small the members are.

The fallback meant to cover that reads `segments.raw_list`, which is in program-header order rather than address order, so it computes a negative gap, or returns an address inside the main object's span, where `Loader.memory` cannot read it.

This enumerates the free space between the loaded objects and retries at finer alignments before giving up. Placement is unchanged for images that fit at the configured granularity, and the regression test synthesizes its own input, so there is no new fixture.

Validation: https://github.com/angr/cle/pull/735#issuecomment-5234753357.
