### PR TITLE
ELF: Load the .eh_frame function hints without load_debug_info

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -207,12 +207,33 @@ class ELF(MetaELF):
             self._desperate_for_symbols = True
             self.symbols.update(self._symbol_cache.values())
 
-        # .eh_frame is an allocated, non-debug section: it is mapped into the process image and is
-        # present even in fully stripped binaries, unlike .debug_*. CFGFast consumes the function
-        # hints derived from its FDEs and turns them on by default, so load them whether or not
-        # debug information was requested. Everything else below stays behind _load_debug_info.
-        load_function_hints = not self.is_relocatable
-        if self.has_dwarf_info and (self.loader._load_debug_info or load_function_hints):
+        # .eh_frame is an allocated, non-debug section: mapped into the process image and present
+        # even in fully stripped binaries, unlike .debug_*. CFGFast consumes the function hints
+        # derived from its FDEs and enables them by default, so load them whether or not debug
+        # information was requested.
+        #
+        # This reads its own DWARFInfo instead of sharing the one below. Relocating the debug
+        # sections is unnecessary for .eh_frame and raises on objects that keep .rela.debug_*,
+        # which would otherwise cost those objects every hint; and a section this does not read
+        # failing to parse should not decide whether .eh_frame is read at all.
+        #
+        # Relocatable objects are skipped: an FDE address there is relative to the section holding
+        # the function, and cle maps each section independently. See angr/cle#597.
+        if not self.is_relocatable and self._reader.get_section_by_name(".eh_frame") is not None:
+            try:
+                eh_frame_dwarf = self._reader.get_dwarf_info(relocate_dwarf_sections=False)
+            except (DWARFError, ELFError, ValueError):
+                log.warning(
+                    "An exception occurred in pyelftools when reading the .eh_frame of %s. "
+                    "Continuing without function hints.",
+                    self.binary_basename,
+                    exc_info=True,
+                )
+            else:
+                if eh_frame_dwarf.has_EH_CFI():
+                    self._load_function_hints_from_fde(eh_frame_dwarf, FunctionHintSource.EH_FRAME)
+
+        if self.has_dwarf_info and self.loader._load_debug_info:
             # load DWARF information
             try:
                 dwarf = self._reader.get_dwarf_info()
@@ -227,17 +248,12 @@ class ELF(MetaELF):
                 self.has_dwarf_info = False
 
             if dwarf:
-                # Load function hints
-                if load_function_hints and dwarf.has_EH_CFI():
-                    self._load_function_hints_from_fde(dwarf, FunctionHintSource.EH_FRAME)
-
-                if self.loader._load_debug_info:
-                    # Load DIEs
-                    self._load_dies(dwarf)
-                    # Load exception handling artifacts
-                    if dwarf.has_EH_CFI():
-                        self._load_exception_handling(dwarf)
-                        self._load_line_info(dwarf)
+                # Load DIEs
+                self._load_dies(dwarf)
+                # Load exception handling artifacts
+                if dwarf.has_EH_CFI():
+                    self._load_exception_handling(dwarf)
+                    self._load_line_info(dwarf)
 
         if debug_symbols:
             self.__process_debug_file(debug_symbols)

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -207,7 +207,12 @@ class ELF(MetaELF):
             self._desperate_for_symbols = True
             self.symbols.update(self._symbol_cache.values())
 
-        if self.has_dwarf_info and self.loader._load_debug_info:
+        # .eh_frame is an allocated, non-debug section: it is mapped into the process image and is
+        # present even in fully stripped binaries, unlike .debug_*. CFGFast consumes the function
+        # hints derived from its FDEs and turns them on by default, so load them whether or not
+        # debug information was requested. Everything else below stays behind _load_debug_info.
+        load_function_hints = not self.is_relocatable
+        if self.has_dwarf_info and (self.loader._load_debug_info or load_function_hints):
             # load DWARF information
             try:
                 dwarf = self._reader.get_dwarf_info()
@@ -222,13 +227,17 @@ class ELF(MetaELF):
                 self.has_dwarf_info = False
 
             if dwarf:
-                # Load DIEs
-                self._load_dies(dwarf)
-                # Load function hints and exception handling artifacts
-                if dwarf.has_EH_CFI():
+                # Load function hints
+                if load_function_hints and dwarf.has_EH_CFI():
                     self._load_function_hints_from_fde(dwarf, FunctionHintSource.EH_FRAME)
-                    self._load_exception_handling(dwarf)
-                    self._load_line_info(dwarf)
+
+                if self.loader._load_debug_info:
+                    # Load DIEs
+                    self._load_dies(dwarf)
+                    # Load exception handling artifacts
+                    if dwarf.has_EH_CFI():
+                        self._load_exception_handling(dwarf)
+                        self._load_line_info(dwarf)
 
         if debug_symbols:
             self.__process_debug_file(debug_symbols)
@@ -611,6 +620,11 @@ class ELF(MetaELF):
         Load frame description entries out of the .eh_frame section. These entries include function addresses and can be
         used to improve CFG recovery.
 
+        This is not called for relocatable objects. An FDE address there is relative to the
+        section holding the function and only becomes meaningful once a linker places that
+        section; cle maps each section independently, so adding the image base delta yields
+        hints pointing into the wrong section. See angr/cle#597.
+
         :param dwarf:   The DWARF info object from pyelftools.
         :return:        None
         """
@@ -625,8 +639,19 @@ class ELF(MetaELF):
                             source,
                         )
                     )
-        except (DWARFError, ValueError):
-            log.warning("An exception occurred in pyelftools when loading FDE information.", exc_info=True)
+        # This runs for every ELF now, not only those loaded with debug information, so a CIE or FDE
+        # that pyelftools cannot read must cost the object its function hints and not its load.
+        # KeyError: a CIE's FDE_encoding comes from the optional "R" augmentation, which pyelftools
+        # reads unconditionally rather than falling back to the default pointer encoding.
+        # ELFParseError (an ELFError) wraps construct's errors, and a bogus length in a truncated
+        # section surfaces as OverflowError or trips one of pyelftools' own assertions.
+        except (DWARFError, ELFError, ValueError, KeyError, OverflowError, AssertionError):
+            log.warning(
+                "An exception occurred in pyelftools when loading FDE information for %s. "
+                "Continuing without function hints.",
+                self.binary_basename,
+                exc_info=True,
+            )
 
     def _load_exception_handling(self, dwarf):
         """

--- a/tests/test_eh_frame_hints.py
+++ b/tests/test_eh_frame_hints.py
@@ -39,6 +39,11 @@ class TestEhFrameHints(TestCase):
         _, with_debug = self._hints("x86_64", "fauxware", load_debug_info=True)
         assert len(with_debug) == len(without)
 
+    def test_hints_survive_debug_sections_that_do_not_parse(self):
+        """.eh_frame needs no DWARF relocation, so relocating .debug_* must not gate it."""
+        _, hints = self._hints("x86_64", "dir_gcc_-O0")
+        assert len(hints) == 395
+
     def test_relocatable_objects_get_no_hints(self):
         """An FDE address in ET_REL is section-relative, so a hint from it points nowhere."""
         for load_debug_info in (False, True):

--- a/tests/test_eh_frame_hints.py
+++ b/tests/test_eh_frame_hints.py
@@ -1,4 +1,3 @@
-# pylint:disable=missing-class-docstring
 """Tests for the function hints cle derives from .eh_frame."""
 
 from __future__ import annotations
@@ -14,7 +13,10 @@ TESTS_BASE = os.path.join(HERE, "..", "..", "binaries", "tests")
 
 
 class TestEhFrameHints(TestCase):
-    def _hints(self, *path, **kwargs):
+    """The hints must be available without asking the loader for debug information."""
+
+    @staticmethod
+    def _hints(*path, **kwargs):
         loader = cle.Loader(os.path.join(TESTS_BASE, *path), auto_load_libs=False, **kwargs)
         return loader, loader.main_object.function_hints
 

--- a/tests/test_eh_frame_hints.py
+++ b/tests/test_eh_frame_hints.py
@@ -1,0 +1,53 @@
+# pylint:disable=missing-class-docstring
+"""Tests for the function hints cle derives from .eh_frame."""
+
+from __future__ import annotations
+
+import os
+from unittest import TestCase, main
+
+import cle
+from cle.backends import FunctionHintSource
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+TESTS_BASE = os.path.join(HERE, "..", "..", "binaries", "tests")
+
+
+class TestEhFrameHints(TestCase):
+    def _hints(self, *path, **kwargs):
+        loader = cle.Loader(os.path.join(TESTS_BASE, *path), auto_load_libs=False, **kwargs)
+        return loader, loader.main_object.function_hints
+
+    def test_hints_are_loaded_without_debug_info(self):
+        """CFGFast enables eh_frame by default, so hints must exist without load_debug_info."""
+        loader, hints = self._hints("x86_64", "fauxware")
+        assert len(hints) == 7
+        assert all(hint.source == FunctionHintSource.EH_FRAME for hint in hints)
+        assert all(loader.main_object.contains_addr(hint.addr) for hint in hints)
+
+    def test_hints_are_loaded_for_a_stripped_binary(self):
+        """A stripped binary is the case that needs this most: .eh_frame outlives .symtab."""
+        loader, hints = self._hints("x86_64", "true")
+        assert loader.main_object.get_symbol("main") is None
+        assert len(hints) == 70
+
+    def test_debug_info_does_not_load_the_hints_twice(self):
+        """Asking for debug info must not add a second copy of every hint."""
+        _, without = self._hints("x86_64", "fauxware")
+        _, with_debug = self._hints("x86_64", "fauxware", load_debug_info=True)
+        assert len(with_debug) == len(without)
+
+    def test_relocatable_objects_get_no_hints(self):
+        """An FDE address in ET_REL is section-relative, so a hint from it points nowhere."""
+        for load_debug_info in (False, True):
+            _, hints = self._hints("x86_64", "copy.o", load_debug_info=load_debug_info)
+            assert hints == []
+
+    def test_a_cie_without_an_fde_encoding_does_not_fail_the_load(self):
+        """The "R" augmentation is optional; reading .eh_frame must not cost a load."""
+        _, hints = self._hints("mips", "busybox")
+        assert hints == []
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`CFGFast` enables `eh_frame=True` by default and seeds function starts from
`FunctionHintSource.EH_FRAME`, and under a default `angr.Project` there are none
to seed from. Loading three x86-64 ELFs the ordinary way and then again with
`load_debug_info=True`:

```
x86_64/fauxware            default load:   0 hints []
                           load_debug_info=True:   7 hints
x86_64/true (stripped)     default load:   0 hints []
                           load_debug_info=True:  70 hints
```

`binaries/tests/x86_64/true` is the case that matters: it is stripped, so those 70
FDE-derived starts are the only surviving record of where its functions begin. A
default-on feature did nothing for any ordinary user, on any architecture.

### Root cause

The FDE hint load sat inside the debug-information block:

```python
                if dwarf.has_EH_CFI():
                    self._load_function_hints_from_fde(dwarf, FunctionHintSource.EH_FRAME)
```

which runs only when `loader._load_debug_info` is set, and `angr.Project` does not
set it. The gate is wrong in principle as well as in effect: `.eh_frame` is an
allocated, non-debug section, mapped into the process image and present in
stripped binaries, where `.debug_*` is not.

### Fix

Hoist the FDE hint load out of that block, reading its own `DWARFInfo` with
`relocate_dwarf_sections=False`: relocating the debug sections is unnecessary for
`.eh_frame` and raises on objects that keep `.rela.debug_*`, which would otherwise
cost those objects every hint. DIEs, exception handling and line info stay behind
`_load_debug_info` as they were.

```
x86_64/fauxware            default load:   7 hints ['EH_FRAME']
                           load_debug_info=True:   7 hints
x86_64/true (stripped)     default load:  70 hints ['EH_FRAME']
                           load_debug_info=True:  70 hints
x86_64/copy.o (ET_REL)     default load:   0 hints []
                           load_debug_info=True:   0 hints
```

Relocatable objects are skipped: an FDE address there is relative to the section
holding the function, and cle maps each section independently, so the hint points
into the wrong section. That is #597, and `copy.o` above went from 48 wrong hints
to none. Running the FDE reader for every ELF also required widening its exception
guard, as #768 does for the opt-in path; whichever lands first, I will rebase the
other onto it.

### Testing

`tests/test_eh_frame_hints.py` covers the six cases: hints without
`load_debug_info`, the stripped binary, that asking for debug information does not
double them, a binary whose `.debug_*` sections do not relocate, that a relocatable
object gets none either way, and that a CIE without an FDE encoding does not cost
the load. The first four see 0 hints on the merge base and the fifth sees 48.

Closes #744. Validation: https://github.com/angr/cle/pull/777#issuecomment-5388468681

session: sharpen
