### PR TITLE
ELF: Search /usr/lib/debug for a separate debug file

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -17,7 +17,9 @@ from elftools.dwarf.descriptions import describe_attr_value, describe_form_class
 from elftools.dwarf.die import DIE
 from elftools.dwarf.dwarf_expr import DWARFExprParser
 from elftools.dwarf.dwarfinfo import DWARFInfo
+from elftools.dwarf.lineprogram import LineProgram
 from elftools.dwarf.ranges import BaseAddressEntry, RangeEntry
+from elftools.dwarf.structs import DWARFStructs
 from elftools.elf import dynamic, elffile, enums, sections
 from elftools.elf.relocation import RelocationSection, RelrRelocationSection
 from sortedcontainers import SortedDict
@@ -669,6 +671,34 @@ class ELF(MetaELF):
         except (DWARFError, ValueError):
             log.warning("An exception occurred in pyelftools when loading FDE information.", exc_info=True)
 
+    @staticmethod
+    def _line_program_for_cu(dwarf: DWARFInfo, cu: CompileUnit) -> LineProgram | None:
+        """
+        Fetch the line program a compilation unit points at, decoded in the DWARF format the line
+        program declares for itself.
+
+        Each unit chooses the 32-bit or the 64-bit DWARF format in its own initial length field, so a
+        compilation unit may reference a line program that made the other choice. pyelftools decodes
+        the line program header with the compilation unit's structures, which reads a header length of
+        the wrong width and shifts every field behind it.
+        """
+        top_die = cu.get_top_DIE()
+        if "DW_AT_stmt_list" not in top_die.attributes or dwarf.debug_line_sec is None:
+            return None
+        offset = top_die.attributes["DW_AT_stmt_list"].value
+
+        structs = cu.structs
+        dwarf.debug_line_sec.stream.seek(offset)
+        dwarf_format = 64 if dwarf.debug_line_sec.stream.read(4) == b"\xff\xff\xff\xff" else 32
+        if dwarf_format != structs.dwarf_format:
+            structs = DWARFStructs(
+                little_endian=structs.little_endian,
+                dwarf_format=dwarf_format,
+                address_size=structs.address_size,
+                dwarf_version=structs.dwarf_version,
+            )
+        return dwarf._parse_line_program_at_offset(offset, structs)  # pylint:disable=protected-access
+
     def _load_line_info(self, dwarf):
         """
         Generates addr_to_line as a mapping: addr -> (filename, lineno).
@@ -684,7 +714,7 @@ class ELF(MetaELF):
             if "DW_AT_comp_dir" in die.attributes:
                 comp_dir = die.attributes["DW_AT_comp_dir"].value.decode()
             try:
-                lineprog = dwarf.line_program_for_CU(cu)
+                lineprog = self._line_program_for_cu(dwarf, cu)
             except ELFParseError:
                 continue
             if lineprog is None:
@@ -889,7 +919,7 @@ class ELF(MetaELF):
             filename_idx = None
 
         if filename_idx is not None:
-            debug_line = dwarf.line_program_for_CU(cu)
+            debug_line = self._line_program_for_cu(dwarf, cu)
             assert debug_line is not None
             if debug_line.header.file_names is not None:
                 basename = debug_line.header.file_names[filename_idx]

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -230,7 +230,8 @@ class ELF(MetaELF):
                 if dwarf.has_EH_CFI():
                     self._load_function_hints_from_fde(dwarf, FunctionHintSource.EH_FRAME)
                     self._load_exception_handling(dwarf)
-                    self._load_line_info(dwarf)
+                # Load line information out of .debug_line
+                self._load_line_info(dwarf)
 
         if debug_symbols:
             self.__process_debug_file(debug_symbols)
@@ -240,7 +241,7 @@ class ELF(MetaELF):
                 if os.path.isfile(debug_filename):
                     self.__process_debug_file(debug_filename)
             if self.binary:
-                debug_filename = os.path.join("/usr/lib/debug", os.path.realpath(self.binary))
+                debug_filename = "/usr/lib/debug" + os.path.realpath(self.binary)
                 if os.path.isfile(debug_filename):
                     self.__process_debug_file(debug_filename)
 

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -35,6 +35,18 @@ class TestDwarf(TestCase):
         assert inlined[0].low_pc == 0x43FC49
         assert inlined[0].high_pc == 0x43FEE8
 
+    def test_dwarf64_line_program(self):
+        # The .debug_line units of this binary use the 64-bit DWARF format while the compilation
+        # units that reference them use the 32-bit one.
+        binary_path = os.path.join(TESTS_BASE, "mips64", "true")
+        ld = cle.Loader(binary_path, auto_load_libs=False, load_debug_info=True)
+        elf = ld.main_object
+        assert isinstance(elf, cle.backends.ELF)
+        subroutine = elf.functions_debug_info[0x12000206C]
+        assert subroutine.name == "main"
+        assert subroutine.source_file == "src/true.c"
+        assert ("/home/qinfan/coreutils/coreutils-8.32/src/true.c", 56) in elf.addr_to_line[0x12000206C]
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_dwarf.py
+++ b/tests/test_dwarf.py
@@ -47,6 +47,16 @@ class TestDwarf(TestCase):
         assert subroutine.source_file == "src/true.c"
         assert ("/home/qinfan/coreutils/coreutils-8.32/src/true.c", 56) in elf.addr_to_line[0x12000206C]
 
+    def test_line_info_without_eh_frame(self):
+        # This binary carries .debug_line and no .eh_frame, and a stream has no file name to look
+        # a separate debug file up by.
+        binary_path = os.path.join(TESTS_BASE, "armel", "efm32gg.elf")
+        with open(binary_path, "rb") as stream:
+            ld = cle.Loader(stream, auto_load_libs=False, load_debug_info=True)
+        elf = ld.main_object
+        assert isinstance(elf, cle.backends.ELF)
+        assert ("/home/tobi/research/mbed-os-projects/basic_exercises/main.cpp", 31) in elf.addr_to_line[0x20A2]
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Draft until #770 merges: this branch carries that commit, so the diff shows it
too, and validation reruns once it is rebased onto master.

An ELF loaded from a stream gets no line information at all, and `/usr/lib/debug`
has never been searched. Loading `binaries/tests/armel/efm32gg.elf` from an open
file object with `load_debug_info=True`:

```
efm32gg.elf from a stream: 0 addresses with line info
addr_to_line[0x20a2] = <absent>
```

The binary carries a full `.debug_line`. Worse, for an ELF loaded by path the
lookup that was meant to find a separate debug file resolves to the binary
itself, so every such ELF is opened and walked a second time as its own debug
file. On `binaries/tests/x86_64/fauxware` that shows up as a doubled symbol
table -- `165 symbols, 53 names appearing twice+` where the file has 83 -- and on
`binaries/tests/i386/oxfoo1m3` the second pass is fatal:

```
--- i386/oxfoo1m3, whose reopened copy carries a compressed section header
    EXCEPTION: elftools.common.exceptions.ELFParseError: expected 4, found 0
```

### Root cause

Two independent mistakes.

```python
debug_filename = os.path.join("/usr/lib/debug", os.path.realpath(self.binary))
```

`os.path.join` drops everything before an absolute component, so this is
`os.path.realpath(self.binary)` -- the binary. The global debug directory has
never been searched, and instead the object reprocesses itself, registering its
symbol table twice and reparsing sections pyelftools rejects on a second pass.

And the line table is loaded only inside the `.eh_frame` branch:

```python
                if dwarf.has_EH_CFI():
                    self._load_function_hints_from_fde(dwarf, FunctionHintSource.EH_FRAME)
                    self._load_exception_handling(dwarf)
                    self._load_line_info(dwarf)
```

`.debug_line` does not depend on `.eh_frame`. An object without unwind tables got
its `addr_to_line` only as a side effect of the accidental second pass, which a
stream-loaded object never gets because there is no file name to look up.

### Fix

Concatenate rather than join, the way gdb builds a global debug directory path,
and move `_load_line_info` out of the `.eh_frame` condition.

```
efm32gg.elf from a stream: 1935 addresses with line info
addr_to_line[0x20a2] = [('/home/tobi/research/mbed-os-projects/basic_exercises/main.cpp', 31)]
--- i386/oxfoo1m3, whose reopened copy carries a compressed section header
    loaded: 0 sections
```

`fauxware` loses the duplicates with it: `83 symbols, 3 names appearing twice+`.

### Testing

`tests/test_dwarf.py::TestDwarf::test_line_info_without_eh_frame` loads
`efm32gg.elf` from a stream and asserts the `0x20a2` entry above; `addr_to_line`
is empty on the parent commit.

Validation: https://github.com/angr/cle/pull/771#issuecomment-5338493418

session: sharpen
