### PR TITLE
COFF: Extend the object over the whole image it maps

### DIFF
--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -479,6 +479,9 @@ class Coff(Backend):
             )
 
         self.memory.add_backer(0, bytes(self._image_vmem))
+        # The image is the whole file, which reaches past the last section: the relocation, symbol
+        # and string tables follow the section data.
+        self._max_addr = len(self._image_vmem) - 1
         self.mapped_base = self.linked_base = 0
         self.pic = True
         # assume windows, this can be wrong, but is more often right.

--- a/tests/test_coff.py
+++ b/tests/test_coff.py
@@ -74,6 +74,16 @@ class TestCoff(unittest.TestCase):
         field_addr = section_vaddr(ld.main_object, ".text") + field_offset
         assert ld.memory.load(field_addr, 4) == struct.pack("<i", expected)
 
+    def test_the_object_extends_over_everything_it_maps(self):
+        # The loader gives the next object the space above max_addr, so an extent that stops short
+        # of the mapped image gets that object mapped on top of this one.
+        exe = os.path.join(TEST_BASE, "tests", "x86_64", "fauxware.obj")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        obj = ld.main_object
+
+        mapped_end = obj.min_addr + max(start + len(backer) for start, backer in obj.memory.backers())
+        assert obj.max_addr >= mapped_end - 1
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A COFF object claims less address space than it backs. On
`binaries/tests/x86_64/fauxware.obj`:

```
object extent   0x400000-0x4028d4
memory it backs 0x400000-0x4039da
SHORT by 0x1106 bytes
address 0x403000 is inside the mapped image and reads as 00000000005d0100
find_object_containing(0x403000) -> None
describe_addr(0x403000) -> not part of a loaded object
```

`0x1106` bytes of mapped memory belong to no object. Every consumer that asks
which object owns an address -- `describe_addr`, symbol attribution, and the
loader's own placement of the next object, which starts from `max_addr` -- is told
that range is free.

### Root cause

The backend maps the whole object file at rva 0:

```python
        self.memory.add_backer(0, bytes(self._image_vmem))
```

but leaves `max_addr` to `Backend`'s default, which derives it from the section
table. An object file's relocation, symbol and string tables sit past the last
section's raw data, and they are inside the image because the image is the whole
file. So the two disagree by exactly the size of those trailing tables.

### Fix

Report the extent of the image the backend actually maps; the backend is the only
thing that knows how much of the file went into memory.

```
object extent   0x400000-0x4039da
memory it backs 0x400000-0x4039da
covered
address 0x403000 is inside the mapped image and reads as 00000000005d0100
find_object_containing(0x403000) -> <Coff Object fauxware.obj, maps [0x400000:0x4039da]>
describe_addr(0x403000) -> .chks64+0x883 in fauxware.obj (0x3000)
```

### Testing

`tests/test_coff.py::TestCoff::test_the_object_extends_over_everything_it_maps`
loads the fixture and asserts `max_addr` reaches the end of the highest backer; it
is short by `0x1106` on the merge base. The fixture is already on binaries master.

#764 rewrites the same lines of this constructor, and #761 and #724 append to
`tests/test_coff.py` at the same point, so whichever of them lands first the
others will want a trivial rebase.

Validation: https://github.com/angr/cle/pull/775#issuecomment-5385108980

session: sharpen
