### PR TITLE
ELF: Apply the header fields a p-code opinion constrains

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1634,6 +1634,36 @@ class ELF(MetaELF):
         return elf_opinions
 
     @staticmethod
+    def _pcode_secondary_matches(secondary, e_flags):
+        """
+        Test the e_flags constraint an ELF opinion states as its secondary attribute.
+
+        Ghidra writes it either as a number to compare against the whole field, or as a
+        "0b" pattern whose dots are the bits the opinion leaves free. A secondary naming
+        a compiler, such as golang or swift, constrains something the ELF header does not
+        record, so the opinion carrying it never applies here.
+        """
+        text = secondary.strip()
+        if text.startswith("0b"):
+            value = 0
+            mask = 0
+            for bit in text[2:]:
+                if bit.isspace():
+                    continue
+                if bit not in "01.":
+                    return False
+                value <<= 1
+                mask <<= 1
+                if bit != ".":
+                    mask |= 1
+                    value |= int(bit)
+            return (e_flags & mask) == value
+        try:
+            return int(text, 0) == e_flags
+        except ValueError:
+            return False
+
+    @staticmethod
     def _get_compatible_pcode_languages(reader):
         """
         Find compatible pypcode languages for this ELF file.
@@ -1653,14 +1683,8 @@ class ELF(MetaELF):
                 continue
             if e_machine not in {int(p) for p in o["primary"].split(",")}:
                 continue
-            if "secondary" in o:
-                try:
-                    value = int(o["secondary"])
-                    if value != reader.header.e_type:
-                        continue
-                except ValueError:
-                    # FIXME: Mask parsing (spaces and DC 0b .... ..1. ..0.)
-                    pass
+            if "secondary" in o and not ELF._pcode_secondary_matches(o["secondary"], reader.header.e_flags):
+                continue
             opinions.append(o)
 
         log.info("Available opinions: %s", opinions)
@@ -1668,6 +1692,8 @@ class ELF(MetaELF):
         languages = []
         for arch in pypcode.Arch.enumerate():
             for lang in arch.languages:
+                if lang.ldef.attrib["endian"] != endian:
+                    continue
                 for o in opinions:
                     if (reader.elfclass == 32 and int(lang.size) > 32) or (
                         reader.elfclass == 64 and int(lang.size) <= 32

--- a/tests/test_arch_detect.py
+++ b/tests/test_arch_detect.py
@@ -12,6 +12,7 @@ except ImportError:
     pypcode = None
 
 import cle
+from cle.backends.elf.elf import ELF
 
 test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../binaries/tests"))
 
@@ -28,6 +29,33 @@ class TestArchPcodeDetect(unittest.TestCase):
         arch = ld.main_object.arch
         assert isinstance(arch, archinfo.ArchPcode)
         assert arch.name == "68000:BE:32:default"
+
+    def test_elf_nds32(self):
+        binpath = os.path.join(test_location, "nds32/crt0_nds32le.o")
+        ld = cle.Loader(binpath, auto_load_libs=False)
+        arch = ld.main_object.arch
+        assert isinstance(arch, archinfo.ArchPcode)
+        assert arch.name == "NDS32:LE:32:default"
+
+    def test_elf_hppa(self):
+        # The only ELF opinion for EM_PARISC applies to e_flags 528, which this file has.
+        binpath = os.path.join(test_location, "hppa/test-instr_hppa")
+        ld = cle.Loader(binpath, auto_load_libs=False)
+        arch = ld.main_object.arch
+        assert isinstance(arch, archinfo.ArchPcode)
+        assert arch.name == "pa-risc:BE:32:default"
+
+    def test_opinion_secondary_forms(self):
+        # The three forms the shipped opinions write e_flags in: decimal for PA-RISC,
+        # hexadecimal for MSP430X, and a bit pattern with free bits for LoongArch lp64d.
+        matches = ELF._pcode_secondary_matches
+        assert matches("528", 0x210)
+        assert not matches("528", 0x214)
+        assert matches("0x2d", 0x2D)
+        assert not matches("0x2d", 0)
+        assert matches("0b .... .... .... .... .... .... .... .011", 0x43)
+        assert not matches("0b .... .... .... .... .... .... .... .011", 0x42)
+        assert not matches("golang", 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Two things go wrong when an architecture is reached through Ghidra's ELF opinions rather than archinfo. `tests/hppa/test-instr_hppa` does not load at all — no opinion survives the filter, so nothing offers a p-code language and the loader falls through to `arch_from_id`:

```text
  archinfo.arch.ArchNotFound: Can't find architecture info for architecture em_parisc
  with 32 bits and Iend_BE endness
```

And a little-endian object is read big-endian. `tests/nds32/crt0_nds32le.o` loads as

```text
  arch.name: NDS32:BE:32:default
  memory_endness: Iend_BE
```

so every word the backend reads out of it — relocation targets, section contents, anything a consumer disassembles — is byte-swapped.

### Root cause

`ELF._get_compatible_pcode_languages` filtered the opinions with

```python
if "secondary" in o:
    try:
        value = int(o["secondary"])
        if value != reader.header.e_type:
            continue
    except ValueError:
        # FIXME: Mask parsing (spaces and DC 0b .... ..1. ..0.)
        pass
```

The opinions state their secondary attribute as `e_flags`, not `e_type`. The one EM_PARISC opinion is keyed to 528, which this file's `e_flags` carries and its `e_type` does not, so the opinion was dropped. A hexadecimal or `0b` bit-pattern secondary raised `ValueError` and was kept regardless of what it said. Separately, the opinions usually omit `endian`, and nothing else held the chosen language to the byte order the file declares, so the big-endian NDS32 language matched first.

### Fix

`ELF._pcode_secondary_matches(secondary, e_flags)` parses both forms Ghidra writes — an integer through `int(text, 0)`, and a `0b` pattern whose `.` positions are free bits, as a value/mask pair — and returns False for a secondary naming something the ELF header does not record, such as a `golang` compiler tag. The caller compares it against `reader.header.e_flags` and skips a non-matching opinion instead of keeping it, and the language loop skips any language whose `ldef.attrib["endian"]` disagrees with the file. Both constraints now come from the ELF header:

```text
  matches('528'                                        , 0x210) = True
  matches('528'                                        , 0x214) = False
  matches('0b .... .... .... .... .... .... .... .011' , 0x43) = True
  matches('golang'                                     , 0x0) = False
```

hppa then loads as `pa-risc:BE:32:default` and the NDS32 object as `NDS32:LE:32:default`. Where several languages stay genuinely compatible, as for RISC-V or 68000, they are all still returned.

### Testing

`test_elf_hppa`, `test_elf_nds32` and `test_opinion_secondary_forms` in `tests/test_arch_detect.py`; the load-bearing assertion is `assert arch.name == "NDS32:LE:32:default"`. All three fail on the merge base — the hppa case with the `ArchNotFound` above — and pass on this head.

sync: angr/binaries#177

Validation: https://github.com/angr/cle/pull/740#issuecomment-5278889410

session: sharpen
