### PR TITLE
ELF: Read a line program in the DWARF format it declares

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -17,7 +17,9 @@ from elftools.dwarf.descriptions import describe_attr_value, describe_form_class
 from elftools.dwarf.die import DIE
 from elftools.dwarf.dwarf_expr import DWARFExprParser
 from elftools.dwarf.dwarfinfo import DWARFInfo
+from elftools.dwarf.lineprogram import LineProgram
 from elftools.dwarf.ranges import BaseAddressEntry, RangeEntry
+from elftools.dwarf.structs import DWARFStructs
 from elftools.elf import dynamic, elffile, enums, sections
 from elftools.elf.relocation import RelocationSection, RelrRelocationSection
 from sortedcontainers import SortedDict
@@ -669,6 +671,34 @@ class ELF(MetaELF):
         except (DWARFError, ValueError):
             log.warning("An exception occurred in pyelftools when loading FDE information.", exc_info=True)
 
+    @staticmethod
+    def _line_program_for_cu(dwarf: DWARFInfo, cu: CompileUnit) -> LineProgram | None:
+        """
+        Fetch the line program a compilation unit points at, decoded in the DWARF format the line
+        program declares for itself.
+
+        Each unit chooses the 32-bit or the 64-bit DWARF format in its own initial length field, so a
+        compilation unit may reference a line program that made the other choice. pyelftools decodes
+        the line program header with the compilation unit's structures, which reads a header length of
+        the wrong width and shifts every field behind it.
+        """
+        top_die = cu.get_top_DIE()
+        if "DW_AT_stmt_list" not in top_die.attributes or dwarf.debug_line_sec is None:
+            return None
+        offset = top_die.attributes["DW_AT_stmt_list"].value
+
+        structs = cu.structs
+        dwarf.debug_line_sec.stream.seek(offset)
+        dwarf_format = 64 if dwarf.debug_line_sec.stream.read(4) == b"\xff\xff\xff\xff" else 32
+        if dwarf_format != structs.dwarf_format:
+            structs = DWARFStructs(
+                little_endian=structs.little_endian,
+                dwarf_format=dwarf_format,
+                address_size=structs.address_size,
+                dwarf_version=structs.dwarf_version,
+            )
+        return dwarf._parse_line_program_at_offset(offset, structs)  # pylint:disable=protected-access
+
     def _load_line_info(self, dwarf):
         """
         Generates addr_to_line as a mapping: addr -> (filename, lineno).
@@ -684,7 +714,7 @@ class ELF(MetaELF):
             if "DW_AT_comp_dir" in die.attributes:
                 comp_dir = die.attributes["DW_AT_comp_dir"].value.decode()
             try:
-                lineprog = dwarf.line_program_for_CU(cu)
+                lineprog = self._line_program_for_cu(dwarf, cu)
             except ELFParseError:
                 continue
             if lineprog is None:
@@ -889,7 +919,7 @@ class ELF(MetaELF):
             filename_idx = None
 
         if filename_idx is not None:
-            debug_line = dwarf.line_program_for_CU(cu)
+            debug_line = self._line_program_for_cu(dwarf, cu)
             assert debug_line is not None
             if debug_line.header.file_names is not None:
                 basename = debug_line.header.file_names[filename_idx]

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -35,6 +35,18 @@ class TestDwarf(TestCase):
         assert inlined[0].low_pc == 0x43FC49
         assert inlined[0].high_pc == 0x43FEE8
 
+    def test_dwarf64_line_program(self):
+        # The .debug_line units of this binary use the 64-bit DWARF format while the compilation
+        # units that reference them use the 32-bit one.
+        binary_path = os.path.join(TESTS_BASE, "mips64", "true")
+        ld = cle.Loader(binary_path, auto_load_libs=False, load_debug_info=True)
+        elf = ld.main_object
+        assert isinstance(elf, cle.backends.ELF)
+        subroutine = elf.functions_debug_info[0x12000206C]
+        assert subroutine.name == "main"
+        assert subroutine.source_file == "src/true.c"
+        assert ("/home/qinfan/coreutils/coreutils-8.32/src/true.c", 56) in elf.addr_to_line[0x12000206C]
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`binaries/tests/mips64/true` cannot be loaded with debug information:

```
EXCEPTION: IndexError: list index out of range
  raised at: File ".../cle/backends/elf/elf.py", line 902, in _load_die_lex_block
```

The index is into the line program's file table, which came out empty. The
exception escapes the load, so the binary is unusable with
`load_debug_info=True` -- no DIEs, no symbols from debug information, no line
table.

### Root cause

Every DWARF unit chooses the 32-bit or the 64-bit format in its own initial
length field, and a compilation unit may reference a line program that made the
other choice. This binary is exactly that: 32-bit compilation units pointing at
64-bit `.debug_line` units. pyelftools decodes the line program with the
compilation unit's structures:

```python
lineprog = dwarf.line_program_for_CU(cu)
```

`line_program_for_CU` passes `cu.structs`, so the header's `unit_length` and
`header_length` are read at 4 bytes where the unit wrote 12, and every field
behind them shifts. The file table parses to nothing, and `_load_die_lex_block`
indexes it.

### Fix

`_line_program_for_cu` reads the format from the line program's own initial length
-- `0xffffffff` marking the 64-bit form -- and reparses with matching
`DWARFStructs` when the two disagree. Both call sites use it. When the two agree,
which is the overwhelmingly common case, it is `cu.structs` and the call is
what it was.

```
main at 0x12000206c: name='main' source_file='src/true.c'
addr_to_line[0x12000206c] = [('/home/qinfan/coreutils/coreutils-8.32/src/true.c', 56)]
```

The defect is pyelftools', still present on its master, so this is a workaround at
the call site rather than a fix at the cause.

### Testing

`tests/test_dwarf.py::TestDwarf::test_dwarf64_line_program` loads the binary with
`load_debug_info=True` and asserts the name, the source file and the line number
above; it raises `IndexError` on the merge base. The fixture is already on
binaries master.

Validation: https://github.com/angr/cle/pull/770#issuecomment-5338335328

session: sharpen
