### PR TITLE
ELF: Stop unloaded sections from claiming a relocatable object's addresses

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1442,6 +1442,7 @@ class ELF(MetaELF):
 
         for sec_readelf in self._reader.iter_sections():
             remap_offset = 0
+            occupies_memory = True
             if self.is_relocatable and sec_readelf.header["sh_flags"] & 2:  # alloc flag
                 # Relocatable objects' section addresses are meaningless (they are meant to be relocated anyway)
                 # We thus have to map them manually to valid virtual addresses to emulate a linker's behaviour.
@@ -1451,10 +1452,14 @@ class ELF(MetaELF):
                     new_addr = (new_addr + (align - 1)) // align * align
                 remap_offset = new_addr - sh_addr
 
-                if sec_readelf.header["sh_type"] not in _NON_ALLOCATED_SECTION_NAMES:
+                if sec_readelf.header["sh_type"] in _NON_ALLOCATED_SECTION_NAMES:
+                    # No space is reserved for these and no backer is added below, so the address just
+                    # computed belongs to whichever section comes next.
+                    occupies_memory = False
+                else:
                     new_addr += sec_readelf.header["sh_size"]
 
-            section = ELFSection(sec_readelf, remap_offset=remap_offset)
+            section = ELFSection(sec_readelf, remap_offset=remap_offset, occupies_memory=occupies_memory)
             sec_list.append((sec_readelf, section))
 
             # Register sections first, process later - this is required by relocatable objects

--- a/cle/backends/elf/regions.py
+++ b/cle/backends/elf/regions.py
@@ -46,7 +46,7 @@ class ELFSection(Section):
     SHF_STRINGS = 0x20
     SHT_NULL = "SHT_NULL"
 
-    def __init__(self, readelf_sec, remap_offset=0):
+    def __init__(self, readelf_sec, remap_offset=0, occupies_memory=True):
         super().__init__(
             maybedecode(readelf_sec.name),
             readelf_sec.header.sh_offset,
@@ -61,6 +61,7 @@ class ELFSection(Section):
         self.info = readelf_sec.header.sh_info
         self.align = readelf_sec.header.sh_addralign
         self.remap_offset = remap_offset
+        self._occupies_memory = occupies_memory
 
     @property
     def is_readable(self):
@@ -76,7 +77,7 @@ class ELFSection(Section):
 
     @property
     def occupies_memory(self):
-        return self.flags & self.SHF_ALLOC != 0 and self.memsize > 0
+        return self._occupies_memory and self.flags & self.SHF_ALLOC != 0 and self.memsize > 0
 
     @property
     def is_executable(self):

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -5,12 +5,17 @@ import unittest
 
 import cle
 from cle.address_translator import AT
-from cle.backends import Section, Segment
+from cle.backends import ELF, Section, Segment
 
 TESTS_BASE = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     os.path.join("..", "..", "binaries", "tests"),
 )
+
+
+def name_of(section: Section | None) -> str | None:
+    """The name of a section an address lookup returned, or None when it found nothing."""
+    return None if section is None else section.name
 
 
 groundtruth = {
@@ -173,6 +178,49 @@ class TestRunSections(unittest.TestCase):
     def test_segments(self):
         for (arch, filename), data in groundtruth.items():
             self._run_segments(arch, filename, data["segments"])
+
+
+class TestRelocatableSections(unittest.TestCase):
+    """
+    A relocatable object carries no addresses of its own, so CLE assigns them. The assignment has to
+    agree with what CLE actually maps.
+    """
+
+    BINARY = os.path.join(TESTS_BASE, "x86_64", "switch_default_abort.o")
+
+    def _load(self):
+        ld = cle.Loader(self.BINARY, auto_load_libs=False)
+        main = ld.main_object
+        assert isinstance(main, ELF)
+        self.assertTrue(main.is_relocatable)
+        return ld, main
+
+    def test_every_mapped_address_resolves_to_its_section(self):
+        ld, main = self._load()
+
+        mapped = sorted((s for s in main.sections if s.occupies_memory), key=lambda s: s.vaddr)
+        for lower, upper in zip(mapped, mapped[1:]):
+            self.assertLessEqual(
+                lower.vaddr + lower.memsize,
+                upper.vaddr,
+                f"{lower.name} overlaps {upper.name}",
+            )
+
+        # The lookup bisects on the section end addresses, so one overlap loses whole sections.
+        for section in mapped:
+            for addr in range(section.vaddr, section.vaddr + section.memsize):
+                self.assertEqual(name_of(main.sections.find_region_containing(addr)), section.name)
+                self.assertEqual(name_of(ld.find_section_containing(addr)), section.name)
+
+    def test_unloaded_section_claims_no_address(self):
+        _, main = self._load()
+
+        # No space is reserved for a note section and none of its bytes are loaded, so the address it
+        # would take belongs to the section that follows it.
+        note = main.sections_map[".note.gnu.property"]
+        self.assertEqual(note.type, "SHT_NOTE")
+        self.assertFalse(note.occupies_memory)
+        self.assertEqual(main.sections_map[".text"].vaddr, main.mapped_base)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

In a relocatable object, a section that cle deliberately does not map still takes an address from the layout, so it sits on top of the section that follows. On `tests/x86_64/switch_default_abort.o` the `SHF_ALLOC` `.note.gnu.property` lands at the address `.eh_frame` starts at, and `find_section_containing` then answers `None` over the whole of `.eh_frame`:

```text
  .eh_frame              +0x90     size=0x40     occ=True
  .note.gnu.property     +0x90     size=0x20     occ=True
--- overlaps among sections reported as occupying memory ---
  .note.gnu.property(+0x90,0x20) overlaps .eh_frame(+0x90)
  +0x80    loader=.rodata
  +0xc0    loader=None
```

Whatever the shadowed section is, consumers that gate on the containing section lose it: `CFGFast` discards blocks whose section is not executable, and `JumpTableResolver` rejects a table that falls outside a mapped section.

### Root cause

`ELF._load_sections` lays a relocatable object's allocated sections out itself, because their `sh_addr` values are meaningless. A section whose type is in `_NON_ALLOCATED_SECTION_NAMES` is given the running address but reserves no space and gets no backer:

```python
if sec_readelf.header["sh_type"] not in _NON_ALLOCATED_SECTION_NAMES:
    new_addr += sec_readelf.header["sh_size"]
```

`ELFSection.occupies_memory` then had no way to know that, being only `self.flags & self.SHF_ALLOC != 0 and self.memsize > 0`, and this note section is `SHF_ALLOC` with `sh_size` `0x20`. `Regions` documents that its members do not overlap and bisects on their end addresses, so one such section makes the lookup return `None` — or a stale neighbour, depending on what was looked up before — over the range it covers.

### Fix

`_load_sections` carries an `occupies_memory` flag, sets it false for exactly the types it already refuses to reserve space for, and passes it to `ELFSection`, whose property ANDs it in. That is what the constant's own comment, *"Sections that do not occupy memory at runtime"*, already claims about them. No address, byte, relocation or symbol assignment moves — the sections keep the addresses they were given and stop claiming to occupy memory there:

```text
  .note.gnu.property     +0x90     size=0x20     occ=False
--- overlaps among sections reported as occupying memory ---
  none
  +0xc0    loader=.eh_frame
```

### Testing

`TestRelocatableSections.test_every_mapped_address_resolves_to_its_section` walks every section that reports `occupies_memory` and asserts `self.assertEqual(name_of(ld.find_section_containing(addr)), section.name)` at each of its addresses; `test_unloaded_section_claims_no_address` pins that the note section reports no memory. Both fail on the merge base and pass on this head, on `tests/x86_64/switch_default_abort.o`, which is already on `angr/binaries` master.

Validation: https://github.com/angr/cle/pull/739#issuecomment-5276743793

session: sharpen
