### PR TITLE
COFF: Expose undefined externals through self.imports

### DIFF
--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -288,6 +288,23 @@ class CoffSection(Section):
         return (self._coff_sec.Characteristics & IMAGE_SCN.CNT_UNINITIALIZED_DATA) != 0
 
 
+class CoffSymbol(Symbol):
+    """
+    Symbol of a COFF object.
+    """
+
+    def __init__(self, owner, name, relative_addr, size, sym_type, is_import=False):
+        super().__init__(owner, name, relative_addr, size, sym_type)
+        self._is_import = is_import
+
+    @property
+    def is_import(self):
+        """
+        Whether this symbol is defined elsewhere. A COFF object states that with section number zero.
+        """
+        return self._is_import
+
+
 class CoffRelocation(Relocation):
     """
     Relocation for a COFF object.
@@ -488,8 +505,6 @@ class Coff(Backend):
         self._add_defined_symbols()
         self._add_relocs()
 
-        # FIXME: Expose __imp_* symbols through self.imports
-
     def _add_defined_symbols(self) -> None:
         for sym_name, sym_idx in self._coff.symbol_name_to_idx.items():
             sym = self._coff.symbols[sym_idx]
@@ -532,7 +547,7 @@ class Coff(Backend):
             return None
 
         if name == "__ImageBase":
-            return Symbol(self, name, 0, 0, SymbolType.TYPE_OTHER)
+            return CoffSymbol(self, name, 0, 0, SymbolType.TYPE_OTHER)
 
         sym = self._coff.symbols[self._coff.symbol_name_to_idx[name]]
         if sym.StorageClass in {
@@ -540,13 +555,16 @@ class Coff(Backend):
             IMAGE_SYM_CLASS.LABEL,
             IMAGE_SYM_CLASS.EXTERNAL,
         }:
-            symbol_type = SymbolType.TYPE_FUNCTION if sym.Type == 0x20 else SymbolType.TYPE_OTHER
+            # A COFF symbol's Type field states a function with 0x20 and states nothing at all with 0,
+            # which is what every GCC-family toolchain emits. TYPE_NONE is how CLE spells "the file did
+            # not say", and it is what a relocatable ELF's STT_NOTYPE symbols already become.
+            symbol_type = SymbolType.TYPE_FUNCTION if sym.Type == 0x20 else SymbolType.TYPE_NONE
             if sym.SectionNumber > 0:
                 sym_addr = self._coff.sections[sym.SectionNumber - 1].PointerToRawData + sym.Value
-                return Symbol(self, name, sym_addr, 1, symbol_type)
+                return CoffSymbol(self, name, sym_addr, 1, symbol_type)
             elif sym.SectionNumber == 0:
                 if produce_extern_symbols:
-                    return Symbol(self, name, 0, sym.Value, symbol_type)
+                    return CoffSymbol(self, name, 0, sym.Value, symbol_type, is_import=True)
                 return None
 
         raise NotImplementedError("Unsupported symbol")

--- a/tests/test_coff.py
+++ b/tests/test_coff.py
@@ -74,6 +74,25 @@ class TestCoff(unittest.TestCase):
         field_addr = section_vaddr(ld.main_object, ".text") + field_offset
         assert ld.memory.load(field_addr, 4) == struct.pack("<i", expected)
 
+    def test_undefined_externals_are_imports(self):
+        # A COFF object names what it needs from elsewhere with section number zero. Those never reached
+        # self.imports, which is the only thing angr looks at, so nothing hooked them and the extern
+        # addresses stayed decodable zero fill.
+        exe = os.path.join(TEST_BASE, "tests", "x86_64", "fauxware.obj")
+        ld = cle.Loader(exe, auto_load_libs=True)
+        imports = ld.main_object.imports
+
+        assert "strcmp" in imports
+        assert "_RTC_CheckStackVars" in imports
+        # a symbol the object defines itself is not an import
+        assert "main" not in imports
+
+        for name, reloc in imports.items():
+            symbol = reloc.symbol
+            assert symbol is not None and symbol.is_import, name
+            assert reloc.resolvedby is not None, name
+            assert reloc.resolvedby.owner is ld.extern_object, name
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A COFF object never says what it needs from elsewhere. On
`binaries/tests/x86_64/fauxware.obj`:

```
obj.imports: 0 entries
```

`Project._register_object` reads `self.imports` and nothing else to decide what
to hook, so a call to `strcmp` or `exit` in this object lands in the extern
object's zero fill and is decoded as instructions. The object's ten undefined
externals are all reachable from its code.

### Root cause

A COFF object names an undefined external by giving the symbol section number
zero. cle already allocates each of those an extern address and relocates against
it -- the addresses exist -- but nothing on the symbol says it is an import, so
`self.imports` is never populated. The second half is `Type`: a COFF symbol says
`0x20` for a function and `0` for "no type information", which is what every
GCC-family toolchain emits, and cle read `0` as data. An import listed as data is
listed and then skipped rather than hooked.

### Fix

Say so on the symbol -- the generic relocation machinery already does the rest --
and map an untyped COFF symbol to `TYPE_NONE`, as a relocatable ELF's
`STT_NOTYPE` symbols already are, rather than to a data symbol.

```
obj.imports: 10 entries
    ?_OptionsStorage@?1??__local_stdio_printf_options@@9@9 TYPE_NONE      -> 0x500000 in ExternObject
    _RTC_CheckStackVars                                  TYPE_FUNCTION  -> 0x500028 in ExternObject
    _RTC_InitBase                                        TYPE_FUNCTION  -> 0x500040 in ExternObject
    _RTC_Shutdown                                        TYPE_FUNCTION  -> 0x500048 in ExternObject
    __imp___acrt_iob_func                                TYPE_NONE      -> 0x500030 in ExternObject
    __imp___stdio_common_vfprintf                        TYPE_NONE      -> 0x500008 in ExternObject
    __imp__open                                          TYPE_NONE      -> 0x500018 in ExternObject
    __imp__read                                          TYPE_NONE      -> 0x500020 in ExternObject
    __imp_exit                                           TYPE_NONE      -> 0x500038 in ExternObject
    strcmp                                               TYPE_FUNCTION  -> 0x500010 in ExternObject
```

### Testing

`tests/test_coff.py::TestCoff::test_undefined_externals_are_imports` asserts that
the fixture reports `strcmp` and `_RTC_CheckStackVars` among its imports, that
`main` is not among them, and that every import carries an `is_import` symbol
resolved into the extern object. `obj.imports` is empty on the merge base, so it
fails on the first assertion.

Fixes #746. Validation: https://github.com/angr/cle/pull/761#issuecomment-5315056508

session: sharpen
