### PR TITLE
Relocate R_*_RELATIVE against the load bias, not the mapped base

### DIFF
--- a/cle/backends/elf/relocation/generic.py
+++ b/cle/backends/elf/relocation/generic.py
@@ -152,7 +152,9 @@ class GenericRelativeReloc(ELFReloc):
     def value(self):
         if self.resolvedby is not None:
             return self.resolvedby.rebased_addr
-        return self.owner.mapped_base + self.addend
+        # B + A, where B is the load bias (mapped_base - linked_base) and A is a
+        # link-time virtual address.
+        return AT.from_lva(self.addend, self.owner).to_mva()
 
 
 class GenericAbsoluteReloc(ELFReloc):

--- a/tests/test_relative_relocations.py
+++ b/tests/test_relative_relocations.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import os
+
+import cle
+from cle.backends.elf.relocation.amd64 import R_X86_64_RELATIVE
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
+
+# The fixture is a shared object linked with -Wl,-Ttext-segment=0x400000, so its
+# lowest PT_LOAD sits at 0x400000 rather than at zero. Its three
+# R_X86_64_RELATIVE relocations fill a pointer table with the addresses of
+# alpha, beta and delta.
+FIXTURE = os.path.join(TEST_BASE, "x86_64", "relative_reloc_nonzero_base.so")
+POINTEES = ("alpha", "beta", "delta")
+
+
+def check_relative_pointer_table(base_addr):
+    """An R_*_RELATIVE relocation writes the load bias plus the addend.
+
+    The bias is ``mapped_base - linked_base``. CLE used to write
+    ``mapped_base + addend``, which is the same number only when the object was
+    linked at zero -- the case for an ordinary shared library, and not the case
+    for a PIE the linker gave a non-zero text segment address. On such an object
+    every relative relocation landed ``linked_base`` bytes too high, so pointer
+    tables in .data.rel.ro pointed past the end of the image.
+    """
+    main_opts = {"backend": "elf"}
+    if base_addr is not None:
+        main_opts["base_addr"] = base_addr
+    ld = cle.Loader(FIXTURE, auto_load_libs=False, main_opts=main_opts)
+    obj = ld.main_object
+
+    assert obj.linked_base == 0x400000
+    relocs = [r for r in obj.relocs if isinstance(r, R_X86_64_RELATIVE)]
+    assert len(relocs) == len(POINTEES)
+
+    table = obj.get_symbol("table")
+    assert table is not None
+    for index, name in enumerate(POINTEES):
+        pointee = obj.get_symbol(name)
+        assert pointee is not None
+        word = ld.memory.unpack_word(table.rebased_addr + index * obj.arch.bytes)
+        assert word == pointee.rebased_addr
+        assert obj.min_addr <= word <= obj.max_addr
+        pointed_at = ld.find_symbol(word)
+        assert pointed_at is not None and pointed_at.name == name
+
+
+def test_relative_relocation_at_the_linked_base():
+    # mapped_base == linked_base, so the bias is zero and the addend is the answer.
+    check_relative_pointer_table(None)
+
+
+def test_relative_relocation_rebased():
+    # A non-zero bias on top of a non-zero linked base: the two terms the old
+    # expression conflated are both non-zero and different.
+    check_relative_pointer_table(0x1000000)
+
+
+def test_relative_relocation_at_a_zero_linked_base():
+    """An object linked at zero relocates exactly as it did before.
+
+    A modern toolchain links every shared library and almost every PIE at zero,
+    where the bias and the mapped base are the same number. That is why a loader
+    can confuse the two and stay correct on nearly everything, and it is the case
+    this must leave alone.
+    """
+    libc = os.path.join(TEST_BASE, "x86_64", "libc.so.6")
+    ld = cle.Loader(libc, auto_load_libs=False, main_opts={"backend": "elf", "base_addr": 0x5000000})
+    obj = ld.main_object
+
+    assert obj.linked_base == 0
+    relocs = [r for r in obj.relocs if isinstance(r, R_X86_64_RELATIVE) and r.resolvedby is None]
+    assert relocs
+    for reloc in relocs:
+        assert reloc.value == obj.mapped_base + reloc.addend
+        assert obj.min_addr <= reloc.value <= obj.max_addr
+
+
+if __name__ == "__main__":
+    test_relative_relocation_at_the_linked_base()
+    test_relative_relocation_rebased()
+    test_relative_relocation_at_a_zero_linked_base()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Every `R_*_RELATIVE` relocation in an object the linker gave a non-zero text
segment address is written too high, by the linked base. On
`binaries/tests/x86_64/relative_reloc_nonzero_base.so`, linked with
`-Wl,-Ttext-segment=0x400000`, the three-entry pointer table in `.data.rel.ro`
points outside the image:

```
linked_base=0x400000 mapped_base=0x400000 image 0x400000-0x403fff
    table[0] = 0x801000   alpha = 0x401000   WRONG, OUTSIDE the image
    table[1] = 0x801010   beta = 0x401010   WRONG, OUTSIDE the image
    table[2] = 0x801020   delta = 0x401020   WRONG, OUTSIDE the image
```

That is the shape Go's linker emits. A pointer table that lands outside the image
is not a silent inaccuracy: CFGFast follows it, and the addresses resolve into
cle's extern object, so blocks get decoded out of zero fill while the real switch
targets lose their only in-edge.

### Root cause

```python
    def value(self):
        if self.resolvedby is not None:
            return self.resolvedby.rebased_addr
        return self.owner.mapped_base + self.addend
```

The ELF ABI defines this relocation as `B + A`, where `B` is the **load bias** --
`mapped_base - linked_base` -- and `A` is a link-time virtual address.
`mapped_base + addend` is the same number only when `linked_base` is zero, which
is the case for every ordinary shared library and almost every PIE. That is why
the confusion survives: it is correct on nearly everything.

### Fix

Use the load-bias translation that `GenericIRelativeReloc` in the same file
already uses, `AT.from_lva(self.addend, self.owner).to_mva()`. The branch for a
relocation that resolved to a symbol is untouched.

```
linked_base=0x400000 mapped_base=0x400000 image 0x400000-0x403fff
    table[0] = 0x401000   alpha = 0x401000   ok, inside the image
    table[1] = 0x401010   beta = 0x401010   ok, inside the image
    table[2] = 0x401020   delta = 0x401020   ok, inside the image
linked_base=0x400000 mapped_base=0x1000000 image 0x1000000-0x1003fff
    table[0] = 0x1001000   alpha = 0x1001000   ok, inside the image
    table[1] = 0x1001010   beta = 0x1001010   ok, inside the image
    table[2] = 0x1001020   delta = 0x1001020   ok, inside the image
```

The angr-side issue https://github.com/angr/angr/issues/6889 addresses only the
first half of the damage, the blocks decoded out of the extern object.

### Testing

`tests/test_relative_relocations.py` loads the fixture at its preferred base and
rebased -- so that the two terms the old expression conflated are both non-zero
and different -- and checks each table entry against the symbol it should name.
`test_relative_relocation_at_a_zero_linked_base` is the negative case on
`binaries/tests/x86_64/libc.so.6`, which must not move. The first two fail on the
merge base. Reported as https://github.com/angr/angr/issues/6834.

Validation: https://github.com/angr/cle/pull/773#issuecomment-5379590154

sync: angr/binaries#188

session: sharpen
