### PR TITLE
Regions: Stop the address lookups from assuming an order the list may not have

### DIFF
--- a/cle/backends/elf/regions.py
+++ b/cle/backends/elf/regions.py
@@ -44,7 +44,9 @@ class ELFSection(Section):
     SHF_ALLOC = 0x2
     SHF_EXECINSTR = 0x4
     SHF_STRINGS = 0x20
+    SHF_TLS = 0x400
     SHT_NULL = "SHT_NULL"
+    SHT_NOBITS = "SHT_NOBITS"
 
     def __init__(self, readelf_sec, remap_offset=0):
         super().__init__(

--- a/cle/backends/regions.py
+++ b/cle/backends/regions.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+import bisect
 from collections.abc import Iterator
-
-from cle.utils import key_bisect_find, key_bisect_insort_left
 
 from .region import Region
 
@@ -12,16 +11,21 @@ class Regions[R: Region]:
     A container class acting as a list of regions (sections or segments). Additionally, it keeps an sorted list of
     all regions that are mapped into memory to allow fast lookups.
 
-    We assume none of the regions overlap with others.
+    Regions are usually disjoint, but nothing guarantees it: a relocatable object can place several sections at one
+    address and a malformed file can say anything at all. The sorted list is therefore ordered by start address only,
+    and the lookups carry a running maximum of the end addresses beside it -- ``_max_end[i]`` is the highest end
+    address among the first ``i + 1`` regions. That is sorted whether or not the regions are, which is what makes a
+    bisection over it mean something; where the regions are disjoint it is each region's own end address.
     """
 
     def __init__(self, lst: list[R] | None = None):
         self._list = lst if lst is not None else []
+        self._sorted_list: list[R] = []
+        self._max_end: list[int] = []
 
         if self._list:
-            self._sorted_list: list[R] = self._make_sorted(self._list)
-        else:
-            self._sorted_list = []
+            self._sorted_list = self._make_sorted(self._list)
+            self._max_end = self._make_max_end(self._sorted_list)
 
     @property
     def raw_list(self) -> list[R]:
@@ -44,8 +48,8 @@ class Regions[R: Region]:
         :rtype:   int or None
         """
 
-        if self._sorted_list:
-            return self._sorted_list[-1].max_addr
+        if self._max_end:
+            return self._max_end[-1] - 1
         return None
 
     def __getitem__(self, idx: int) -> R:
@@ -56,6 +60,7 @@ class Regions[R: Region]:
 
         # update self._sorted_list
         self._sorted_list = self._make_sorted(self._list)
+        self._max_end = self._make_max_end(self._sorted_list)
 
     def __iter__(self) -> Iterator[R]:
         return iter(self._list)
@@ -77,6 +82,7 @@ class Regions[R: Region]:
         """
         for x in self._list:
             x._rebase(delta)
+        self._max_end = [end + delta for end in self._max_end]
 
     def append(self, region: R):
         """
@@ -87,7 +93,9 @@ class Regions[R: Region]:
         self._list.append(region)
 
         if self._is_region_mapped(region):
-            key_bisect_insort_left(self._sorted_list, region, keyfunc=lambda x: x.vaddr)
+            index = bisect.bisect_left(self._sorted_list, region.vaddr, key=lambda x: x.vaddr)
+            self._sorted_list.insert(index, region)
+            self._insert_max_end(index, region)
 
     def remove(self, region: R) -> None:
         """
@@ -96,7 +104,10 @@ class Regions[R: Region]:
         :param region: The region to remove.
         """
         if self._is_region_mapped(region):
-            self._sorted_list.remove(region)
+            index = self._sorted_list.index(region)
+            self._sorted_list.pop(index)
+            self._max_end.pop(index)
+            self._refresh_max_end(index)
         self._list.remove(region)
 
     def find_region_containing(self, addr: int) -> R | None:
@@ -107,14 +118,16 @@ class Regions[R: Region]:
         :return:        The region that covers the specific address, or None if no such region is found.
         """
 
-        pos = key_bisect_find(
-            self._sorted_list, addr, keyfunc=lambda x: x if isinstance(x, int) else x.vaddr + x.memsize
-        )
-        if pos >= len(self._sorted_list):
-            return None
-        region = self._sorted_list[pos]
-        if region.contains_addr(addr):
-            return region
+        # Everything before this ends at or before addr, and everything from here on that starts after
+        # addr is too late. The first of the few in between that covers addr is the answer.
+        index = bisect.bisect_right(self._max_end, addr)
+        while index < len(self._sorted_list):
+            region = self._sorted_list[index]
+            if region.vaddr > addr:
+                break
+            if region.contains_addr(addr):
+                return region
+            index += 1
         return None
 
     def find_region_next_to(self, addr: int) -> R | None:
@@ -126,9 +139,8 @@ class Regions[R: Region]:
                          address,
         """
 
-        pos = key_bisect_find(
-            self._sorted_list, addr, keyfunc=lambda x: x if isinstance(x, int) else x.vaddr + x.memsize
-        )
+        # _max_end is sorted, so this is the first region whose end address is past addr
+        pos = bisect.bisect_right(self._max_end, addr)
         if pos >= len(self._sorted_list):
             return None
 
@@ -140,12 +152,17 @@ class Regions[R: Region]:
         # pylint: disable=import-outside-toplevel
         from .elf.regions import ELFSection
 
-        mapped = True
         if region.memsize == 0:
-            mapped = False
-        elif isinstance(region, ELFSection) and not region.occupies_memory:
-            mapped = False
-        return mapped
+            return False
+        if isinstance(region, ELFSection):
+            if not region.occupies_memory:
+                return False
+            if region.type == ELFSection.SHT_NOBITS and region.flags & ELFSection.SHF_TLS:
+                # .tbss is the zero-filled tail of the thread-local template. Its address is where a
+                # thread's own copy starts; in the image the linker puts the section that follows over
+                # the top of it, so it holds none of the bytes at the addresses it claims.
+                return False
+        return True
 
     @staticmethod
     def _make_sorted(lst: list[R]) -> list[R]:
@@ -158,3 +175,32 @@ class Regions[R: Region]:
         """
 
         return sorted([r for r in lst if Regions._is_region_mapped(r)], key=lambda x: x.vaddr)
+
+    @staticmethod
+    def _make_max_end(sorted_list: list[R]) -> list[int]:
+        """
+        Return the running maximum of the regions' end addresses.
+        """
+
+        out = []
+        running = 0
+        for region in sorted_list:
+            running = max(running, region.vaddr + region.memsize)
+            out.append(running)
+        return out
+
+    def _insert_max_end(self, index: int, region: R) -> None:
+        end = region.vaddr + region.memsize
+        value = max(self._max_end[index - 1], end) if index else end
+        self._max_end.insert(index, value)
+        for i in range(index + 1, len(self._max_end)):
+            if self._max_end[i] >= value:
+                break
+            self._max_end[i] = value
+
+    def _refresh_max_end(self, index: int) -> None:
+        running = self._max_end[index - 1] if index else 0
+        for i in range(index, len(self._sorted_list)):
+            region = self._sorted_list[i]
+            running = max(running, region.vaddr + region.memsize)
+            self._max_end[i] = running

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -1,3 +1,4 @@
+# pylint:disable=no-self-use
 from __future__ import annotations
 
 import os
@@ -57,6 +58,10 @@ groundtruth = {
 
 
 class TestRunSections(unittest.TestCase):
+    """
+    Check the sections and segments CLE reports against a known-good table.
+    """
+
     def _run_sections(self, arch, filename, sections):
         binary_path = os.path.join(TESTS_BASE, arch, filename)
 
@@ -173,6 +178,51 @@ class TestRunSections(unittest.TestCase):
     def test_segments(self):
         for (arch, filename), data in groundtruth.items():
             self._run_segments(arch, filename, data["segments"])
+
+
+class TestOverlappingRegions(unittest.TestCase):
+    """
+    Check the address lookups where regions share addresses.
+    """
+
+    def test_lookups_survive_an_overlap(self):
+        # Regions is documented as holding regions that do not overlap, and the lookups bisected the end
+        # addresses on that basis. When two regions do overlap the list is no longer sorted by that key, and
+        # the bisection can walk past a region that covers the address and report there is none.
+        outer = Segment(0, 0x1000, 0x3000, 0x3000)
+        inner = Segment(0, 0x2000, 0x100, 0x100)
+        regions = cle.backends.Regions([outer, inner])
+
+        assert regions.find_region_containing(0x1500) is outer
+        assert regions.find_region_containing(0x3500) is outer
+        assert regions.find_region_containing(0x4000) is None
+        # where both cover the address, the first one in address order wins
+        assert regions.find_region_containing(0x2050) is outer
+
+        assert regions.find_region_next_to(0x2200) is outer
+        assert regions.find_region_next_to(0x4000) is None
+
+        assert regions.max_addr == 0x3FFF
+
+    def test_tbss_does_not_answer_for_what_is_over_it(self):
+        # .tbss is the zero-filled tail of the thread-local template. Its address is where a thread's copy
+        # begins, and in the image the linker places the section after it over the top, so it holds none of
+        # the bytes at the addresses it claims.
+        binary_path = os.path.join(TESTS_BASE, "x86_64", "libc.so.6")
+        ld = cle.Loader(binary_path, auto_load_libs=False)
+        obj = ld.main_object
+
+        tbss = obj.sections_map[".tbss"]
+        covered = [
+            section
+            for section in obj.sections
+            if section is not tbss and section.memsize and tbss.contains_addr(section.vaddr)
+        ]
+        assert covered
+
+        for section in covered:
+            assert obj.sections.find_region_containing(section.vaddr) is section
+            assert obj.find_section_containing(section.vaddr) is section
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

An address lookup can walk past a region that does cover the address and report
there is none. On `binaries/tests/armel/btrfs.ko`, `.text` spans
`0x400000`-`0x4b9b58` and no address in it can be attributed to a section:

```
.text spans 0x400000-0x4b9b58
19 other sections start at 0x400000 and end inside it, e.g. .rel.gnu.linkonce.this_module (ends 0x400008), .rel.ARM.exidx.exit.text (ends 0x400010), .note.gnu.build-id (ends 0x400024)
find_section_containing(0x400024) -> None
find_section_containing(0x400100) -> None
find_section_containing(0x4b9b00) -> None
```

`find_section_containing` is what tells a consumer which bytes are code, so on
this object every block in `.text` looks like it belongs to no section at all.

### Root cause

`Regions` keeps its members sorted by start address and then bisects their **end**
addresses:

```python
    We assume none of the regions overlap with others.
```

That assumption makes the two orders the same order. It does not hold here: the
19 non-allocated sections of a kernel module all state `sh_addr` 0 and land on
`.text`'s start, so the end-address sequence is `0x400008, 0x400010, 0x400024,
… , 0x4b9b58` interleaved with `.text` last. The bisection lands on the first
region whose end exceeds the address, finds a region that starts at `0x400000`
but ends before the address it was asked about, and returns `None` -- one
short-ended neighbour is enough to hide every region behind it.

### Fix

The lookups now carry a running maximum of the end addresses beside the sorted
list: `_max_end[i]` is the highest end address among the first `i + 1` regions.
That sequence is nondecreasing whether or not the regions overlap, so the
bisection over it means something in either case, and where the regions are
disjoint it *is* each region's own end address and both reduce to exactly the
bisection they were. `.tbss` is also kept out of the ELF section list, since its
address is where a thread's own copy of the template begins rather than a range of
the image, and the linker places the following section over the top of it.

```
find_section_containing(0x400024) -> <.text | offset 0x58, vaddr 0x400000, size 0xb9b58>
find_section_containing(0x400100) -> <.text | offset 0x58, vaddr 0x400000, size 0xb9b58>
find_section_containing(0x4b9b00) -> <.text | offset 0x58, vaddr 0x400000, size 0xb9b58>
```

### Testing

`tests/test_regions.py::TestOverlappingRegions::test_lookups_survive_an_overlap`
puts a small region inside a larger one and asserts the four lookups; on the
merge base `find_region_containing(0x3500)` returns `None`.
`test_tbss_does_not_answer_for_what_is_over_it` checks the exclusion on
`binaries/tests/x86_64/libc.so.6`, where `.tbss` covers `.init_array` and `__libc_subfreeres`, which hold
the bytes at those addresses. `btrfs.ko` above is the reproducer in the wild, not
a fixture the tests load.

Fixes #742. Validation: https://github.com/angr/cle/pull/760#issuecomment-5314966331

session: sharpen
