### PR TITLE
Minidump: Describe a loaded module by the sections it actually has

### DIFF
--- a/cle/backends/minidump/__init__.py
+++ b/cle/backends/minidump/__init__.py
@@ -8,6 +8,7 @@ from minidump import minidumpfile
 from minidump.streams import SystemInfoStream
 
 from cle.backends.backend import Backend, register_backend
+from cle.backends.coff import IMAGE_SCN
 from cle.backends.region import Section, Segment
 from cle.errors import CLEError, CLEInvalidBinaryError
 
@@ -17,6 +18,38 @@ class MinidumpMissingStreamError(Exception):
         super().__init__()
         self.message = message
         self.stream = stream
+
+
+class DumpSection(Section):
+    """
+    One section of a module that was loaded in the dumped process.
+
+    A minidump has no section table of its own; it records memory ranges and the modules that were
+    mapped over them. The module's image is mapped headers and all, so the module states which of its
+    own bytes are code, and that is where these come from. A module whose headers the dump did not
+    capture is described by one section spanning it, permissive in all three.
+    """
+
+    def __init__(self, name, offset, vaddr, memsize, filesize, characteristics):
+        super().__init__(name, offset, vaddr, memsize)
+        self.filesize = filesize
+        self.characteristics = characteristics
+
+    @property
+    def is_readable(self):
+        return self.characteristics & IMAGE_SCN.MEM_READ != 0
+
+    @property
+    def is_writable(self):
+        return self.characteristics & IMAGE_SCN.MEM_WRITE != 0
+
+    @property
+    def is_executable(self):
+        return self.characteristics & IMAGE_SCN.MEM_EXECUTE != 0
+
+    @property
+    def only_contains_uninitialized_data(self):
+        return self.characteristics & IMAGE_SCN.CNT_UNINITIALIZED_DATA != 0
 
 
 class Minidump(Backend):
@@ -69,9 +102,9 @@ class Minidump(Backend):
                     break
             else:
                 raise CLEInvalidBinaryError("Missing segment for loaded module: " + module.name)
-            section = Section(module.name, segment.start_file_address, module.baseaddress, module.size)
-            self.sections.append(section)
-            self.sections_map[ntpath.basename(section.name)] = section
+            for section in self._module_sections(module):
+                self.sections.append(section)
+                self.sections_map[section.name] = section
 
         self._thread_data = {}
 
@@ -82,6 +115,57 @@ class Minidump(Backend):
             data = self._binary_stream.read(thread.ThreadContext.DataSize)  # pylint: disable=undefined-loop-variable
             self._binary_stream.seek(0)
             self._thread_data[tid] = (teb, data)
+
+    def _dumped_extent(self, vaddr: int, memsize: int) -> tuple[int, int]:
+        """Where ``vaddr`` sits in the dump file, and how much of ``memsize`` the dump holds."""
+        segment = self.segments.find_region_containing(vaddr)
+        if segment is None:
+            return 0, 0
+        return segment.offset + (vaddr - segment.vaddr), min(memsize, segment.vaddr + segment.memsize - vaddr)
+
+    def _module_sections(self, module):
+        """The sections of one loaded module, read out of the image the dump mapped."""
+        base = module.baseaddress
+        table = None
+        section_count = 0
+        try:
+            dos_header = self.memory.load(base, 0x40)
+            if dos_header[:2] == b"MZ":
+                (pe_offset,) = struct.unpack_from("<I", dos_header, 0x3C)
+                coff_header = self.memory.load(base + pe_offset, 0x18)
+                if coff_header[:4] == b"PE\0\0":
+                    (section_count,) = struct.unpack_from("<H", coff_header, 6)
+                    (optional_size,) = struct.unpack_from("<H", coff_header, 0x14)
+                    # the image format allows at most this many sections; a larger count is a sign the
+                    # bytes at the module base are not a PE header after all
+                    if 0 < section_count <= 96:
+                        table = self.memory.load(base + pe_offset + 0x18 + optional_size, 40 * section_count)
+        except (KeyError, struct.error):
+            table = None
+
+        module_name = ntpath.basename(module.name)
+        if table is None:
+            offset, filesize = self._dumped_extent(base, module.size)
+            characteristics = IMAGE_SCN.MEM_READ | IMAGE_SCN.MEM_WRITE | IMAGE_SCN.MEM_EXECUTE
+            return [DumpSection(module_name, offset, base, module.size, filesize, characteristics)]
+
+        sections = []
+        for index in range(section_count):
+            entry = 40 * index
+            raw_name, virtual_size, rva, raw_size = struct.unpack_from("<8sIII", table, entry)
+            (characteristics,) = struct.unpack_from("<I", table, entry + 36)
+            if rva >= module.size:
+                continue
+            # some linkers leave VirtualSize zero and mean SizeOfRawData
+            memsize = min(virtual_size or raw_size, module.size - rva)
+            if not memsize:
+                continue
+            name = raw_name.rstrip(b"\0").decode("ascii", errors="replace")
+            offset, filesize = self._dumped_extent(base + rva, memsize)
+            sections.append(
+                DumpSection(f"{module_name}:{name}", offset, base + rva, memsize, filesize, characteristics)
+            )
+        return sections
 
     def close(self):
         super().close()

--- a/cle/backends/minidump/__init__.py
+++ b/cle/backends/minidump/__init__.py
@@ -10,7 +10,7 @@ from minidump.streams import SystemInfoStream
 from cle.backends.backend import Backend, register_backend
 from cle.backends.coff import IMAGE_SCN
 from cle.backends.region import Section, Segment
-from cle.errors import CLEError, CLEInvalidBinaryError
+from cle.errors import CLEError
 
 
 class MinidumpMissingStreamError(Exception):
@@ -26,8 +26,10 @@ class DumpSection(Section):
 
     A minidump has no section table of its own; it records memory ranges and the modules that were
     mapped over them. The module's image is mapped headers and all, so the module states which of its
-    own bytes are code, and that is where these come from. A module whose headers the dump did not
-    capture is described by one section spanning it, permissive in all three.
+    own bytes are code, and that is where these come from. A module whose layout the dump does not
+    describe is covered by one section spanning it, permissive in all three. ``filesize`` says how far
+    the capture runs from the section's own base, so it is zero for a section whose base was not
+    captured even when the dump holds bytes further into it.
     """
 
     def __init__(self, name, offset, vaddr, memsize, filesize, characteristics):
@@ -49,7 +51,9 @@ class DumpSection(Section):
 
     @property
     def only_contains_uninitialized_data(self):
-        return self.characteristics & IMAGE_SCN.CNT_UNINITIALIZED_DATA != 0
+        # Either the image declares the section uninitialized, or the dump did not capture the section's own
+        # base, in which case no address in it resolves to a file offset.
+        return self.filesize == 0 or self.characteristics & IMAGE_SCN.CNT_UNINITIALIZED_DATA != 0
 
 
 class Minidump(Backend):
@@ -97,11 +101,9 @@ class Minidump(Backend):
             self.memory.add_backer(segment.start_virtual_address, data)
 
         for module in self._mdf.modules.modules:
-            for segment in segments:
-                if segment.start_virtual_address == module.baseaddress:
-                    break
-            else:
-                raise CLEInvalidBinaryError("Missing segment for loaded module: " + module.name)
+            # A dump captures only the memory ranges its writer selected, so a module's image may be present in
+            # full, in part, or not at all. A module with nothing captured still gets a section: its address range
+            # is what tells an analysis which module an address belongs to.
             for section in self._module_sections(module):
                 self.sections.append(section)
                 self.sections_map[section.name] = section
@@ -140,6 +142,10 @@ class Minidump(Backend):
                     # bytes at the module base are not a PE header after all
                     if 0 < section_count <= 96:
                         table = self.memory.load(base + pe_offset + 0x18 + optional_size, 40 * section_count)
+                        if len(table) < 40 * section_count:
+                            # Clemory.load stops at the end of the captured region, so a dump whose capture
+                            # ends inside the table tells us no more about the layout than one with no headers.
+                            table = None
         except (KeyError, struct.error):
             table = None
 
@@ -233,9 +239,14 @@ class Minidump(Backend):
         for register, position in fmt_registers.items():
             thread_registers[register] = members[position]
 
+        # The segment base lives in the thread's TEB rather than in its saved context, and a dump that captured
+        # only a few memory ranges usually does not include the TEB page. Leave the register out when it cannot be
+        # read, so that everything the context does record stays usable.
         if self.arch.name == "AMD64" or self.wow64:
-            gs_base = self.memory.unpack_word(teb + 0x30)
-            thread_registers["gs_const"] = gs_base
+            try:
+                thread_registers["gs_const"] = self.memory.unpack_word(teb + 0x30)
+            except KeyError:
+                pass
             if self.arch.name == "AMD64":
                 NUM_XMM_REGS = 16
                 xmms = struct.unpack_from("16s" * NUM_XMM_REGS, data, offset=0x1A0)
@@ -243,8 +254,10 @@ class Minidump(Backend):
                     f"xmm{i}": int.from_bytes(xmm, "little", signed=False) for i, xmm in enumerate(xmms)
                 }
         elif self.arch.name == "X86":
-            fs_base = self.memory.unpack_word(teb + 0x18)
-            thread_registers["fs"] = fs_base
+            try:
+                thread_registers["fs"] = self.memory.unpack_word(teb + 0x18)
+            except KeyError:
+                pass
 
         if self.wow64:
             register_translation = [
@@ -261,7 +274,11 @@ class Minidump(Backend):
                 ("fs", "gs_const"),  # ???
             ]
 
-            thread_registers = {ereg: thread_registers[rreg] & 0xFFFFFFFF for ereg, rreg in register_translation}
+            thread_registers = {
+                ereg: thread_registers[rreg] & 0xFFFFFFFF
+                for ereg, rreg in register_translation
+                if rreg in thread_registers
+            }
 
         return thread_registers
 

--- a/cle/backends/tls/minidump_tls.py
+++ b/cle/backends/tls/minidump_tls.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
 
+import logging
+
 import archinfo
 
 from cle.backends.tls.tls_object import ThreadManager
+
+log = logging.getLogger(__name__)
 
 
 class MinidumpThreadManager(ThreadManager):
     def __init__(self, loader, arch, **kwargs):  # pylint: disable=unused-argument
         self.loader = loader
         self.arch = arch
-        self.threads = [
-            MinidumpThread(loader, arch, loader.main_object.thread_registers(tid)) for tid in loader.main_object.threads
-        ]
+        self.threads = []
+        for tid in loader.main_object.threads:
+            try:
+                self.threads.append(MinidumpThread(loader, arch, loader.main_object.thread_registers(tid)))
+            except KeyError:
+                # Locating a thread's TLS array means reading its TEB, which a dump that captured only a few
+                # memory ranges usually leaves out. Such a thread has no reachable thread-local storage, but the
+                # rest of the dump still loads.
+                log.warning("Skipping thread %#x: the minidump did not capture its TEB", tid)
         self.modules = []  # ???
 
     def new_thread(self, insert=False):  # pylint: disable=no-self-use

--- a/tests/test_minidump.py
+++ b/tests/test_minidump.py
@@ -17,11 +17,19 @@ def test_minidump():
     assert isinstance(ld.main_object, cle.Minidump)
     assert isinstance(ld.main_object.arch, archinfo.ArchX86)
     assert ld.main_object.os == "windows"
-    assert len(ld.main_object.sections) == 30
+    # One section per section of each of the 30 loaded modules, read out of the images the dump mapped.
+    assert len(ld.main_object.sections) == 182
 
     sections_map = ld.main_object.sections_map
-    assert "jusched.exe" in sections_map
-    assert "kernel32.dll" in sections_map
+    assert "jusched.exe:.text" in sections_map
+    assert "kernel32.dll:.text" in sections_map
+
+    text = sections_map["kernel32.dll:.text"]
+    assert (text.is_readable, text.is_writable, text.is_executable) == (True, False, True)
+    data = sections_map["kernel32.dll:.data"]
+    assert (data.is_readable, data.is_writable, data.is_executable) == (True, True, False)
+
+    assert sum(1 for section in ld.main_object.sections if section.is_executable) == 40
 
     assert len(ld.main_object.threads) == 2
     registers = ld.main_object.thread_registers(0x0548)
@@ -44,5 +52,19 @@ def test_minidump():
     }
 
 
+@unittest.skipIf(cle.backends.minidump.minidumpfile is None, "minidump not available")
+def test_minidump_sections_state_their_permissions():
+    """A dump's sections used to be built from the abstract base class, so asking raised NotImplementedError."""
+    exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "jusched_x86.dmp")
+    ld = cle.Loader(exe, auto_load_libs=False)
+
+    executable = [section for section in ld.main_object.sections if section.is_executable]
+    assert executable
+    assert all(section.is_readable for section in executable)
+    # the code of a loaded module is a fraction of the module, and a much smaller fraction of the dump
+    assert sum(section.memsize for section in executable) < sum(section.memsize for section in ld.main_object.sections)
+
+
 if __name__ == "__main__":
     test_minidump()
+    test_minidump_sections_state_their_permissions()

--- a/tests/test_minidump.py
+++ b/tests/test_minidump.py
@@ -4,6 +4,7 @@ import os
 import unittest
 
 import archinfo
+import pefile
 
 import cle
 
@@ -31,7 +32,20 @@ def test_minidump():
 
     assert sum(1 for section in ld.main_object.sections if section.is_executable) == 40
 
+    # The image is mapped headers and all, which is what makes its own section table readable back out of the dump.
+    assert ld.memory.load(0x140000, 2) == pefile.IMAGE_DOS_SIGNATURE.to_bytes(2, "little")
+
+    # This dump captured every module whole, so each section holds as many file bytes as it spans in memory, and
+    # the file offset it reports reads back the bytes the dump has at that address.
+    text = sections_map["jusched.exe:.text"]
+    assert text.filesize == text.memsize
+    assert not text.only_contains_uninitialized_data
+    with open(exe, "rb") as fp:
+        fp.seek(text.addr_to_offset(text.max_addr - 15))
+        assert fp.read(16) == ld.memory.load(text.max_addr - 15, 16)
+
     assert len(ld.main_object.threads) == 2
+    assert len(ld.tls.threads) == 2
     registers = ld.main_object.thread_registers(0x0548)
     assert isinstance(registers, dict)
     assert registers == {
@@ -65,6 +79,62 @@ def test_minidump_sections_state_their_permissions():
     assert sum(section.memsize for section in executable) < sum(section.memsize for section in ld.main_object.sections)
 
 
+@unittest.skipIf(cle.backends.minidump.minidumpfile is None, "minidump not available")
+def test_partial_minidump():
+    # A crash dump this small captures the faulting instruction and the thread stacks and nothing else, so not one
+    # of the modules it lists is captured at its base address.
+    exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "partial", "minidump2.dmp")
+    ld = cle.Loader(exe, auto_load_libs=False)
+    obj = ld.main_object
+
+    assert isinstance(obj, cle.Minidump)
+    assert isinstance(obj.arch, archinfo.ArchX86)
+    assert obj.os == "windows"
+    assert len(obj.segments) == 3
+    assert len(obj.sections) == 13
+
+    # An uncaptured module has no readable header, so it falls back to one section spanning the image. That section
+    # still places the module, which is what tells an analysis whose address an address is, but it maps no file
+    # bytes and it claims no permission it cannot support.
+    assert "test_app.exe" in obj.sections_map
+    assert "kernel32.dll" in obj.sections_map
+    assert all(section.memsize > 0 for section in obj.sections)
+    assert all(section.filesize == 0 for section in obj.sections)
+    assert all(section.only_contains_uninitialized_data for section in obj.sections)
+    assert all(section.addr_to_offset(section.vaddr) is None for section in obj.sections)
+
+    ntdll = obj.sections_map["ntdll.dll"]
+    assert ntdll.vaddr == 0x7C900000
+    assert ntdll.memsize == 0xB0000
+    # The one captured code range lives inside ntdll but does not start at its base address, and what the loader
+    # serves there is what the dump file holds for it.
+    assert ntdll.contains_addr(0x7C90EB14)
+    captured = next(segment for segment in obj.segments if segment.contains_addr(0x7C90EB14))
+    with open(exe, "rb") as fp:
+        fp.seek(captured.offset + 0x7C90EB14 - captured.vaddr)
+        assert fp.read(4) == ld.memory.load(0x7C90EB14, 4)
+
+    # The TEB pages are not captured, so the general-purpose registers survive without the fs segment base.
+    assert obj.threads == [0x0BF4, 0x11C0]
+    assert obj.thread_registers(0x0BF4) == {
+        "edi": 0x0,
+        "esi": 0x7B8,
+        "ebx": 0x7C883780,
+        "edx": 0x7C97C0D8,
+        "ecx": 0x7C80B46E,
+        "eax": 0x400000,
+        "ebp": 0x12F384,
+        "eip": 0x7C90EB94,
+        "eflags": 0x246,
+        "esp": 0x12F320,
+    }
+
+    # Without a TEB there is no way to reach a thread's TLS array, so no thread is modeled rather than the load
+    # failing outright.
+    assert not ld.tls.threads
+
+
 if __name__ == "__main__":
     test_minidump()
     test_minidump_sections_state_their_permissions()
+    test_partial_minidump()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

CFGFast cannot run on any minidump that has a loaded module in it. On
`binaries/tests/x86/windows/jusched_x86.dmp`:

```
30 sections
first five section keys: CRYPTBASE.dll, KERNELBASE.dll, advapi32.dll, bcryptPrimitives.dll, combase.dll
asking a section whether it is executable: NotImplementedError
```

`CFGBase` prefers sections over segments when it builds its executable map, so
the exception is raised on the ordinary path, not on an unusual query.

A dump that captured only part of a process does not load at all. The Breakpad
crash dump `binaries/tests/x86/windows/partial/minidump2.dmp` holds the faulting
instruction and the two thread stacks and nothing else:

```
  raise CLEInvalidBinaryError("Missing segment for loaded module: " + module.name)
cle.errors.CLEInvalidBinaryError: Missing segment for loaded module: c:\test_app.exe
```

### Root cause

One loop, and the same assumption three times: that a dump contains the whole of
what it describes.

```python
for segment in segments:
    if segment.start_virtual_address == module.baseaddress:
        break
else:
    raise CLEInvalidBinaryError("Missing segment for loaded module: " + module.name)
section = Section(module.name, segment.start_file_address, module.baseaddress, module.size)
```

`Section` is the abstract base: its `is_readable`, `is_writable` and
`is_executable` raise `NotImplementedError`. There is also nothing right to
return. A module is not a section — it is a mapped PE image with `r-x` text
beside `r--` and `rw-` data — so no single triple describes it honestly, which is
why the abstract class was left in place.

The exact-base requirement is the same assumption one line up. A dump captures
the ranges its writer selected, so a module's image may be present in full, in
part, or not at all, and a module that is not present at its base is not a
malformed dump.

Thread setup makes it a third time, reading the segment base out of the TEB with
`self.memory.unpack_word(teb + 0x30)`. A dump that did not capture the TEB page
loses every register in the saved context to that `KeyError`, not just `fs`.

### Fix

The image is mapped headers and all, so the sections come from the module's own
section table, read back out of the dumped memory: `DumpSection` answers the
three predicates from the section's `Characteristics`, and `filesize` says how far
the capture runs from the section's own base. A module whose layout the dump does
not describe still gets one section spanning it, with the permissive answer the
loader implied before — whether its headers were never captured or the capture ran
out inside its section table, since `Clemory.load` stops at the end of a captured
region and a short read tells us no more than no read. Section names gain a `<module>:` prefix, so `sections_map`
is keyed by `kernel32.dll:.text` rather than by `kernel32.dll`; the fallback
section keeps the bare module name, because it stands for the whole module.

Nothing is required at a module's base any more. A partially captured module gets
whatever the dump holds of it, and an uncaptured one still gets a section, which
is what tells an analysis whose address an address is. Such a section reports
`filesize == 0`, so it places the module without offering `CFGBase` an executable
region spanning it; the validation record measures that on a corpus sample. `Region` carries one
`(offset, filesize)` pair, so bytes captured further into such a section stay
unreachable through it. The TEB reads are guarded
individually, the wow64 register translation skips what is absent, and a thread
whose TEB was not captured is left out of the TLS model rather than failing the
load.

```
182 sections
first five section keys: CRYPTBASE.dll:.data, CRYPTBASE.dll:.didat, CRYPTBASE.dll:.idata, CRYPTBASE.dll:.reloc, CRYPTBASE.dll:.rsrc
40 of them are executable
```

40 executable sections out of 182 is the point: on the merge base the answer for
all 30 was an exception, and the honest answer for a whole-module section would
have been "executable", which is what the loader would have believed of every
byte of every module.

### Testing

`tests/test_minidump.py::test_minidump_sections_state_their_permissions` asks the fixture's sections
which are executable — the call that raises on the merge base — and checks the
executable ones are a strict fraction of the dump. `test_minidump` pins the
resulting shape: the `kernel32.dll:.text` and `kernel32.dll:.data` permission
triples, and that the file offset `jusched.exe:.text` reports reads back the
bytes the dump holds at that address. `test_partial_minidump` loads the partial
dump, which raises `CLEInvalidBinaryError` on the merge base, and asserts its 13
placing sections, both thread ids and one thread's registers without a segment
base, and that no TLS thread is modeled.

Fixes #749. Supersedes #682, which takes the permissions from the optional
`MemoryInfoListStream` that almost no dump carries.

This also absorbs #715, which repaired the partial-capture half of the same loop
against a whole-module section this change replaces. Its content is here, and that
thread records where each piece went.

Validation: https://github.com/angr/cle/pull/759#issuecomment-5314966209

session: sharpen
