### PR TITLE
Check out a referenced angr/binaries pull request on macOS and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,33 @@ jobs:
       - uses: actions/checkout@v6
         with:
           path: cle
+      - name: Resolve the angr/binaries ref
+        id: binaries-ref
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ref=master
+          number=$(printf '%s' "$PR_BODY" |
+            grep -Eo '(angr/binaries#|github\.com/angr/binaries/pull/)[0-9]+' |
+            head -n 1 |
+            grep -Eo '[0-9]+$') || true
+          if [ -n "$number" ]; then
+            state=$(gh api "repos/angr/binaries/pulls/$number" --jq .state) || state=unavailable
+            if [ "$state" = open ]; then
+              ref="refs/pull/$number/head"
+            else
+              echo "angr/binaries#$number is $state, so it is not used"
+            fi
+          fi
+          echo "Checking out angr/binaries at $ref"
+          echo "ref=$ref" >>"$GITHUB_OUTPUT"
       - uses: actions/checkout@v6
         with:
           repository: angr/binaries
           path: binaries
+          ref: ${{ steps.binaries-ref.outputs.ref }}
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

The `ci` jobs cle inherits check `angr/binaries` out at the pull request the
description names. `Test macos-15` and `Test windows-2022`, which this workflow
defines itself, check it out with no `ref:`, so they get master. A cle change
whose regression loads a new fixture therefore passes every inherited job and
fails those two until the fixture lands.

Both jobs now read the reference out of the body the way `resolve_refs.py` does:
`angr/binaries#<number>` or a pull request URL, first one found, and its head
only while that pull request is still open. A push, or a body naming no binaries
pull request, takes master. The body reaches the step in an environment variable
and only the digits extracted from it reach the ref, so nothing in it is
interpreted.

This description names angr/binaries#184, the fixture angr/cle#764 needs, so the
run on it exercises the path.

Validation: https://github.com/angr/cle/pull/738#issuecomment-5258509714
