### PR TITLE
Survive a CIE that declares no FDE encoding

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -625,7 +625,11 @@ class ELF(MetaELF):
                             source,
                         )
                     )
-        except (DWARFError, ValueError):
+        except (DWARFError, ValueError, KeyError):
+            # KeyError: pyelftools reads a CIE's FDE_encoding unconditionally, but the "R"
+            # augmentation that defines it is optional, so a CIE without one raises rather than
+            # falling back to the default pointer encoding. Losing the unwind hints for such an
+            # object is survivable; failing its load is not.
             log.warning("An exception occurred in pyelftools when loading FDE information.", exc_info=True)
 
     def _load_exception_handling(self, dwarf):
@@ -666,7 +670,11 @@ class ELF(MetaELF):
                         )
                         self.exception_handlings.append(handling)
 
-        except (DWARFError, ValueError):
+        except (DWARFError, ValueError, KeyError):
+            # KeyError: pyelftools reads a CIE's FDE_encoding unconditionally, but the "R"
+            # augmentation that defines it is optional, so a CIE without one raises rather than
+            # falling back to the default pointer encoding. Losing the unwind hints for such an
+            # object is survivable; failing its load is not.
             log.warning("An exception occurred in pyelftools when loading FDE information.", exc_info=True)
 
     def _load_line_info(self, dwarf):

--- a/tests/test_dwarf_resiliency.py
+++ b/tests/test_dwarf_resiliency.py
@@ -14,6 +14,17 @@ class TestDwarfResiliency(TestCase):
         binary_path = os.path.join(TESTS_BASE, "i386", "dwarf_resiliency_0")
         _ = cle.Loader(binary_path, auto_load_libs=False, load_debug_info=True)
 
+    def test_fde_without_encoding_augmentation(self):
+        """A CIE may omit the "R" augmentation, and then its FDEs have no explicit encoding.
+
+        pyelftools reads that encoding unconditionally and raises KeyError, which used to escape
+        the FDE reader and fail the whole load whenever debug information was requested.
+        """
+        for arch in ("mips", "mipsel"):
+            binary_path = os.path.join(TESTS_BASE, arch, "busybox")
+            loader = cle.Loader(binary_path, auto_load_libs=False, load_debug_info=True)
+            assert loader.main_object is not None
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

An object whose unwind tables cannot be read becomes an object that cannot be
loaded. `binaries/tests/mips/busybox` and `binaries/tests/mipsel/busybox` with
`load_debug_info=True`:

```
mips/busybox: EXCEPTION: KeyError: 'FDE_encoding'
mipsel/busybox: EXCEPTION: KeyError: 'FDE_encoding'
```

Nothing about these binaries is unusual apart from one CIE, and the whole load
fails: no sections, no symbols, no debug information, on a binary that is
otherwise entirely readable.

### Root cause

The `R` augmentation that gives a CIE its FDE encoding is optional. pyelftools
reads it unconditionally:

```python
cie.augmentation_dict['FDE_encoding']
```

and raises `KeyError` where a correct reader would fall back to the default
pointer encoding. cle's handler around the FDE walk was written for exactly this
class of failure but does not list that exception:

```python
        except (DWARFError, ValueError):
            log.warning("An exception occurred in pyelftools when loading FDE information.", exc_info=True)
```

so the `KeyError` escapes past it and out of `ELF.__init__`.

### Fix

Catch `KeyError` alongside the others, in `_load_function_hints_from_fde` and in
`_load_exception_handling`, which is guarded by the same handler and reads the
same CIEs. The existing warning is kept, so the loss is still reported. The unwind
hints are lost either way; the load no longer is.

```
mips/busybox: loaded, 19 sections, 0 .eh_frame hints
mipsel/busybox: loaded, 22 sections, 0 .eh_frame hints
```

This is resilience against a dependency, not a fix for the cause: a CIE without
`R` should yield `DW_EH_PE_absptr` rather than raising, which is pyelftools' to
correct.

### Testing

`tests/test_dwarf_resiliency.py::TestDwarfResiliency::test_fde_without_encoding_augmentation`
loads both binaries with `load_debug_info=True` and asserts the main object
exists; both raise `KeyError` on the merge base. Both fixtures are already on
binaries master, so this needs no new test input.

Validation: https://github.com/angr/cle/pull/768#issuecomment-5337190982

session: sharpen
