### PR TITLE
COFF: Give a section with no file bytes an address of its own

### DIFF
--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -430,6 +430,22 @@ RELOC_CLASSES: dict[IntEnum, dict[IntEnum, type[Relocation]]] = {
     },
 }
 
+#: ``IMAGE_SCN_ALIGN_*`` is a four-bit field holding one plus the log2 of the alignment. Zero states none,
+#: for which the linker's own default is 16 bytes.
+_ALIGN_MASK = 0x00F00000
+_ALIGN_SHIFT = 20
+
+
+def _section_alignment(section: CoffSectionTableEntry) -> int:
+    encoded = (section.Characteristics & _ALIGN_MASK) >> _ALIGN_SHIFT
+    return 1 << (encoded - 1) if encoded else 16
+
+
+#: ``SizeOfRawData`` is 32 bits wide, and for a section with no bytes in the file nothing else in the file
+#: bounds it. This caps the zero-filled space such a section is given.
+MAX_IMAGE_SIZE = 0x10000000
+
+
 COFF_MACHINE_TO_ARCH_NAME = {
     IMAGE_FILE_MACHINE.I386: "x86",
     IMAGE_FILE_MACHINE.AMD64: "AMD64",
@@ -459,26 +475,52 @@ class Coff(Backend):
 
         # FIXME: Currently we just map the whole object file for convenience. Create a better memory map, discard object
         # file structure data.
-        self._image_vmem = self._data
+        image = bytearray(self._data)
 
         # Add each section
+        self._section_addrs: list[int] = []
+        next_uninitialized_vaddr = len(image)
         for section_idx, section in enumerate(self._coff.sections):
             section_name = self._coff.get_section_name(section_idx)
-            vaddr = section.PointerToRawData
             vsize = section.SizeOfRawData
-            self.segments.append(Segment(section.PointerToRawData, vaddr, section.SizeOfRawData, vsize))
+            if section.PointerToRawData or not vsize or not section.Characteristics & IMAGE_SCN.CNT_UNINITIALIZED_DATA:
+                vaddr = section.PointerToRawData
+                filesize = vsize
+            else:
+                # A section marked IMAGE_SCN_CNT_UNINITIALIZED_DATA has no bytes in the file and states
+                # PointerToRawData 0, which in the layout above is the file header. Placing it there lays it over
+                # the header and, once it is longer than the section table, over the sections that follow: a mingw
+                # object whose .bss is 0x1300 bytes long covers the first 0x11fc bytes of its own .text. Give it
+                # zero-filled space of its own past the image instead.
+                alignment = _section_alignment(section)
+                vaddr = (next_uninitialized_vaddr + alignment - 1) & ~(alignment - 1)
+                next_uninitialized_vaddr = vaddr + vsize
+                if next_uninitialized_vaddr <= MAX_IMAGE_SIZE:
+                    image.extend(bytes(next_uninitialized_vaddr - len(image)))
+                else:
+                    log.warning(
+                        "Section %s states %#x bytes of uninitialized data, which would take the image past "
+                        "%#x. Leaving it unbacked.",
+                        section_name,
+                        vsize,
+                        MAX_IMAGE_SIZE,
+                    )
+                filesize = 0
+            self._section_addrs.append(vaddr)
+            self.segments.append(Segment(section.PointerToRawData, vaddr, filesize, vsize))
             self.sections.append(
                 CoffSection(
                     section_name,
                     section.PointerToRawData,
-                    section.SizeOfRawData,
+                    filesize,
                     vaddr,
                     vsize,
                     section,
                 )
             )
 
-        self.memory.add_backer(0, bytes(self._image_vmem))
+        self._image_vmem = bytes(image)
+        self.memory.add_backer(0, self._image_vmem)
         self.mapped_base = self.linked_base = 0
         self.pic = True
         # assume windows, this can be wrong, but is more often right.
@@ -501,11 +543,11 @@ class Coff(Backend):
                 self.symbols.add(self.get_symbol(sym_name))
 
     def _add_relocs(self) -> None:
-        for section_idx, section in enumerate(self._coff.sections):
+        for section_idx in range(len(self._coff.sections)):
             for reloc in self._coff.relocations[section_idx]:
                 sym = self._coff.symbols[reloc.SymbolTableIndex]
                 sym_name = self._coff.get_symbol_name(reloc.SymbolTableIndex)
-                patch_offset = section.PointerToRawData + reloc.VirtualAddress
+                patch_offset = self._section_addrs[section_idx] + reloc.VirtualAddress
 
                 if sym.StorageClass in {
                     IMAGE_SYM_CLASS.STATIC,
@@ -542,7 +584,7 @@ class Coff(Backend):
         }:
             symbol_type = SymbolType.TYPE_FUNCTION if sym.Type == 0x20 else SymbolType.TYPE_OTHER
             if sym.SectionNumber > 0:
-                sym_addr = self._coff.sections[sym.SectionNumber - 1].PointerToRawData + sym.Value
+                sym_addr = self._section_addrs[sym.SectionNumber - 1] + sym.Value
                 return Symbol(self, name, sym_addr, 1, symbol_type)
             elif sym.SectionNumber == 0:
                 if produce_extern_symbols:

--- a/tests/test_coff.py
+++ b/tests/test_coff.py
@@ -74,6 +74,56 @@ class TestCoff(unittest.TestCase):
         field_addr = section_vaddr(ld.main_object, ".text") + field_offset
         assert ld.memory.load(field_addr, 4) == struct.pack("<i", expected)
 
+    def test_uninitialized_section_gets_space_of_its_own(self):
+        # .bss states no PointerToRawData because it has no bytes in the file, and this object's
+        # is 0x1000 long -- far past the 0xb4 where .text begins. Mapped at the file offset it
+        # states, it lies over the file header and the whole of .text.
+        exe = os.path.join(TEST_BASE, "tests", "x86", "coff_bss.obj")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        obj = ld.main_object
+        bss = next(section for section in obj.sections if section.name == ".bss")
+        text = next(section for section in obj.sections if section.name == ".text")
+
+        assert bss.memsize == 0x1000
+        assert bss.vaddr >= text.vaddr + text.memsize
+        assert obj.find_section_containing(text.vaddr) is text
+        # Uninitialized data reads as zero, not as whatever the file happens to hold there.
+        assert ld.memory.load(bss.vaddr, bss.memsize) == bytes(bss.memsize)
+        buffer_symbol = obj.get_symbol("_buffer")
+        assert buffer_symbol is not None
+        assert buffer_symbol.rebased_addr == bss.vaddr
+
+    def test_a_section_with_no_file_bytes_and_no_flag_gets_no_space(self):
+        # The section states PointerToRawData 0 with SizeOfRawData 0x4000000 and marks itself
+        # code, not uninitialized data. Its size is under MAX_IMAGE_SIZE, so the ceiling would
+        # not stop it; only the IMAGE_SCN_CNT_UNINITIALIZED_DATA condition does.
+        exe = os.path.join(TEST_BASE, "tests", "x86", "coff_bss_no_flag.obj")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        obj = ld.main_object
+        bss = next(section for section in obj.sections if section.name == ".bss")
+
+        assert bss.memsize == 0x4000000
+        assert not bss.only_contains_uninitialized_data
+        # It keeps the address its header states rather than getting space of its own.
+        assert bss.vaddr == obj.mapped_base
+        assert sum(len(backer) for _, backer in obj.memory.backers()) == os.path.getsize(exe)
+
+    def test_an_uninitialized_section_past_the_ceiling_is_not_materialized(self):
+        # .bss states 0x20000000 bytes and the file is 580 long. Nothing in the file bounds
+        # SizeOfRawData, so zero-filling whatever it says turns a header field into an allocation.
+        exe = os.path.join(TEST_BASE, "tests", "x86", "coff_huge_bss.obj")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        obj = ld.main_object
+        bss = next(section for section in obj.sections if section.name == ".bss")
+        text = next(section for section in obj.sections if section.name == ".text")
+
+        assert bss.memsize == 0x20000000
+        assert bss.vaddr >= text.vaddr + text.memsize
+        # The image is the file and nothing more, so it does not grow with the field.
+        assert sum(len(backer) for _, backer in obj.memory.backers()) == os.path.getsize(exe)
+        with self.assertRaises(KeyError):
+            ld.memory.load(bss.vaddr, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A COFF section with no bytes in the file is mapped over the code. On
`binaries/tests/x86/coff_bss.obj`, a mingw object whose `.bss` is 0x1000 long:

```
section         vaddr  memsize
.text        0x4000b4     0x40
.data        0x400000      0x0
.bss         0x400000   0x1000
.rdata$zzz   0x4000f4     0x14
find_section_containing(.text vaddr 0x4000b4) -> .bss
_buffer symbol at 0x400000
first 16 bytes at .bss: 4c010400000000001c0100000f000000
```

`.bss` starts on the file header and runs over the whole of `.text`. CFGFast drops
every block whose section is not executable, so the object's code is unreachable;
uninitialized data reads back as the COFF header (`4c 01` is `Machine`
`IMAGE_FILE_MACHINE_I386`, `04 00` the section count); and `_buffer`, a `.bss`
symbol, gets an address inside the header rather than in its own storage.

It also loses whole objects. Four MSVC objects, in five copies, between 1.16 MB
and 4.86 MB do not load at all on master:

```
ValueError: Address 0x500000 is already backed!   (three of the four)
ValueError: Address 0x800000 is already backed!   (the 4.86 MB one)
  both from Clemory.add_backer, via Loader._map_object
```

The `.bss` at the image base stretches the main object's span over the address the
loader then places the extern object at. All four are in a working tree that is not
public, and no public object reproduces it: all 1,097 objects with this shape that
come from publicly downloadable packages load on master. So the reproducer cannot
be published.

### Root cause

The backend maps the object at its file offsets and gives every section
`vaddr = PointerToRawData`:

```python
vaddr = section.PointerToRawData
self.segments.append(Segment(section.PointerToRawData, vaddr, section.SizeOfRawData, vsize))
```

A section with no file bytes states that offset as 0, while still stating its
length elsewhere. The fixture's header says exactly that:

```
.text    SizeOfRawData=0x40   PointerToRawData=0xb4  Characteristics=0x60500020
.bss     SizeOfRawData=0x1000 PointerToRawData=0x0   Characteristics=0xc0600080
```

so `.bss` is placed at 0 and, being longer than the header and section table,
extends over everything that follows.

### Fix

A section marked `IMAGE_SCN_CNT_UNINITIALIZED_DATA` gets zero-filled space of its
own past the image, at the alignment its `IMAGE_SCN_ALIGN_*` states. Relocation
patch offsets and symbol addresses come from a per-section address list rather
than from `PointerToRawData`, so they follow the new layout.

```
.bss         0x400260   0x1000
find_section_containing(.text vaddr 0x4000b4) -> .text
_buffer symbol at 0x400260
first 16 bytes at .bss: 00000000000000000000000000000000
```

The flag, not the zero pointer, is the condition, because the zero pointer alone
is something a file controls: a 120-byte object can state `PointerToRawData` 0
with `SizeOfRawData` `0x4000000` on a section marked code, and honouring that is
64 MiB of zero fill bought with one header field. The format already says which
sections have no bytes in the file, and `CoffSection` already exposes it as
`only_contains_uninitialized_data`.

**A section without the flag is not refused.** It keeps the address its header
states, which is exactly what master does with it, and cle stops inventing storage
for a shape nothing in the survey below produced. Nothing stops loading.

That is measured, not assumed. Across `angr/binaries`, four dataset trees and
every `.o`, `.obj`, `.lib`, `.a` and `.syso` under a 365,293-file Nix store --
731,573 COFF objects, 730,821 of them archive members -- 1,480 sections state
`PointerToRawData` 0 with a non-zero size, in 64 distinct shapes, and **every one
sets the flag**. 1,097 of those sections, one per object, are in packages anyone can download, the
largest a 16,116,128-byte `.bss` in Go 1.26.7's `race_windows.syso`.

`MAX_IMAGE_SIZE`, `0x10000000`, is the second line, for a section that does set
the flag and still states an absurd size -- the field is 32 bits wide, so it can
ask for close to 4 GiB. Past the bound the section is placed and reports its
stated size, but no zero fill is allocated and a warning names it, which is what
`_get_memory_mapped_image` does past `max_virtual_address` in
`cle/backends/pe/pe.py`. That constant is `0x100000000`; this one is smaller
because PE bounds an address whose data the file still has to hold, while nothing
in a file bounds this.

A relocation that resolves into a section left unbacked that way raises
`KeyError`. That is out of scope here: the ceiling fires on 0 of the 731,573
objects surveyed above, whose largest image is 16,679,072 bytes against the
ceiling's 268,435,456.

### Testing

Three tests in `tests/test_coff.py`, one per path. `coff_bss_no_flag.obj` carries
the fix's own condition: its `.bss` states `0x4000000` with the flag clear, and
the test asserts it keeps `mapped_base` and that the image is the file's 120
bytes. `coff_huge_bss.obj` states `0x20000000` with the flag set and asserts the
image stays at 580 bytes. `coff_bss.obj` asserts the ordinary case still gets its
space. Remove only the flag condition and the first fails at `4194432 == 4194304`;
remove only the bound and the second fails at `536871520 == 580`.

All three fixtures are in angr/binaries#184, which every job here resolves, so it
merges first. It conflicts with binaries 223 in one place, the builder's module
docstring, where 223 rewrites the paragraph into two; land 223 first and rebase.

Merge this and #806 in either order, then #804. Both conflict with this branch in
`cle/backends/coff.py` and `tests/test_coff.py`, textually and already at
`51c1f241`. #804 carries a copy of this commit and adds a second unbounded
allocation through its realignment path, which #806's file bound closes.

Validation: https://github.com/angr/cle/pull/764#issuecomment-5329105180

sync: angr/binaries#184

session: sharpen
