### PR TITLE
Load static archives with a /SYM64/ symbol table

### DIFF
--- a/cle/backends/static_archive.py
+++ b/cle/backends/static_archive.py
@@ -1,12 +1,51 @@
 from __future__ import annotations
 
 import logging
+from io import SEEK_END, BufferedReader
 
 import arpy
+
+from cle.errors import CLEInvalidBinaryError
 
 from .backend import Backend, register_backend
 
 log = logging.getLogger(__name__)
+
+# An ar member header is 16 bytes of name, 12 + 6 + 6 + 8 of metadata, 10 bytes of decimal size, then this magic.
+AR_HEADER_LEN = 60
+AR_HEADER_MAGIC = b"`\n"
+
+
+def _skip_sym64_symbol_table(stream: BufferedReader, offset: int) -> int:
+    """
+    Return the offset of the first member of an ar archive, skipping the symbol table at ``offset`` if it is the 64-bit
+    variant.
+
+    The symbol table is the first member of the archive, named "/" for the 32-bit index and "/SYM64/" for the 64-bit
+    one. arpy only knows the first spelling: it classifies "/SYM64/" as a member whose real name lives in the long
+    filename table, then raises ValueError parsing "SYM64" as the offset into that table. arpy discards the symbol
+    table for either spelling, so skipping the member loses nothing.
+
+    Anything that does not look like a 64-bit symbol table lying inside the file leaves the offset alone, so arpy
+    reports malformed archives as usual.
+    """
+    stream.seek(0, SEEK_END)
+    file_len = stream.tell()
+
+    stream.seek(offset)
+    header = stream.read(AR_HEADER_LEN)
+    if len(header) < AR_HEADER_LEN or header[58:60] != AR_HEADER_MAGIC or header[:16].rstrip() != b"/SYM64/":
+        return offset
+
+    try:
+        size = int(header[48:58])
+    except ValueError:
+        return offset
+
+    end = offset + AR_HEADER_LEN + size
+    if size < 0 or end > file_len:
+        return offset
+    return end + end % 2  # members start at an even offset
 
 
 class StaticArchive(Backend):
@@ -27,8 +66,13 @@ class StaticArchive(Backend):
         if self.loader._main_object is None:
             self.loader._main_object = self
 
-        ar = arpy.Archive(fileobj=self._binary_stream)
-        ar.read_all_headers()
+        try:
+            ar = arpy.Archive(fileobj=self._binary_stream)
+            ar.next_header_offset = _skip_sym64_symbol_table(self._binary_stream, ar.next_header_offset)
+            ar.read_all_headers()
+        except (arpy.ArchiveFormatError, arpy.ArchiveAccessError, ValueError) as e:
+            raise CLEInvalidBinaryError(f"Malformed static archive {self.binary_basename}") from e
+
         for name, stream in ar.archived_files.items():
             child = self.loader._load_object_isolated(stream)
             child.binary = child.binary_basename = name.decode()

--- a/tests/test_static_archive.py
+++ b/tests/test_static_archive.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import struct
 import tempfile
 import unittest
 
@@ -9,51 +8,36 @@ import cle
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
-OBJECT = os.path.join(TEST_BASE, "tests", "x86_64", "test.o")
-LONG_NAME = b"a_member_with_a_long_name.o"
+# A MIPS64 big-endian static library indexed by a 64-bit "/SYM64/" symbol table, holding one member.
+SYM64_ARCHIVE = os.path.join(TEST_BASE, "tests", "mips64", "sym64_archive.a")
+
+# An ARM static library indexed by an ordinary 32-bit "/" symbol table, with a "//" long filename table.
+GNU_ARCHIVE = os.path.join(
+    TEST_BASE,
+    "tests_src",
+    "i2c_master_read-nucleol152re",
+    "mbed",
+    "TARGET_NUCLEO_L152RE",
+    "TOOLCHAIN_GCC_ARM",
+    "libmbed.a",
+)
+
+# The symbol table is the first member of an archive, so its header follows the 8-byte global header. Inside a 60-byte
+# member header the decimal size occupies bytes 48 to 58 and the terminating magic occupies the last two.
+FIRST_HEADER = 8
+SIZE_FIELD = slice(48, 58)
+MAGIC_FIELD = slice(58, 60)
 
 
-def ar_member(name: bytes, body: bytes) -> bytes:
+def patched(path: str, header_offset: int, field: slice, value: bytes) -> bytes:
     """
-    Build one ar member: a 60-byte header followed by the body, padded to an even length.
+    Read an archive and overwrite one field of the member header at `header_offset`, to get a malformed archive that
+    differs from a real one in exactly that field.
     """
-    header = struct.pack(
-        "16s 12s 6s 6s 8s 10s 2s",
-        name.ljust(16),
-        b"0".ljust(12),
-        b"0".ljust(6),
-        b"0".ljust(6),
-        b"0".ljust(8),
-        str(len(body)).encode().ljust(10),
-        b"`\n",
-    )
-    return header + body + (b"\n" if len(body) % 2 else b"")
-
-
-def ar_archive(index_name: bytes, index_width: int) -> bytes:
-    """
-    Build a GNU ar archive holding two copies of an object file, one named directly and one named through the long
-    filename table, indexed by a symbol table whose entries are `index_width` bytes wide.
-
-    "/" with 4-byte entries is the ordinary symbol table. "/SYM64/" with 8-byte entries is the 64-bit one, which GNU ar
-    writes for mips64 targets and for archives too large to index with 32-bit offsets.
-    """
-    with open(OBJECT, "rb") as f:
-        body = f.read()
-
-    table = ar_member(b"//", LONG_NAME + b"/\n")
-    obj = ar_member(b"test.o/", body)
-    long_obj = ar_member(b"/0", body)
-
-    # The symbol table maps a symbol to the offset of the member header defining it, so its own length has to be known
-    # before the entries can be filled in.
-    names = b"main\x00foo\x00"
-    index_len = index_width * 3 + len(names)
-    index_end = 8 + 60 + index_len + index_len % 2
-    entry = ">Q" if index_width == 8 else ">I"
-    index = struct.pack(entry, 2) + struct.pack(entry, index_end + len(table)) * 2 + names
-
-    return b"!<arch>\n" + ar_member(index_name, index) + table + obj + long_obj
+    with open(path, "rb") as f:
+        data = bytearray(f.read())
+    data[header_offset + field.start : header_offset + field.stop] = value
+    return bytes(data)
 
 
 class TestStaticArchive(unittest.TestCase):
@@ -62,45 +46,53 @@ class TestStaticArchive(unittest.TestCase):
     """
 
     @staticmethod
-    def _load(data: bytes) -> cle.Loader:
+    def _load_bytes(data: bytes) -> cle.Loader:
         with tempfile.TemporaryDirectory() as directory:
             path = os.path.join(directory, "libtest.a")
             with open(path, "wb") as f:
                 f.write(data)
             return cle.Loader(path, auto_load_libs=False)
 
-    def _check(self, index_name: bytes, index_width: int):
-        ld = self._load(ar_archive(index_name, index_width))
+    @staticmethod
+    def _load_archive(path: str, **options) -> cle.StaticArchive:
+        """
+        Load an archive from disk, which the AR backend has to claim.
+        """
+        ld = cle.Loader(path, auto_load_libs=False, **options)
         assert isinstance(ld.main_object, cle.StaticArchive)
-        assert ld.main_object.arch.name == "AMD64"
-        children = [child.binary_basename for child in ld.main_object.child_objects]
-        assert children == ["test.o", LONG_NAME.decode()]
+        return ld.main_object
 
     def test_symbol_table(self):
-        self._check(b"/", 4)
+        # An ordinary archive must keep loading: the 64-bit symbol table is skipped by name, so nothing else moves.
+        # rebase_granularity works around an unrelated R_ARM_THM_CALL range failure on this library, as cle's own error
+        # message for it suggests.
+        archive = self._load_archive(GNU_ARCHIVE, rebase_granularity=0x1000)
+        assert archive.arch.name == "ARMCortexM"
+        children = [child.binary_basename for child in archive.child_objects]
+        assert children[:3] == ["AnalogIn.o", "BusIn.o", "BusOut.o"]
+        # Names too long for the 16-byte header field come out of the "//" table.
+        assert "mbed_wait_api_no_rtos.o" in children
 
     def test_sym64_symbol_table(self):
-        self._check(b"/SYM64/", 8)
+        archive = self._load_archive(SYM64_ARCHIVE)
+        assert archive.arch.name == "MIPS64"
+        assert archive.arch.memory_endness == "Iend_BE"
+        children = [child.binary_basename for child in archive.child_objects]
+        assert children == ["x11_xcb.o"]
+        symbols = {symbol.name for symbol in archive.child_objects[0].symbols}
+        assert "XGetXCBConnection" in symbols
 
     def test_bad_header_magic(self):
         # A member header with no terminating magic. arpy raises ArchiveFormatError, which is not a CLEError.
         with self.assertRaises(cle.CLEInvalidBinaryError):
-            self._load(b"!<arch>\n" + b" " * 60)
-
-    def test_bad_long_name_offset(self):
-        # A member whose name is an offset into the long filename table but is not a number, which is how a "/SYM64/"
-        # header reaches arpy today. arpy raises ValueError out of int().
-        with self.assertRaises(cle.CLEInvalidBinaryError):
-            self._load(b"!<arch>\n" + ar_member(b"/nope", b""))
+            self._load_bytes(patched(GNU_ARCHIVE, FIRST_HEADER, MAGIC_FIELD, b"XX"))
 
     def test_sym64_size_past_end(self):
         # A 64-bit symbol table whose header claims a size running past the end of the file. Trusting that size would
-        # skip the whole archive and drop every member, so report the malformed header instead.
-        archive = bytearray(ar_archive(b"/SYM64/", 8))
-        size_field = slice(8 + 48, 8 + 58)  # the size field of the first member header, past the 8-byte global header
-        archive[size_field] = str(len(archive) * 2).encode().ljust(10)
+        # skip the whole archive and drop every member, so leave the table for arpy, which rejects the archive: it
+        # reads "/SYM64/" as a member whose name is an offset into the long filename table and raises ValueError.
         with self.assertRaises(cle.CLEInvalidBinaryError):
-            self._load(bytes(archive))
+            self._load_bytes(patched(SYM64_ARCHIVE, FIRST_HEADER, SIZE_FIELD, b"999999999 "))
 
 
 if __name__ == "__main__":

--- a/tests/test_static_archive.py
+++ b/tests/test_static_archive.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import struct
+import tempfile
+import unittest
+
+import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
+
+OBJECT = os.path.join(TEST_BASE, "tests", "x86_64", "test.o")
+LONG_NAME = b"a_member_with_a_long_name.o"
+
+
+def ar_member(name: bytes, body: bytes) -> bytes:
+    """
+    Build one ar member: a 60-byte header followed by the body, padded to an even length.
+    """
+    header = struct.pack(
+        "16s 12s 6s 6s 8s 10s 2s",
+        name.ljust(16),
+        b"0".ljust(12),
+        b"0".ljust(6),
+        b"0".ljust(6),
+        b"0".ljust(8),
+        str(len(body)).encode().ljust(10),
+        b"`\n",
+    )
+    return header + body + (b"\n" if len(body) % 2 else b"")
+
+
+def ar_archive(index_name: bytes, index_width: int) -> bytes:
+    """
+    Build a GNU ar archive holding two copies of an object file, one named directly and one named through the long
+    filename table, indexed by a symbol table whose entries are `index_width` bytes wide.
+
+    "/" with 4-byte entries is the ordinary symbol table. "/SYM64/" with 8-byte entries is the 64-bit one, which GNU ar
+    writes for mips64 targets and for archives too large to index with 32-bit offsets.
+    """
+    with open(OBJECT, "rb") as f:
+        body = f.read()
+
+    table = ar_member(b"//", LONG_NAME + b"/\n")
+    obj = ar_member(b"test.o/", body)
+    long_obj = ar_member(b"/0", body)
+
+    # The symbol table maps a symbol to the offset of the member header defining it, so its own length has to be known
+    # before the entries can be filled in.
+    names = b"main\x00foo\x00"
+    index_len = index_width * 3 + len(names)
+    index_end = 8 + 60 + index_len + index_len % 2
+    entry = ">Q" if index_width == 8 else ">I"
+    index = struct.pack(entry, 2) + struct.pack(entry, index_end + len(table)) * 2 + names
+
+    return b"!<arch>\n" + ar_member(index_name, index) + table + obj + long_obj
+
+
+class TestStaticArchive(unittest.TestCase):
+    """
+    Test the AR backend.
+    """
+
+    @staticmethod
+    def _load(data: bytes) -> cle.Loader:
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "libtest.a")
+            with open(path, "wb") as f:
+                f.write(data)
+            return cle.Loader(path, auto_load_libs=False)
+
+    def _check(self, index_name: bytes, index_width: int):
+        ld = self._load(ar_archive(index_name, index_width))
+        assert isinstance(ld.main_object, cle.StaticArchive)
+        assert ld.main_object.arch.name == "AMD64"
+        children = [child.binary_basename for child in ld.main_object.child_objects]
+        assert children == ["test.o", LONG_NAME.decode()]
+
+    def test_symbol_table(self):
+        self._check(b"/", 4)
+
+    def test_sym64_symbol_table(self):
+        self._check(b"/SYM64/", 8)
+
+    def test_bad_header_magic(self):
+        # A member header with no terminating magic. arpy raises ArchiveFormatError, which is not a CLEError.
+        with self.assertRaises(cle.CLEInvalidBinaryError):
+            self._load(b"!<arch>\n" + b" " * 60)
+
+    def test_bad_long_name_offset(self):
+        # A member whose name is an offset into the long filename table but is not a number, which is how a "/SYM64/"
+        # header reaches arpy today. arpy raises ValueError out of int().
+        with self.assertRaises(cle.CLEInvalidBinaryError):
+            self._load(b"!<arch>\n" + ar_member(b"/nope", b""))
+
+    def test_sym64_size_past_end(self):
+        # A 64-bit symbol table whose header claims a size running past the end of the file. Trusting that size would
+        # skip the whole archive and drop every member, so report the malformed header instead.
+        archive = bytearray(ar_archive(b"/SYM64/", 8))
+        size_field = slice(8 + 48, 8 + 58)  # the size field of the first member header, past the 8-byte global header
+        archive[size_field] = str(len(archive) * 2).encode().ljust(10)
+        with self.assertRaises(cle.CLEInvalidBinaryError):
+            self._load(bytes(archive))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`cle.Loader` cannot open a static archive whose index is the 64-bit variant. On `tests/mips64/sym64_archive.a` the load dies inside arpy, before any member is reached:

```text
  File "arpy.py", line 277, in __fix_name
    gnu_position = int(header.proxy_name[1:])
ValueError: invalid literal for int() with base 10: b'SYM64'
```

That is not a `CLEError`, so a caller walking a directory of libraries cannot tell "not a valid archive" from a bug in cle, and one such library takes the whole load down. A malformed archive of any other kind escapes the same way, as `arpy.ArchiveFormatError`.

### Root cause

`StaticArchive.__init__` hands the stream straight to arpy:

```python
ar = arpy.Archive(fileobj=self._binary_stream)
ar.read_all_headers()
```

The first member of an ar archive is its symbol table, named `/` for the 32-bit index and `/SYM64/` for the 64-bit one that GNU ar writes when the offsets need 64 bits — which is how this mips64 library is written. arpy knows only the first spelling, so it classifies `/SYM64/` as a member whose real name is an offset into the long filename table and raises `ValueError` parsing `SYM64` as that offset. The classification belongs in arpy, but the pinned `arpy==1.1.1` and the current release both get it wrong.

### Fix

arpy discards the symbol table for either spelling, so nothing of value was being read from it. `_skip_sym64_symbol_table` advances `ar.next_header_offset` past the first member when its header really names `/SYM64/`, carries the magic, and declares a size that lies inside the file; anything else leaves the offset alone and lets arpy report the archive as malformed. The constructor wraps arpy's parse failures in `CLEInvalidBinaryError`, chaining the original as the cause.

```text
Loader(sym64_archive.a): loaded StaticArchive arch=MIPS64 endness=Iend_BE members=1
  first=['x11_xcb.o'] 'XGetXCBConnection' in member 0 symbols: True
Loader(libbadmagic.a): RAISED cle.errors.CLEInvalidBinaryError: Malformed static archive libbadmagic.a
Loader(libbadsize.a):  RAISED cle.errors.CLEInvalidBinaryError: Malformed static archive libbadsize.a
```

The 64-bit symbol table's contents are deliberately not parsed.

### Testing

`tests/test_static_archive.py::TestStaticArchive::test_sym64_symbol_table` loads the real mips64 library and asserts `children == ["x11_xcb.o"]`; `::test_symbol_table` pins the ordinary `/`-indexed GNU archive still resolving its long member names; `::test_bad_header_magic` and `::test_sym64_size_past_end` pin the two malformed shapes as `CLEInvalidBinaryError`, the second confirming the skip is not taken on a size that lies outside the file. The fixture is on `angr/binaries` master, added by that repository's PR 176, which merged on 2026-08-12.

Validation: https://github.com/angr/cle/pull/736#issuecomment-5234761652

session: sharpen
