### PR TITLE
STM32: Parse the IRQ vectors get_irq_handler was written to read

### DIFF
--- a/cle/backends/stm32.py
+++ b/cle/backends/stm32.py
@@ -37,24 +37,37 @@ class VectorTable(LittleEndianStructure):
         ("systick_handler", c_uint32),  # 0x3C: SysTick handler
     ]
 
+    # A Cortex-M NVIC drives at most 480 external interrupt lines (ARMv8-M; ARMv7-M allows 240), so
+    # the vector table holds no more IRQ vectors than this however far the image runs on past it.
+    MAX_IRQ_VECTORS = 480
+
+    #: The peripheral IRQ vectors, indexed by IRQ number. They follow the 16 system exception
+    #: vectors the fields above cover. A raw flash image does not record how many IRQ vectors its
+    #: device has, so this holds every one the image has room for, up to what an NVIC can address.
+    irq_handlers: tuple[int, ...] = ()
+
     @property
     def reset_handler_addr(self) -> int:
         """Reset handler address with Thumb bit cleared"""
         return self.reset_handler & (~1)
 
     def get_irq_handler(self, irq_num: int) -> int:
-        """Get peripheral interrupt handler address (IRQ 0+)"""
-        vector_offset = (16 + irq_num) * 4
-        if vector_offset + 4 > len(self._data):
+        """Get peripheral interrupt handler address (IRQ 0+), or 0 if the table holds no such vector"""
+        if irq_num < 0:
+            raise ValueError(f"IRQ number must not be negative: {irq_num}")
+        if irq_num >= len(self.irq_handlers):
             return 0
-        return struct.unpack_from("<I", self._data, vector_offset)[0]
+        return self.irq_handlers[irq_num]
 
     @classmethod
     def from_bytes(cls, data: bytes) -> VectorTable:
         """Create VectorTable from bytes data"""
         if len(data) < cls._size_():
             raise ValueError(f"Data too short for vector table (need at least {cls._size_()} bytes)")
-        return cls.from_buffer_copy(data[: cls._size_()])
+        table = cls.from_buffer_copy(data[: cls._size_()])
+        count = min((len(data) - cls._size_()) // 4, cls.MAX_IRQ_VECTORS)
+        table.irq_handlers = struct.unpack_from(f"<{count}I", data, cls._size_())
+        return table
 
     @classmethod
     def _size_(cls) -> int:

--- a/tests/test_stm32.py
+++ b/tests/test_stm32.py
@@ -7,6 +7,7 @@ import struct
 import pytest
 
 import cle
+from cle.backends.stm32 import VectorTable
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 # The same Nucleo-L152RE firmware as a raw flash image and as an ELF.
@@ -88,3 +89,60 @@ def test_stm32_entry_point_option_wins_over_the_reset_vector():
 def test_stm32_requested_by_name_rejects_a_truncated_image():
     with pytest.raises(cle.CLECompatibilityError):
         cle.Loader(io.BytesIO(firmware_with_vectors()[:0x20]), main_opts={"backend": "stm32"}, auto_load_libs=False)
+
+
+def test_stm32_vector_table_reads_peripheral_irq_handlers():
+    """
+    The ctypes fields cover the 16 system exception vectors only; the peripheral IRQ vectors that
+    follow them are parsed out of the rest of the image.
+    """
+    loader = cle.Loader(FIRMWARE, auto_load_libs=False)
+    elf = cle.Loader(FIRMWARE_ELF, auto_load_libs=False)
+    main_object = loader.main_object
+    assert isinstance(main_object, cle.STM32Backend)
+    vector_table = main_object.vector_table
+
+    # This firmware routes every peripheral interrupt to the startup file's shared default handler.
+    default_handler_symbol = elf.find_symbol("Default_Handler")
+    assert default_handler_symbol is not None
+    default_handler = default_handler_symbol.rebased_addr
+    for irq_num in range(12):
+        handler = vector_table.get_irq_handler(irq_num)
+        assert handler == vector_table.irq_handlers[irq_num]
+        assert handler & ~1 == default_handler
+        assert handler & 1, "a Cortex-M vector carries the Thumb bit"
+
+
+def test_stm32_vector_table_stops_at_the_nvic_limit():
+    """
+    The image runs for thousands of words past its vector table, and none of the words beyond the
+    NVIC's last interrupt line is a vector.
+    """
+    with open(FIRMWARE, "rb") as f:
+        image = f.read()
+    vector_table = VectorTable.from_bytes(image)
+
+    words_after_the_system_vectors = (len(image) - VectorTable._size_()) // 4
+    assert words_after_the_system_vectors > VectorTable.MAX_IRQ_VECTORS
+    assert len(vector_table.irq_handlers) == VectorTable.MAX_IRQ_VECTORS
+    assert vector_table.get_irq_handler(VectorTable.MAX_IRQ_VECTORS) == 0
+
+
+def test_stm32_vector_table_reports_irq_vectors_the_image_does_not_hold():
+    with open(FIRMWARE, "rb") as f:
+        system_vectors_only = f.read(64)
+
+    table = VectorTable.from_bytes(system_vectors_only)
+    assert table.irq_handlers == ()
+    assert table.get_irq_handler(0) == 0
+
+
+def test_stm32_vector_table_rejects_a_negative_irq_number():
+    """
+    Without this, IRQ -16 through -1 would silently read the system exception vectors instead.
+    """
+    with open(FIRMWARE, "rb") as f:
+        vector_table = VectorTable.from_bytes(f.read())
+
+    with pytest.raises(ValueError):
+        vector_table.get_irq_handler(-1)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`VectorTable.get_irq_handler` read `self._data`, an attribute the structure never set, so every call raised `AttributeError`. `from_bytes` built the structure with `from_buffer_copy` over the first 64 bytes and discarded the rest, which is where the peripheral IRQ vectors it wants live.

Those 64 bytes are the 16 system exception vectors the ctypes fields describe; how many IRQ vectors follow them is a property of the device that a raw flash image does not record. `from_bytes` now unpacks the words after them into `irq_handlers` and `get_irq_handler` indexes that. A Cortex-M NVIC drives at most 480 external interrupt lines, so the parse stops there rather than reporting whatever code follows the table as a handler, and a negative IRQ number is rejected.

The regression reads the IRQ vectors of the Nucleo-L152RE image already in `binaries` and checks them against `Default_Handler` in the ELF build of the same firmware; `python -m pytest tests/test_stm32.py` covers it.

Follow-up to #716, as requested in https://github.com/angr/cle/pull/716#discussion_r3796611439. Validation: https://github.com/angr/cle/pull/763#issuecomment-5319197273