### PR TITLE
UEFI: Load every FFS file type that carries a module image

### DIFF
--- a/cle/backends/te.py
+++ b/cle/backends/te.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import struct
 from collections import namedtuple
+from typing import cast
 
 import archinfo
 
 from . import Backend, Section, register_backend
 from .coff import IMAGE_SCN
+from .region import Segment
+from .regions import Regions
 
 HEADER = struct.Struct("<HHBBHIIQIIII")
 SECTION_HEADER = struct.Struct("<8sIIIIIIHHI")
@@ -118,7 +121,6 @@ class TE(Backend):
         # an RVA, in the same space as the section virtual addresses below
         self._entry = self.linked_base + self.header.address_of_entry_point
 
-        has_relocs = False
         for section_header in self.section_headers:
             section = TESection(section_header, self.linked_base, stripped_offset)
             self._sections.append(section)
@@ -136,12 +138,12 @@ class TE(Backend):
             data = data.ljust(section.memsize, b"\0")
             self.memory.add_backer(section_header.virtual_address, data)
 
-            if section_header.number_of_relocations != 0:
-                has_relocs = True
+        # in a TE image, as in the PE image it was stripped from, sections and segments have the same meaning
+        self._segments = cast(Regions[Segment], self._sections)
 
-        self._segments = self._sections
-
-        self.pic = has_relocs
+        # the TE header's first data directory is the base relocation table, so an image with relocation entries
+        # can be rebased
+        self.pic = self.header.data_directory_0_size != 0
 
 
 register_backend("te", TE)

--- a/cle/backends/uefi_firmware.py
+++ b/cle/backends/uefi_firmware.py
@@ -4,6 +4,7 @@ import io
 import logging
 import mmap
 from dataclasses import dataclass
+from enum import IntEnum
 from typing import cast
 from uuid import UUID
 
@@ -27,6 +28,29 @@ class UefiDriverLoadError(Exception):
     """
     This error is raised (and caught internally) if the data contained in the UEFI entity tree doesn't make sense.
     """
+
+
+class ModuleFileType(IntEnum):
+    """
+    The FFS file types that encapsulate an executable module image.
+
+    The UEFI Platform Initialization specification, volume 3, requires a file of each of these types to contain
+    exactly one PE32 or TE section, which is the image this backend loads. The file types left out hold data
+    (RAW, FREEFORM), padding, or a nested firmware volume, which the tree walk descends into on its own.
+    """
+
+    SECURITY_CORE = 0x03
+    PEI_CORE = 0x04
+    DXE_CORE = 0x05
+    PEIM = 0x06
+    DRIVER = 0x07
+    COMBINED_PEIM_DRIVER = 0x08
+    APPLICATION = 0x09
+    MM = 0x0A
+    COMBINED_MM_DXE = 0x0C
+    MM_CORE = 0x0D
+    MM_STANDALONE = 0x0E
+    MM_CORE_STANDALONE = 0x0F
 
 
 class UefiFirmware(Backend):
@@ -93,6 +117,10 @@ class UefiFirmware(Backend):
                 child.parent_object = self
                 self.child_objects.append(child)
 
+        # a module with no base relocations can only be mapped where it was linked, so let those claim their
+        # addresses before the relocatable ones are packed around them
+        self.child_objects.sort(key=lambda child: child.pic)
+
         if self.child_objects:
             self._arch = self.child_objects[0].arch
         else:
@@ -113,7 +141,7 @@ class UefiFirmware(Backend):
         is_firmware_file = isinstance(uefi_obj, uefi_firmware.uefi.FirmwareFile)
         old_uuid = self._current_file
         if is_firmware_file:
-            if uefi_obj.type == 7:  # driver
+            if uefi_obj.type in ModuleFileType:
                 uuid = UUID(bytes=uefi_obj.guid)
                 self._drivers_pending[uuid] = UefiModulePending()
                 self._current_file = uuid

--- a/tests/test_uefi_modules.py
+++ b/tests/test_uefi_modules.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import collections
 import os
+import sys
+import unittest
 
 import cle
 from cle.backends.uefi_firmware import UefiPE, UefiTE
@@ -17,6 +19,7 @@ from cle.backends.uefi_firmware import UefiPE, UefiTE
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 # an EDK2 ArmVirtQemu build: DXE drivers and applications as PE32, the SEC core and the PEI phase as TE
 FIRMWARE = os.path.join(TEST_BASE, "tests", "aarch64", "edk2_armvirtqemu.fd")
+requires_uefi_firmware = unittest.skipIf(sys.platform == "emscripten", "uefi-firmware is unavailable in Pyodide")
 
 
 def load():
@@ -27,6 +30,7 @@ def modules_by_name(firmware):
     return {module.user_interface_name: module for module in firmware.child_objects}
 
 
+@requires_uefi_firmware
 def test_every_module_type_loads():
     firmware = load()
 
@@ -38,6 +42,7 @@ def test_every_module_type_loads():
     }
 
 
+@requires_uefi_firmware
 def test_pei_phase_modules():
     firmware = load()
 
@@ -56,6 +61,7 @@ def test_pei_phase_modules():
     }
 
 
+@requires_uefi_firmware
 def test_dxe_core_and_applications():
     modules = modules_by_name(load())
 
@@ -64,6 +70,7 @@ def test_dxe_core_and_applications():
         assert isinstance(modules[name], UefiPE)
 
 
+@requires_uefi_firmware
 def test_real_te_image():
     firmware = load()
     module = modules_by_name(firmware)["MemoryInit"]
@@ -77,6 +84,7 @@ def test_real_te_image():
     assert firmware.loader.memory.load(module.entry, 8) == b"\xff\x43\x03\xd1\xfd\x7b\x07\xa9"
 
 
+@requires_uefi_firmware
 def test_relocatable_te_image():
     module = modules_by_name(load())["Tcg2Pei"]
 
@@ -85,6 +93,7 @@ def test_relocatable_te_image():
     assert module.pic
 
 
+@requires_uefi_firmware
 def test_execute_in_place_modules_keep_their_addresses():
     firmware = load()
 

--- a/tests/test_uefi_modules.py
+++ b/tests/test_uefi_modules.py
@@ -1,0 +1,105 @@
+"""
+Tests for the modules cle loads out of a UEFI firmware volume.
+
+A volume holds one FFS file per module, and the file's type says which boot phase the module belongs to, not
+whether it is executable. SEC, PEI and DXE phase modules are all loadable images, and the PEI phase ones are
+where a real toolchain emits TE rather than PE32.
+"""
+
+from __future__ import annotations
+
+import collections
+import os
+
+import cle
+from cle.backends.uefi_firmware import UefiPE, UefiTE
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
+# an EDK2 ArmVirtQemu build: DXE drivers and applications as PE32, the SEC core and the PEI phase as TE
+FIRMWARE = os.path.join(TEST_BASE, "tests", "aarch64", "edk2_armvirtqemu.fd")
+
+
+def load():
+    return cle.Loader(FIRMWARE, auto_load_libs=False).main_object
+
+
+def modules_by_name(firmware):
+    return {module.user_interface_name: module for module in firmware.child_objects}
+
+
+def test_every_module_type_loads():
+    firmware = load()
+
+    # the volume's DXE drivers are PE32 and its SEC and PEI phase modules are TE; loading only one FFS file type
+    # would leave a whole class of module out of the image
+    assert collections.Counter(type(module).__name__ for module in firmware.child_objects) == {
+        "UefiPE": 96,
+        "UefiTE": 10,
+    }
+
+
+def test_pei_phase_modules():
+    firmware = load()
+
+    # the SEC core carries no user interface name, so it is the None entry
+    assert {name for name, module in modules_by_name(firmware).items() if isinstance(module, UefiTE)} == {
+        None,
+        "PeiCore",
+        "PlatformPei",
+        "MemoryInit",
+        "CpuPei",
+        "DxeIpl",
+        "PcdPeim",
+        "ResetSystemPei",
+        "Tcg2ConfigPei",
+        "Tcg2Pei",
+    }
+
+
+def test_dxe_core_and_applications():
+    modules = modules_by_name(load())
+
+    # a DXE core file and an application file are PE32 like a driver is, and were dropped along with the TE modules
+    for name in ("DxeCore", "UiApp", "BootManagerMenuApp"):
+        assert isinstance(modules[name], UefiPE)
+
+
+def test_real_te_image():
+    firmware = load()
+    module = modules_by_name(firmware)["MemoryInit"]
+
+    assert module.arch.name == "AARCH64"
+    assert [section.name for section in module.sections] == [".text", ".data"]
+
+    text = next(section for section in module.sections if section.name == ".text")
+    assert text.contains_addr(module.entry)
+    # sub sp, sp, #0xd0; stp x29, x30, [sp, #0x70]
+    assert firmware.loader.memory.load(module.entry, 8) == b"\xff\x43\x03\xd1\xfd\x7b\x07\xa9"
+
+
+def test_relocatable_te_image():
+    module = modules_by_name(load())["Tcg2Pei"]
+
+    # a TE image records its relocatability in the base relocation directory, not in the section table
+    assert ".reloc" in [section.name for section in module.sections]
+    assert module.pic
+
+
+def test_execute_in_place_modules_keep_their_addresses():
+    firmware = load()
+
+    # a module with no base relocations only makes sense at the address it was linked for, so it has to be mapped
+    # there rather than packed in wherever the relocatable modules left room
+    fixed = [module for module in firmware.child_objects if not module.pic]
+    assert fixed
+    for module in fixed:
+        assert module.mapped_base == module.linked_base
+
+
+if __name__ == "__main__":
+    test_every_module_type_loads()
+    test_pei_phase_modules()
+    test_dxe_core_and_applications()
+    test_real_te_image()
+    test_relocatable_te_image()
+    test_execute_in_place_modules_keep_their_addresses()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A UEFI firmware volume loads only its DXE drivers. On
`binaries/tests/aarch64/edk2_armvirtqemu.fd`, an EDK2 ArmVirtQemu build:

```
child modules: {'UefiPE': 93}
TE modules (0): <none>
DxeCore: <not loaded>
UiApp: <not loaded>
BootManagerMenuApp: <not loaded>
```

The DXE core, the SEC core, the PEI core and every PEIM and application are
missing from the loaded image. The PEI-phase files are where a real toolchain
emits TE images, so `UefiTE` was unreachable for any genuine firmware volume --
the backend had no coverage against real toolchain output at all.

### Root cause

The gate names one FFS file type:

```python
            if uefi_obj.type == 7:  # driver
```

An FFS file's type says which boot phase the module belongs to, not whether it is
executable. Type 7 is `EFI_FV_FILETYPE_DRIVER`; `SECURITY_CORE` (3), `PEI_CORE`
(4), `DXE_CORE` (5), `PEIM` (6), `APPLICATION` (9) and the MM types are all
module files that the Platform Initialization specification, volume 3, requires
to hold exactly one PE32 or TE section.

Two further defects kept the TE modules unloadable once reached. `TE` took `pic`
from the section table's `number_of_relocations`, a COFF object-file field that a
linked image leaves zero, so every TE image claimed to be non-relocatable; and the
volume mapped its modules in file order, so a relocatable driver could take the
address an execute-in-place module was linked for.

### Fix

Test membership of the module file types instead of naming one. `TE.pic` now reads
the base relocation directory the TE header records relocatability in. And the
volume maps its non-relocatable modules first, so a module that can only live
where it was linked claims that address before the relocatable ones are packed
around it.

```
child modules: {'UefiPE': 96, 'UefiTE': 10}
TE modules (10): CpuPei, DxeIpl, MemoryInit, None, PcdPeim, PeiCore, PlatformPei, ResetSystemPei, Tcg2ConfigPei, Tcg2Pei
DxeCore: UefiPE
UiApp: UefiPE
BootManagerMenuApp: UefiPE
```

The `None` entry is the SEC core, which carries no user interface name.

### Testing

`tests/test_uefi_modules.py` pins the module census above, the set of TE module
names, and that `DxeCore`, `UiApp` and `BootManagerMenuApp` are `UefiPE`.
`test_real_te_image` goes further on `MemoryInit`: architecture `AARCH64`,
sections `.text` and `.data`, the entry inside `.text`, and the first eight bytes
at the entry equal to `sub sp, sp, #0xd0; stp x29, x30, [sp, #0x70]`. Every one of
them fails on the merge base, where the file is 93 `UefiPE` children and nothing
else. The fixture is already on binaries master.

Validation: https://github.com/angr/cle/pull/774#issuecomment-5382196055

session: sharpen
