### PR TITLE
Mach-O: Register the LC_FUNCTION_STARTS entries as function hints

### DIFF
--- a/cle/backends/backend.py
+++ b/cle/backends/backend.py
@@ -34,6 +34,7 @@ class FunctionHintSource:
     EH_FRAME = 0
     EXTERNAL_EH_FRAME = 1
     EXPORT_TABLE = 2
+    FUNCTION_STARTS = 3
 
 
 class FunctionHint:

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -14,7 +14,7 @@ from os import SEEK_CUR, SEEK_SET
 import archinfo
 from sortedcontainers import SortedKeyList
 
-from cle.backends.backend import AT, Backend, register_backend
+from cle.backends.backend import AT, Backend, FunctionHint, FunctionHintSource, register_backend
 from cle.backends.gopclntab import register_gopclntab_symbols
 from cle.backends.macho.binding import BindingHelper, MachOPointerRelocation, MachOSymbolRelocation, read_uleb
 from cle.backends.regions import Regions
@@ -248,6 +248,7 @@ class MachO(Backend):
         self._parse_symbols(binary_file)
         log.info("Parsing module init/term function pointers")
         self._parse_mod_funcs()
+        self._register_function_start_hints()
 
         if not skip_relocations:
             if self._dyld_chained_fixups_offset:
@@ -804,6 +805,19 @@ class MachO(Backend):
             log.debug("Function start @ %#x (%#x)", uleb[0], address)
             i += uleb[1]
         log.debug("Done parsing function starts")
+
+    def _register_function_start_hints(self):
+        """
+        Turn the LC_FUNCTION_STARTS entries into function hints.
+
+        ld64 records the address of every atom it placed in an executable section, so the table names
+        every function of the image, including ones no symbol survives for. It also names the data
+        atoms a producer puts among them, which is why these are hints and not symbols.
+        """
+        if not self.lc_function_starts:
+            return
+        for address in self.lc_function_starts:
+            self.function_hints.append(FunctionHint(address, 0, FunctionHintSource.FUNCTION_STARTS))
 
     def _load_lc_main(self, f, offset):
         if self.entryoff is not None or self.unixthread_pc is not None:

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -10,6 +10,7 @@ import pytest
 
 import cle
 from cle import MachO
+from cle.backends.backend import FunctionHintSource
 from cle.backends.macho.macho_enums import LoadCommands, MachoFiletype, SectionAttributes, SectionType
 from cle.backends.macho.section import MachOSection
 
@@ -274,6 +275,20 @@ def test_instruction_sections():
     assert macho.sections_map["__TEXT,__cstring"].attributes == 0
 
 
+def test_function_starts_hints():
+    machofile = os.path.join(TEST_BASE, "tests", "aarch64", "dyld_ios15.macho")
+    ld = cle.Loader(machofile, auto_load_libs=False)
+    macho = ld.main_object
+    assert isinstance(macho, cle.MachO)
+
+    hints = [h for h in macho.function_hints if h.source == FunctionHintSource.FUNCTION_STARTS]
+    assert [h.addr for h in hints] == macho.lc_function_starts
+    assert len(hints) == 36
+
+    text = macho.sections_map["__TEXT,__text"]
+    assert all(text.vaddr <= h.addr < text.vaddr + text.memsize for h in hints)
+
+
 def test_find_symbol():
     machofile = os.path.join(TEST_BASE, "tests", "x86_64", "fauxware.macho")
     ld = cle.Loader(machofile, auto_load_libs=False)
@@ -424,6 +439,7 @@ if __name__ == "__main__":
     test_find_symbol()
     test_zerofill_sections()
     test_instruction_sections()
+    test_function_starts_hints()
     test_zero_vmsize_segment()
     test_filesize_larger_than_vmsize()
 


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A Mach-O object hands its consumer no function hints at all, while an ELF one gets a hint for every FDE in `.eh_frame`. On `tests/aarch64/dyld_ios15.macho` the backend decodes the whole `LC_FUNCTION_STARTS` table and then reports nothing:

```text
lc_function_starts count: 36
function_hints count: 0
hints with source FUNCTION_STARTS: 0
```

On a stripped image that table is the only record of where the functions begin, so a consumer seeding on `Backend.function_hints` starts from nothing on every Mach-O.

### Root cause

`MachO._load_lc_function_starts` decodes the ULEB deltas into `self.lc_function_starts` and nothing reads that list afterwards. `Backend.__init__` sets `self.function_hints: list[FunctionHint] = []` and the Mach-O constructor never appends to it, so `Backend.__getstate__` and every consumer see the empty list. `FunctionHintSource` also had no member such a hint could carry:

```python
class FunctionHintSource:
    EH_FRAME = 0
    EXTERNAL_EH_FRAME = 1
    EXPORT_TABLE = 2
```

### Fix

`_register_function_start_hints` turns each entry into a `FunctionHint` under a new `FunctionHintSource.FUNCTION_STARTS`, called from the constructor beside `_parse_mod_funcs`. It is a source of its own rather than an export or an unwind record because ld64 records every atom it placed in an executable section, data atoms included, so a consumer has to be able to tell this table from one that names only functions. No size is recorded — the distance to the next entry is not a function length — so each hint is built as `FunctionHint(address, 0, FunctionHintSource.FUNCTION_STARTS)`.

All 36 entries then arrive as hints, and every one lands inside `__TEXT,__text` at `0x100006ebc`, size `0x998`:

```text
FunctionHintSource.FUNCTION_STARTS: 3
function_hints count: 36
hint addrs == lc_function_starts: True
all hints inside __text: True
```

### Testing

`test_function_starts_hints` asserts `[h.addr for h in hints] == macho.lc_function_starts` on `tests/aarch64/dyld_ios15.macho`, that there are 36 of them, and that each falls inside the bounds of `__TEXT,__text`. It fails on the merge base, where the list is empty.

Land this before angr/angr#6861, which decides which entries to use and reads the hint source added here. Landing this half on its own is not neutral either: angr master's `_load_func_addr_and_names_from_hints` admits every hint source except `EH_FRAME`, so the new `FUNCTION_STARTS` entries become definite function starts the day this merges, with none of the validation the angr half adds — the defect that pull request's Problem section measures on `tests/armhf/FileProtection-05.armv7.macho`. Land the two together, or this one first and the angr one straight after.

Fixes #750. Validation: https://github.com/angr/cle/pull/754#issuecomment-5312117506

sync: angr/angr#6861

session: sharpen