### PR TITLE
Fix two bad PowerPC64 ELFv1 function-descriptor reads

### DIFF
--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -453,11 +453,8 @@ class MetaELF(Backend):
         exists a pointer to the entry point.
 
         Utter bollocks, but this function should fix it.
-
-        A file with no entry point has no such pointer: e_entry is zero, which is how ELF says there is
-        none, and every relocatable object is in that state.
         """
-        if self.is_ppc64_abiv1 and self._entry != 0:
+        if self.is_ppc64_abiv1 and self._entry != 0:  # entry == 0 means the ELF has no entry point or rtoc
             ep_offset = self._entry
             self._entry = self.memory.unpack_word(AT.from_lva(ep_offset, self).to_rva())
             self._ppc64_abiv1_initial_rtoc = self.memory.unpack_word(AT.from_lva(ep_offset + 8, self).to_rva())

--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -453,8 +453,11 @@ class MetaELF(Backend):
         exists a pointer to the entry point.
 
         Utter bollocks, but this function should fix it.
+
+        A file with no entry point has no such pointer: e_entry is zero, which is how ELF says there is
+        none, and every relocatable object is in that state.
         """
-        if self.is_ppc64_abiv1:
+        if self.is_ppc64_abiv1 and self._entry != 0:
             ep_offset = self._entry
             self._entry = self.memory.unpack_word(AT.from_lva(ep_offset, self).to_rva())
             self._ppc64_abiv1_initial_rtoc = self.memory.unpack_word(AT.from_lva(ep_offset + 8, self).to_rva())

--- a/cle/backends/elf/relocation/ppc64.py
+++ b/cle/backends/elf/relocation/ppc64.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import logging
 
+from cle.backends.symbol import SymbolType
+
 from .elfreloc import ELFReloc
 from .generic import (
     GenericAbsoluteAddendReloc,
@@ -25,6 +27,15 @@ log = logging.getLogger(name=__name__)
 
 class R_PPC64_JMP_SLOT(ELFReloc):
     __slots__ = ()
+
+    @property
+    def extern_symbol_type(self):
+        # A jump slot points at a function whatever the symbol table says, and on ELFv1 the
+        # extern for one needs a whole function descriptor. Left as the declared type, an
+        # imported function marked STT_NOTYPE gets a pointer-sized slot instead, and the
+        # descriptor copy below reads past it -- off the end of the extern object when the
+        # symbol is the last one allocated, and over the neighbouring symbol otherwise.
+        return SymbolType.TYPE_FUNCTION
 
     def relocate(self):
         if self.owner.is_ppc64_abiv1:

--- a/cle/backends/elf/relocation/ppc64.py
+++ b/cle/backends/elf/relocation/ppc64.py
@@ -30,11 +30,6 @@ class R_PPC64_JMP_SLOT(ELFReloc):
 
     @property
     def extern_symbol_type(self):
-        # A jump slot points at a function whatever the symbol table says, and on ELFv1 the
-        # extern for one needs a whole function descriptor. Left as the declared type, an
-        # imported function marked STT_NOTYPE gets a pointer-sized slot instead, and the
-        # descriptor copy below reads past it -- off the end of the extern object when the
-        # symbol is the last one allocated, and over the neighbouring symbol otherwise.
         return SymbolType.TYPE_FUNCTION
 
     def relocate(self):

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -46,13 +46,7 @@ class Relocation:
 
     @property
     def extern_symbol_type(self) -> SymbolType:
-        """The symbol type to give the extern this relocation resolves to.
-
-        Defaults to whatever the object declared. A relocation whose meaning fixes the
-        type -- a jump slot always points at a function -- overrides this, because the
-        extern's layout depends on it and an object file is free to leave an imported
-        function ``STT_NOTYPE``.
-        """
+        """The symbol type to give the extern this relocation resolves to."""
         assert self.symbol is not None
         return self.symbol._type
 

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -44,6 +44,18 @@ class Relocation:
 
     AUTO_HANDLE_NONE = False
 
+    @property
+    def extern_symbol_type(self) -> SymbolType:
+        """The symbol type to give the extern this relocation resolves to.
+
+        Defaults to whatever the object declared. A relocation whose meaning fixes the
+        type -- a jump slot always points at a function -- overrides this, because the
+        extern's layout depends on it and an object file is free to leave an imported
+        function ``STT_NOTYPE``.
+        """
+        assert self.symbol is not None
+        return self.symbol._type
+
     def resolve_symbol(
         self, solist: list[Any], thumb=False, extern_object=None, **kwargs
     ):  # pylint: disable=unused-argument
@@ -92,7 +104,7 @@ class Relocation:
         min_size = extern_size_hints.get(self.symbol.name, 0)
 
         new_symbol = extern_object.make_extern(  # type: ignore[union-attr]
-            self.symbol.name, size=min_size, sym_type=self.symbol._type, thumb=thumb
+            self.symbol.name, size=min_size, sym_type=self.extern_symbol_type, thumb=thumb
         )
         self.resolve(new_symbol, extern_object=extern_object)
 

--- a/tests/test_extern.py
+++ b/tests/test_extern.py
@@ -4,6 +4,8 @@ import os
 import unittest
 
 import cle
+from cle.backends.elf.relocation.ppc64 import R_PPC64_JMP_SLOT
+from cle.backends.symbol import SymbolType
 
 TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
@@ -39,6 +41,43 @@ def test_f_finale_extern_size_hints():
     # Verify no overlap: mobjinfo end <= next symbol start
     assert next_sym is not None
     assert mobjinfo.rebased_addr + mobjinfo.size <= next_sym.rebased_addr
+
+
+def test_ppc64_abiv1_untyped_function_import():
+    """An imported function left STT_NOTYPE still needs an ELFv1 function descriptor.
+
+    A jump slot on PowerPC64 ELFv1 holds a whole descriptor rather than an address, so an
+    unresolved import needs one however the symbol table typed it. Deciding that from the
+    declared type gives an untyped import a pointer-sized slot instead, and the descriptor copy
+    then reads past it.
+    """
+    pristine = os.path.join(TESTS_BASE, "tests", "ppc64", "fauxware")
+    untyped = os.path.join(TESTS_BASE, "tests", "ppc64", "fauxware_notype_import")
+
+    def jump_slots(path):
+        """The object, and each of its jump slots paired with the symbol it names."""
+        obj = cle.Loader(path, auto_load_libs=False).main_object
+        slots = []
+        for reloc in obj.relocs:
+            symbol = reloc.symbol
+            if isinstance(reloc, R_PPC64_JMP_SLOT) and symbol is not None:
+                slots.append((symbol, reloc))
+        return obj, slots
+
+    def descriptors(path):
+        obj, slots = jump_slots(path)
+        return {
+            symbol.name: tuple(obj.memory.unpack_word(reloc.relative_addr + offset) for offset in (0, 8, 16))
+            for symbol, reloc in slots
+        }
+
+    # the derived fixture has to still carry the shape, or this test proves nothing
+    _, slots = jump_slots(untyped)
+    assert {s.name for s, _ in slots if s.type is not SymbolType.TYPE_FUNCTION} == {"puts", "exit"}
+
+    expected = descriptors(pristine)
+    assert expected, "the pristine fixture has no jump slots to compare"
+    assert descriptors(untyped) == expected
 
 
 if __name__ == "__main__":

--- a/tests/test_ppc64_initial_rtoc.py
+++ b/tests/test_ppc64_initial_rtoc.py
@@ -41,7 +41,34 @@ def test_ppc64el_abiv1():
     assert ld.main_object.ppc64_initial_rtoc == 0x10018E80
 
 
+def load_relocatable(name):
+    ld = cle.Loader(os.path.join(test_location, "ppc64", name), auto_load_libs=False)
+    main = ld.main_object
+    assert isinstance(main, cle.ELF)
+    assert main.is_ppc64_abiv1
+    assert main.is_relocatable
+    return main
+
+
+def test_ppc64_abiv1_relocatable_mapping_nothing():
+    # e_entry is zero, which is how ELF says there is no entry point, and this object allocates
+    # nothing, so following that zero as a descriptor pointer reads memory that is not there.
+    main = load_relocatable("empty_object.o")
+    assert main.entry == main.mapped_base
+    assert main.ppc64_initial_rtoc is None
+
+
+def test_ppc64_abiv1_relocatable_mapping_code():
+    # The same zero e_entry, with .opd and .text at the start of the image, so following it reads
+    # the object's own first instructions instead of failing.
+    main = load_relocatable("simple_object.o")
+    assert main.entry == main.mapped_base
+    assert main.ppc64_initial_rtoc is None
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     test_ppc64el_abiv1()
     test_ppc64el_abiv2()
+    test_ppc64_abiv1_relocatable_mapping_nothing()
+    test_ppc64_abiv1_relocatable_mapping_code()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Two PowerPC64 ELFv1 objects fail to load outright. On
`binaries/tests/ppc64/fauxware_notype_import`, whose `puts` and `exit` imports are
left `STT_NOTYPE`, and on `binaries/tests/ppc64/empty_object.o`, a relocatable
object with no entry point:

```
--- fauxware_notype_import (an import left STT_NOTYPE)
    EXCEPTION: KeyError: 176
--- empty_object.o (ET_REL, e_entry 0)
    EXCEPTION: KeyError: 0
```

The `KeyError` comes out of `Clemory.unpack`: it is an unmapped-address read, so
the load raises rather than degrading, and neither object can be analysed at all.

### Root cause

Two reads of an ELFv1 function descriptor that assume it is there.

A jump slot on this ABI holds a whole three-word descriptor rather than an
address, and `R_PPC64_JMP_SLOT` copies all three words. The extern the relocation
resolves against is sized from the symbol's declared type:

```python
self.symbol.name, size=min_size, sym_type=self.symbol._type, thumb=thumb
```

An object file is free to leave an imported function `STT_NOTYPE`, and such a
symbol gets a pointer-sized slot; the copy then reads 24 bytes out of 8 -- off the
end of the extern object when the symbol is the last one allocated, and over its
neighbour otherwise.

Second, `_ppc64_abiv1_entry_fix` followed `e_entry` as a descriptor pointer for
every ELFv1 object. A relocatable object has no entry point, which ELF states as
`e_entry == 0`, so the fix-up dereferences address 0.

### Fix

A relocation can now state the type its extern needs, `extern_symbol_type`, and
`R_PPC64_JMP_SLOT` states `TYPE_FUNCTION` -- a jump slot points at a function
whatever the symbol table says. Everything else keeps the declared type. The entry
fix-up is skipped when `e_entry` is zero, which leaves the initial TOC absent
rather than invented.

```
--- fauxware_notype_import (an import left STT_NOTYPE)
    puts: descriptor 0x10100098 0x0 0x0
    exit: descriptor 0x101000d8 0x0 0x0
--- empty_object.o (ET_REL, e_entry 0)
    entry=0x400000 mapped_base=0x400000 ppc64_initial_rtoc=None
```

### Testing

`tests/test_extern.py::test_ppc64_abiv1_untyped_function_import` compares every
jump-slot descriptor of the untyped fixture against the pristine `ppc64/fauxware`
build and requires them equal, after checking the fixture still carries two
untyped imports.
`tests/test_ppc64_initial_rtoc.py::test_ppc64_abiv1_relocatable_mapping_nothing`
and `test_ppc64_abiv1_relocatable_mapping_code` cover the two relocatable shapes
-- one mapping nothing, one with `.opd` and `.text` at the start of the image, so
that following the zero reads real bytes instead of failing. All three raise
`KeyError` on the merge base.

angr 7002 belongs beside this: with the initial TOC absent rather than invented,
that side stops relying on the invented value.

Validation: https://github.com/angr/cle/pull/766#issuecomment-5336786831

sync: angr/binaries#185

session: sharpen
