### PR TITLE
PE: Resolve the machine type of a ReadyToRun image built for another system

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -44,6 +44,23 @@ EFI_SUBSYSTEMS = frozenset(
     )
 )
 
+# .NET's ReadyToRun compiler exclusive-ors the COFF machine type with a constant naming the
+# target operating system when an image is published for something other than Windows, so that
+# the Windows loader refuses a file that is not for it. These are the values of
+# IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE in the .NET runtime's src/coreclr/inc/pedecoder.h.
+READYTORUN_OS_OVERRIDES = {
+    "apple": 0x4644,
+    "freebsd": 0xADC4,
+    "linux": 0x7B79,
+    "netbsd": 0x1993,
+    "openbsd": 0xADC5,
+    "solaris": 0x1992,
+}
+
+IMAGE_COR20_HEADER_SIZE = 72
+IMAGE_COR20_MANAGED_NATIVE_HEADER_OFFSET = 64
+READYTORUN_SIGNATURE = b"RTR\0"
+
 log = logging.getLogger(name=__name__)
 
 
@@ -59,6 +76,62 @@ def image_os(optional_header: Any) -> str:
     """
 
     return "uefi" if optional_header.Subsystem in EFI_SUBSYSTEMS else "windows"
+
+
+def machine_type_name(pe: pefile.PE) -> str:
+    """
+    Name the COFF machine type of a PE the way archinfo expects it, undoing the operating system
+    override a .NET ReadyToRun image carries when it was published for a target other than
+    Windows.
+    """
+    assert pe.FILE_HEADER is not None
+    machine = pe.FILE_HEADER.Machine
+    if machine not in pefile.MACHINE_TYPE:
+        native = _readytorun_machine_type(pe)
+        if native is not None:
+            machine, target_os = native
+            log.info(
+                "ReadyToRun image published for %s: machine type %#x is %s overridden for that target",
+                target_os,
+                pe.FILE_HEADER.Machine,
+                pefile.MACHINE_TYPE.get(machine),
+            )
+    name = pefile.MACHINE_TYPE.get(machine)
+    return name if isinstance(name, str) else hex(machine)
+
+
+def _readytorun_machine_type(pe: pefile.PE) -> tuple[int, str] | None:
+    """
+    Return the real machine type and the target operating system of a ReadyToRun image whose
+    COFF machine type carries an operating system override, or None for any other image.
+
+    A ReadyToRun image is a managed assembly whose CLR header points at a native header
+    beginning with the ReadyToRun signature.
+    """
+    assert pe.OPTIONAL_HEADER is not None
+    # NumberOfRvaAndSizes may be smaller than the sixteen directories the format defines, so the
+    # CLR header's directory is not always present in the array pefile parsed.
+    index = pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR"]
+    if index >= len(pe.OPTIONAL_HEADER.DATA_DIRECTORY):
+        return None
+    com_dd = pe.OPTIONAL_HEADER.DATA_DIRECTORY[index]
+    if not com_dd.VirtualAddress or com_dd.Size < IMAGE_COR20_HEADER_SIZE:
+        return None
+    try:
+        cor20 = pe.get_data(com_dd.VirtualAddress, IMAGE_COR20_HEADER_SIZE)
+        native_header_rva = struct.unpack_from("<I", cor20, IMAGE_COR20_MANAGED_NATIVE_HEADER_OFFSET)[0]
+        if not native_header_rva:
+            return None
+        if pe.get_data(native_header_rva, len(READYTORUN_SIGNATURE)) != READYTORUN_SIGNATURE:
+            return None
+    except (pefile.PEFormatError, struct.error):
+        return None
+
+    for target_os, override in READYTORUN_OS_OVERRIDES.items():
+        machine = pe.FILE_HEADER.Machine ^ override
+        if machine and machine in pefile.MACHINE_TYPE:
+            return machine, target_os
+    return None
 
 
 class PE(Backend):
@@ -124,8 +197,7 @@ class PE(Backend):
         self.os = image_os(self._pe.OPTIONAL_HEADER)
 
         if self._arch is None:
-            machine_type = self._pe.FILE_HEADER.Machine
-            self.set_arch(archinfo.arch_from_id(pefile.MACHINE_TYPE.get(machine_type, hex(machine_type))))
+            self.set_arch(archinfo.arch_from_id(machine_type_name(self._pe)))
 
         self.mapped_base = self.linked_base = self._pe.OPTIONAL_HEADER.ImageBase
 
@@ -230,7 +302,7 @@ class PE(Backend):
 
         assert pe.FILE_HEADER is not None
 
-        arch = archinfo.arch_from_id(pefile.MACHINE_TYPE[pe.FILE_HEADER.Machine])  # pylint:disable=no-member
+        arch = archinfo.arch_from_id(machine_type_name(pe))
         return arch == obj.arch
 
     #

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import struct
 import sys
 import tempfile
 import unittest
@@ -324,6 +325,20 @@ class TestPEBackend(unittest.TestCase):
         assert isinstance(ld.main_object, cle.PE)
         assert ld.main_object.arch.name == "RISCV64"
         assert ld.main_object.os == "uefi"
+
+    def test_readytorun_machine_os_override(self):
+        dll = os.path.join(TEST_BASE, "tests", "x86_64", "readytorun_linux_x64.dll")
+        with open(dll, "rb") as f:
+            header = f.read(0x200)
+        machine = struct.unpack_from("<H", header, struct.unpack_from("<I", header, 0x3C)[0] + 4)[0]
+        # published for linux-x64, so the machine type is AMD64 exclusive-ored with the .NET
+        # override constant for Linux
+        assert machine == 0x8664 ^ 0x7B79
+
+        ld = cle.Loader(dll, auto_load_libs=False)
+        assert isinstance(ld.main_object, cle.PE)
+        assert ld.main_object.arch.name == "AMD64"
+        assert ld.main_object.is_dotnet
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A .NET ReadyToRun assembly published for a target other than Windows cannot be
loaded at all. On `binaries/tests/x86_64/readytorun_linux_x64.dll`:

```
EXCEPTION: archinfo.arch.ArchNotFound: Can't find architecture info for architecture 0xfd1d with '' bits and unsure endness
```

The failure is at architecture selection, so nothing about the image is
recoverable: no sections, no symbols, no entry point.

### Root cause

The backend takes the COFF machine type at face value:

```python
machine_type = self._pe.FILE_HEADER.Machine
self.set_arch(archinfo.arch_from_id(pefile.MACHINE_TYPE.get(machine_type, hex(machine_type))))
```

The ReadyToRun compiler exclusive-ors that field with a constant naming the
target operating system, so that the Windows loader refuses a file that is not
for it. `0xfd1d` is `IMAGE_FILE_MACHINE_AMD64 ^ 0x7b79`, and `0x7b79` is the
value the .NET runtime gives `IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE` for Linux in
`src/coreclr/inc/pedecoder.h`. `MACHINE_TYPE.get` misses, `hex(0xfd1d)` is not an
architecture name, and `arch_from_id` raises.

### Fix

`machine_type_name` undoes the override before naming the architecture. It tries
the six documented constants only when the raw machine type is unknown *and* the
image really is ReadyToRun -- a managed assembly whose CLR header points at a
native header beginning with `RTR\0` -- so a corrupt `Machine` field elsewhere
cannot be rescued by an exclusive-or that happens to land on a valid value. `os`
stays `"windows"`, because the file is still a PE.

```
loaded readytorun_linux_x64.dll: arch=AMD64 os=windows entry=0x180000000
```

### Testing

`tests/test_pe.py::TestPEBackend::test_readytorun_machine_os_override` reads the
`Machine` field out of the file, asserts it is `0x8664 ^ 0x7b79`, then loads the
fixture and asserts `arch.name == "AMD64"` and `is_dotnet`; it raises
`ArchNotFound` on the merge base.

#805 changes how a machine-type name becomes an `archinfo.Arch`, at the same two
call sites this branch rewrites, so the two conflict in `cle/backends/pe/pe.py`
and whichever merges second needs a rebase. The resolution is
`arch_from_machine_type(machine_type_name(...))` at both sites, with both helper
functions kept. #805 can land first: it asserts the mapping rather than loading
a PE, so it needs no fixture, while this branch needs the one named in the
`sync:` line below.

Fixes #751. Validation: https://github.com/angr/cle/pull/757#issuecomment-5313199933

sync: angr/binaries#183

session: sharpen
