### PR TITLE
ELFCore: Keep the permissions of the mappings it turns into blobs

### DIFF
--- a/cle/backends/blob.py
+++ b/cle/backends/blob.py
@@ -5,7 +5,7 @@ import logging
 from cle.errors import CLEError
 
 from .backend import Backend, register_backend
-from .region import Segment
+from .region import PermissionedSegment, Segment
 
 log = logging.getLogger(name=__name__)
 
@@ -19,12 +19,16 @@ class Blob(Backend):
 
     is_default = True  # Tell CLE to automatically consider using the Blob backend
 
-    def __init__(self, *args, offset=None, segments=None, **kwargs):
+    def __init__(self, *args, offset=None, segments=None, permissions=None, **kwargs):
         """
         :param arch:   (required) an :class:`archinfo.Arch` for the binary blob.
         :param offset: Skip this many bytes from the beginning of the file.
         :param segments:      List of tuples describing how to map data into memory. Tuples
                               are of ``(file_offset, mem_addr, size)``.
+        :param permissions:   Optional ``(readable, writable, executable)`` triple describing the memory this
+                              blob was taken from. A raw image records no permissions, so by default every
+                              segment reports itself readable, writable and executable; a caller extracting a
+                              blob from something that does record them - a core dump, say - passes them here.
 
         You can't specify both ``offset`` and ``segments``.
         """
@@ -32,7 +36,9 @@ class Blob(Backend):
             offset = kwargs.pop("custom_offset")
             log.critical("Deprecation warning: the custom_offset parameter has been renamed to offset")
         super().__init__(*args, **kwargs)
-        self.set_load_args(offset=offset, segments=segments)
+        self.set_load_args(offset=offset, segments=segments, permissions=permissions)
+
+        self._permissions = permissions
 
         if self._arch is None:
             raise CLEError("Must specify arch when loading blob!")
@@ -89,7 +95,10 @@ class Blob(Backend):
         string = self._binary_stream.read(size)
         if string:
             self.memory.add_backer(mem_addr - self.linked_base, string)
-        seg = Segment(file_offset, mem_addr, size, size)
+        if self._permissions is None:
+            seg = Segment(file_offset, mem_addr, size, size)
+        else:
+            seg = PermissionedSegment(file_offset, mem_addr, size, size, *self._permissions)
         self.segments.append(seg)
         self._max_addr = max(len(string) + mem_addr - 1, self._max_addr)
         self._min_addr = min(mem_addr, self._min_addr)

--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -10,7 +10,7 @@ import elftools
 from cle.address_translator import AT
 from cle.backends import register_backend
 from cle.backends.blob import Blob
-from cle.backends.region import Segment
+from cle.backends.region import PermissionedSegment
 from cle.errors import CLECompatibilityError, CLEError
 from cle.memory import Clemory
 
@@ -504,16 +504,20 @@ class ELFCore(ELF):
                 if base_addr <= seg.vaddr <= max_addr or seg.vaddr <= base_addr < seg.vaddr + seg.memsize:
                     remaining_segments.pop(i)
 
-                    # if there is data before the beginning of the child or after the end,
-                    # make new artificial segments for it
+                    # if there is data before the beginning of the child or after the end, make new
+                    # artificial segments for it. They are parts of the same mapping, so they have
+                    # its permissions.
+                    perms = (seg.is_readable, seg.is_writable, seg.is_executable)
                     if seg.vaddr < base_addr:
                         size = base_addr - seg.vaddr
-                        remaining_segments.insert(i, Segment(seg.offset, seg.vaddr, size, size))
+                        remaining_segments.insert(i, PermissionedSegment(seg.offset, seg.vaddr, size, size, *perms))
                         i += 1
                     if seg.max_addr > max_addr:
                         size = seg.max_addr - max_addr
                         offset = seg.memsize - size
-                        remaining_segments.insert(i, Segment(seg.offset + offset, seg.vaddr + offset, size, size))
+                        remaining_segments.insert(
+                            i, PermissionedSegment(seg.offset + offset, seg.vaddr + offset, size, size, *perms)
+                        )
                         i += 1
 
                     # ohhhh this is SUCH a confusing address space-conversation problem!
@@ -572,6 +576,7 @@ class ELFCore(ELF):
                 self.binary,
                 mem,
                 segments=[(seg.vaddr, seg.vaddr, seg.memsize)],
+                permissions=(seg.is_readable, seg.is_writable, seg.is_executable),
                 base_addr=seg.vaddr,
                 arch=self.arch,
                 entry_point=0,

--- a/cle/backends/region.py
+++ b/cle/backends/region.py
@@ -120,6 +120,35 @@ class Segment(Region):
     pass
 
 
+class PermissionedSegment(Segment):
+    """
+    A segment with static content whose permissions are stated rather than assumed.
+
+    :class:`Region` answers ``True`` to every permission query, because most segments are built by a
+    backend for a format that records no permissions at all. A backend that does know them - because
+    it read them out of a core dump, say - builds this instead, so that a caller asking whether the
+    range is executable gets the answer the file gives rather than the default.
+    """
+
+    def __init__(self, offset, vaddr, filesize, memsize, is_readable, is_writable, is_executable):
+        super().__init__(offset, vaddr, filesize, memsize)
+        self._is_readable = is_readable
+        self._is_writable = is_writable
+        self._is_executable = is_executable
+
+    @property
+    def is_readable(self):
+        return self._is_readable
+
+    @property
+    def is_writable(self):
+        return self._is_writable
+
+    @property
+    def is_executable(self):
+        return self._is_executable
+
+
 class EmptySegment(Segment):
     """
     A segment with no static content, and permissions

--- a/tests/test_elfcore.py
+++ b/tests/test_elfcore.py
@@ -49,3 +49,34 @@ def test_remote_file_mapper():
         auto_load_libs=True,
     )
     check_objects_loaded(ld)
+
+
+def test_blob_children_keep_the_mapping_permissions():
+    """A core states what each mapping was allowed to do, and the blobs cut out of it say the same."""
+    directory_for_binaries = get_binary_directory()
+    ld = cle.Loader(
+        get_coredump_file(),
+        main_opts={
+            "backend": "elfcore",
+            "remote_file_mapper": lambda x: x.replace("/tmp/foobar/does-not-exist", directory_for_binaries),
+        },
+        auto_load_libs=True,
+    )
+
+    core = ld.elfcore_object
+    assert core is not None
+    blobs = [obj for obj in ld.all_objects if isinstance(obj, cle.Blob)]
+    assert blobs, "the core's leftover mappings should have become blobs"
+
+    for blob in blobs:
+        for segment in blob.segments:
+            source = core.segments.find_region_containing(segment.vaddr)
+            assert source is not None
+            assert (segment.is_readable, segment.is_writable, segment.is_executable) == (
+                source.is_readable,
+                source.is_writable,
+                source.is_executable,
+            ), f"{segment} does not describe the mapping {source} it was cut from"
+
+    # the heap and the stack are in there, and they are not code
+    assert any(not segment.is_executable for blob in blobs for segment in blob.segments)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A core dump records what every mapping was allowed to do, and `ELFCore` reads it
correctly -- then loses it on the way out. On
`binaries/tests/x86_64/coredump/true-libc.so.6-ld-linux-x86-64.so.2.core`, the
five mappings that do not belong to a child object become blobs, and every one of
them claims to be executable:

```
               segment   blob   core
0x000055555575b220    rwx    rw-
0x00007ffff7dd92c0    rwx    rw-
0x00007ffff7ffe1c8    rwx    rw-
0x00007ffffffde000    rwx    rw-
0xffffffffff600000    rwx    r-x
```

Those four `rw-` mappings are the heap, the ld.so and libc data segments and the
stack. Anything that asks the loader which memory is code -- CFGFast's executable
map first of all -- is told all of it is.

### Root cause

`ELFCore` hands each mapping it could not match to a child object to `Blob`,
which builds a plain `Segment`, and `Segment` inherits `Region`'s defaults:

```python
    @property
    def is_executable(self) -> bool:
        # pylint: disable=no-self-use
        return True
```

That default is right for the format `Blob` was written for -- a raw image records
no permissions, so refusing to answer would be worse -- and wrong the moment the
caller does know them. The `p_flags` the core states are read, matched against
child objects, and then dropped at the one point where a `Segment` is constructed.

### Fix

`PermissionedSegment` states its three permissions instead of assuming them,
`Blob` takes an optional `permissions` triple describing the memory it came from,
and `ELFCore` passes each mapping's flags through -- including to the leading and
trailing offcuts it makes when a mapping only partly overlaps a child, which are
parts of the same mapping and get the same flags. A blob loaded from a raw image
is unchanged, because the triple defaults to `None` and the old behaviour with it.

```
               segment   blob   core
0x000055555575b220    rw-    rw-
0x00007ffff7dd92c0    rw-    rw-
0x00007ffff7ffe1c8    rw-    rw-
0x00007ffffffde000    rw-    rw-
0xffffffffff600000    r-x    r-x
```

### Testing

`tests/test_elfcore.py::test_blob_children_keep_the_mapping_permissions` compares
every blob segment of the core fixture against the program header it was cut
from, and asserts at least one is not executable; on the merge base the heap blob
reports `rwx` where the core says `p_flags 0x6`.

Fixes #743. angr/angr#6864 is the other half, where CFGFast's executable map
learns to read these permissions.

Validation: https://github.com/angr/cle/pull/758#issuecomment-5314952297

sync: angr/angr#6864

session: sharpen