### PR TITLE
Do not raise when probing a stream that has no file descriptor

### DIFF
--- a/cle/backends/uefi_firmware.py
+++ b/cle/backends/uefi_firmware.py
@@ -40,7 +40,11 @@ class UefiFirmware(Backend):
     def _to_bytes(cls, fileobj: io.IOBase):
         try:
             fileno = fileobj.fileno()
-        except io.UnsupportedOperation:
+        except (AttributeError, io.UnsupportedOperation):
+            # A stream with no file descriptor behind it either raises
+            # UnsupportedOperation, as the io classes do, or has no fileno at
+            # all. This backend is probed against every stream the loader is
+            # given, so it has to tolerate both.
             pass
         else:
             return mmap.mmap(fileno, 0, access=mmap.ACCESS_READ)

--- a/cle/backends/uefi_firmware.py
+++ b/cle/backends/uefi_firmware.py
@@ -47,7 +47,12 @@ class UefiFirmware(Backend):
             # given, so it has to tolerate both.
             pass
         else:
-            return mmap.mmap(fileno, 0, access=mmap.ACCESS_READ)
+            try:
+                return mmap.mmap(fileno, 0, access=mmap.ACCESS_READ)
+            except ValueError:
+                # an empty file has nothing to map; fall through to the read below, which
+                # yields b"" and lets the probe answer that this is not a UEFI image
+                pass
 
         if isinstance(fileobj, io.BytesIO):
             return fileobj.getbuffer()

--- a/tests/test_backend_probing.py
+++ b/tests/test_backend_probing.py
@@ -1,0 +1,68 @@
+"""Tests for how the loader probes backends against a stream."""
+
+from __future__ import annotations
+
+import io
+import os
+from unittest import TestCase, main
+
+import arpy
+
+import cle
+from cle.errors import CLEError
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+TESTS_BASE = os.path.join(HERE, "..", "..", "binaries", "tests")
+BSD_ARCHIVE = os.path.join(TESTS_BASE, "aarch64", "bsd_symdef_archive.a")
+
+
+class ReadSeekOnly:
+    """The minimum Loader._load_object_isolated documents: read and seek, no file descriptor."""
+
+    def __init__(self, data: bytes):
+        """Wrap the bytes in a buffer this object reads through."""
+        self._buffer = io.BytesIO(data)
+
+    def read(self, size=-1):
+        """Read from the wrapped buffer."""
+        return self._buffer.read(size)
+
+    def seek(self, offset, whence=0):
+        """Seek within the wrapped buffer."""
+        return self._buffer.seek(offset, whence)
+
+    def tell(self):
+        """Report the position in the wrapped buffer."""
+        return self._buffer.tell()
+
+
+def _unclaimed_bytes() -> bytes:
+    """The symbol table of a BSD archive: real bytes that no backend recognises as an object."""
+    archive = arpy.Archive(BSD_ARCHIVE)
+    archive.read_all_headers()
+    member = next(m for name, m in archive.archived_files.items() if b"SYMDEF" in name)
+    member.seek(0)
+    return member.read()
+
+
+class TestBackendProbing(TestCase):
+    """Probing a stream must report that no backend matched, rather than raising."""
+
+    def test_a_stream_without_a_file_descriptor_is_rejected_cleanly(self):
+        """The documented read/seek contract does not promise a file descriptor."""
+        with self.assertRaises(CLEError):
+            cle.Loader(ReadSeekOnly(_unclaimed_bytes()), auto_load_libs=False)
+
+    def test_a_bytesio_is_rejected_the_same_way(self):
+        """A BytesIO already behaves correctly; it is the control for the case above."""
+        with self.assertRaises(CLEError):
+            cle.Loader(io.BytesIO(_unclaimed_bytes()), auto_load_libs=False)
+
+    def test_an_archive_member_without_a_file_descriptor_is_rejected_cleanly(self):
+        """An ar member is one instance of a stream with no file descriptor."""
+        with self.assertRaises(CLEError):
+            cle.Loader(BSD_ARCHIVE, auto_load_libs=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backend_probing.py
+++ b/tests/test_backend_probing.py
@@ -49,9 +49,13 @@ class TestBackendProbing(TestCase):
     """Probing a stream must report that no backend matched, rather than raising."""
 
     def test_a_stream_without_a_file_descriptor_is_rejected_cleanly(self):
-        """The documented read/seek contract does not promise a file descriptor."""
+        """The read/seek dispatch accepts more than the BinaryIO annotation declares."""
         with self.assertRaises(CLEError):
-            cle.Loader(ReadSeekOnly(_unclaimed_bytes()), auto_load_libs=False)
+            # Loader is annotated BinaryIO, but _load_object_isolated dispatches on
+            # hasattr(read)/hasattr(seek), and cle itself hands it arpy members that
+            # have neither fileno nor a BinaryIO base. This is that wider set.
+            stream = ReadSeekOnly(_unclaimed_bytes())
+            cle.Loader(stream, auto_load_libs=False)  # type: ignore[arg-type]
 
     def test_a_bytesio_is_rejected_the_same_way(self):
         """A BytesIO already behaves correctly; it is the control for the case above."""

--- a/tests/test_backend_probing.py
+++ b/tests/test_backend_probing.py
@@ -14,6 +14,7 @@ from cle.errors import CLEError
 HERE = os.path.dirname(os.path.realpath(__file__))
 TESTS_BASE = os.path.join(HERE, "..", "..", "binaries", "tests")
 BSD_ARCHIVE = os.path.join(TESTS_BASE, "aarch64", "bsd_symdef_archive.a")
+EMPTY_FILE = os.path.join(TESTS_BASE, "i386", "packed_elf32_angr_rtdb", "angr_rtdb.pin")
 
 
 class ReadSeekOnly:
@@ -61,6 +62,11 @@ class TestBackendProbing(TestCase):
         """A BytesIO already behaves correctly; it is the control for the case above."""
         with self.assertRaises(CLEError):
             cle.Loader(io.BytesIO(_unclaimed_bytes()), auto_load_libs=False)
+
+    def test_an_empty_file_is_rejected_cleanly(self):
+        """A zero-length file has no mapping, which must not escape the probe as a ValueError."""
+        with self.assertRaises(CLEError):
+            cle.Loader(EMPTY_FILE, auto_load_libs=False)
 
     def test_an_archive_member_without_a_file_descriptor_is_rejected_cleanly(self):
         """An ar member is one instance of a stream with no file descriptor."""


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`Loader._load_object_isolated` accepts any object with `read` and `seek` as a binary to load, but `UefiFirmware._to_bytes` calls `fileobj.fileno()` and catches only `io.UnsupportedOperation`. A stream that has no `fileno` attribute at all raises `AttributeError`, which nothing catches, and because that backend is `is_default` it is probed against every stream the loader is given.

So a stream in that wider set, carrying content that no earlier backend claims, crashes the loader — while an `io.BytesIO` carrying the identical bytes is rejected cleanly with `CLECompatibilityError`, because `_to_bytes` has a branch for that one type. The inconsistency is the bug; this widens the guard so probing reports that no backend matched instead of raising.

Worth being precise about "wider set", because the repository's own typecheck pointed it out while I was preparing this: `Loader.__init__` is annotated `str | BinaryIO | Path | Backend`, and `typing.BinaryIO` does declare `fileno`. A caller who satisfies the annotation is therefore fine today — `io.BytesIO` declares `fileno` and raises `UnsupportedOperation` from it, which `_to_bytes` already handles. The gap is between that annotation and the runtime dispatch, and it is not hypothetical, because **cle itself is the caller that falls into it**: `StaticArchive` hands `_load_object_isolated` the `arpy` members it enumerates, and those have neither a `fileno` nor a `BinaryIO` base.

`arpy`'s `ar` members are one instance, and the reason this surfaced: they expose `read` and `seek` but no `fileno`, so `cle.Loader("binaries/tests/aarch64/bsd_symdef_archive.a")` raises `AttributeError: 'ArchiveFileData' object has no attribute 'fileno'` on master. That archive is a Mach-O static library whose members are `MH_OBJECT`, which cle does not load, so it does not load after this change either — it now fails with a `CLEError` naming the real reason instead of an unhandled `AttributeError`. This change is exception hygiene at the probing layer; it does not make any archive load that did not load before, and I would rather say so than imply otherwise.

A related and separate matter, deliberately not in this change: `StaticArchive` hands every member `arpy` exposes to backend selection, and `arpy` filters out the GNU archive-bookkeeping spellings (`/` and `//`) but has no notion of the BSD one, so a `__.SYMDEF` symbol table is offered to the loader as though it were an object file. Skipping it by name would restore parity with the GNU case. I am happy to send that separately if it is wanted; it needs an ELF static library carrying a BSD symbol table as a fixture, which `angr/binaries` does not currently have.

The regression is `tests/test_backend_probing.py`. Its custom-stream case carries a `type: ignore[arg-type]` for exactly the mismatch described above, with a comment saying so rather than leaving it bare. It covers a minimal read/seek/tell stream, the same bytes in a `BytesIO` as a control that passes both before and after, and the archive. Two of the three fail on master.

No overlap with #736: that change works on the headers above the member loop, this one is in `uefi_firmware.py`, and the two apply cleanly together.
