### PR TITLE
Place the main binary at 0x400000 only when that space is free

### DIFF
--- a/cle/loader.py
+++ b/cle/loader.py
@@ -1032,14 +1032,14 @@ class Loader:
                 base_addr = obj._custom_base_addr
             elif obj.linked_base and self._is_range_free(obj.linked_base, obj_size):
                 base_addr = obj.linked_base
-            elif not obj.is_main_bin:
-                base_addr = self._find_safe_rebase_addr(obj_size)
-            else:
+            elif obj.is_main_bin and self._is_range_free(0x400000, obj_size):
                 log.debug(
                     "The main binary is a position-independent executable. "
                     "It is being loaded with a base address of 0x400000."
                 )
                 base_addr = 0x400000
+            else:
+                base_addr = self._find_safe_rebase_addr(obj_size)
 
             obj.rebase(base_addr)
         else:

--- a/tests/test_rebase.py
+++ b/tests/test_rebase.py
@@ -69,7 +69,27 @@ def test_rebase_granularity_is_not_a_hard_object_limit():
         assert ld.find_object_containing(obj.min_addr) is obj
 
 
+def test_the_main_binary_base_is_not_handed_out_twice():
+    """
+    A container backend loads its children through the loader, and a child can be marked as the
+    main binary: a universal Mach-O marks every slice it loads, because a Mach-O executable
+    refuses to load as anything else. The position-independent main binary has a fixed base
+    address, so the second such object was placed on top of the first.
+    """
+    path = os.path.join(TEST_BASE, "tests", "i386", "manysum")
+    ld = cle.Loader(path, auto_load_libs=False)
+
+    first = MockBackend(0x1000, arch=ld.main_object.arch, is_main_bin=True)
+    second = MockBackend(0x1000, arch=ld.main_object.arch, is_main_bin=True)
+    ld.dynamic_load(first)
+    ld.dynamic_load(second)
+
+    assert first.mapped_base == 0x400000
+    assert second.min_addr > first.max_addr
+
+
 if __name__ == "__main__":
     test_sparse_main_object()
     test_sparse_main_object_unsorted_program_headers()
     test_rebase_granularity_is_not_a_hard_object_limit()
+    test_the_main_binary_base_is_not_handed_out_twice()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

The main binary's conventional base is handed out without being asked for. Two
objects marked as the main binary, dynamically loaded into a loader for
`binaries/tests/i386/manysum`:

```
    first  0x400000-0x400fff
    second 0x400000-0x400fff  ON TOP OF THE FIRST
```

That is not a contrived pair. A container backend loads its children through the
loader, and a Mach-O executable refuses to load as anything but the main binary,
so `Universal2` marks every slice it loads. On
`binaries/tests/multi_arch/fauxware_macho_multiarch` the i386 slice lands on the
container object itself:

```
Universal2   0x400000-0x400000 is_main_bin=True
MachO        0x400000-0x40ffff is_main_bin=True
ExternObject 0x500000-0x500030 is_main_bin=False
MachO        0x100000000-0x100003fff is_main_bin=True
```

### Root cause

`_map_object` asks whether a range is free before it uses a custom base or a
linked base, and does not ask before it uses `0x400000`:

```python
            elif not obj.is_main_bin:
                base_addr = self._find_safe_rebase_addr(obj_size)
            else:
                base_addr = 0x400000
```

The `else` is unconditional, so the main-binary case has no fallback at all: the
second object to ask gets the same address as the first.

### Fix

Ask before taking it, and fall back to the ordinary rebase search when it is
taken. The main binary keeps its conventional base whenever that base is free,
which is every single-main-object load.

```
    first  0x400000-0x400fff
    second 0x8200000-0x8200fff
```

```
Universal2   0x400000-0x400000 is_main_bin=True
MachO        0x500000-0x50ffff is_main_bin=True
ExternObject 0x600000-0x600030 is_main_bin=False
MachO        0x100000000-0x100003fff is_main_bin=True
```

### Testing

`tests/test_rebase.py::test_the_main_binary_base_is_not_handed_out_twice` places
two objects marked as the main binary and asserts the first takes `0x400000` and
the second starts past the first's end; on the merge base both start at
`0x400000`.

#674 would hold the default universal load to a single slice, which hides this for
fat binaries without fixing the unchecked placement.

Validation: https://github.com/angr/cle/pull/776#issuecomment-5385112692

session: sharpen
