### PR TITLE
ELF: Do not crash on a relocation section whose symtab was stripped.

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1296,6 +1296,16 @@ class ELF(MetaELF):
         if isinstance(symtab, sections.NullSection):
             # Oh my god Atmel please stop
             symtab = self._reader.get_section_by_name(".symtab")
+        if symtab is None and section.header.get("sh_type") != "SHT_RELR":
+            # A stripped object can still carry a relocation section whose linked symbol table was stripped away.
+            # Without the table there is nothing that can be registered.
+            # RELR sections are exempt: their entries carry no symbol index.
+            log.warning(
+                "%s: relocation section %s has no symbol table to resolve its entries against; skipping it.",
+                self.binary,
+                section.name,
+            )
+            return
         relocs = []
         for readelf_reloc in section.iter_relocations():
             # Handle packed RELR relocations specially

--- a/tests/test_arm_firmware.py
+++ b/tests/test_arm_firmware.py
@@ -49,3 +49,17 @@ def test_thumb_object():
 if __name__ == "__main__":
     test_thumb_object()
     test_empty_segements()
+
+
+def test_stripped_relocation_section_without_symtab():
+    """
+    Test for bizarre ELves: a stripped Cortex-M firmware that still carries a relocation section.
+
+    ``strip --strip-all`` removes the symbol table but leaves the ``.rel`` section behind, so the section's sh_link
+    points at nothing. Every entry there is indexed by symbol, so there is nothing to register -- but loading the
+    binary must not blow up.
+    """
+    path = os.path.join(test_location, "armel", "fpijr_cortexm_console_stripped")
+    ld = cle.Loader(path, auto_load_libs=False)
+    # If we survive this, we're doing OK. The relocation section carries no resolvable entries.
+    assert ld.main_object is not None


### PR DESCRIPTION
strip --strip-all removes the symbol table but leaves relocation sections in place, so the section's sh_link resolves to a NullSection and the .symtab fallback finds nothing. __register_relocs() then passed None as the symbol table to get_symbol(), which raises TypeError, making the binary unloadable.