### PR TITLE
Load a Mach-O MH_EXECUTE that a container backend owns

### DIFF
--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -182,7 +182,8 @@ class MachO(Backend):
             # Determine the base address the binary was linked against
             # and set the values for the Backend and Loader accordingly
             if self.pic and self.filetype == MachoFiletype.MH_EXECUTE:
-                assert self.is_main_bin, "An file of type MH_EXECUTE should be the main bin, this should not happen"
+                # is_main_bin can be False here: a container backend (CaRT, universal binary) owns
+                # the child until the loader promotes it through force_main_object
                 # a Position Independent Main binary would later be loaded at 0x400000, which isn't legal for Mach-O
                 # Also, its segment vaddrs are relative to 0x100000000, so we set this as the linked base
                 # and the MachO Backend code uses the AdressTranslator to translate linked addresses to relative ones

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -36,6 +36,29 @@ def test_cart_elf():
     assert ld.main_object.os == "UNIX - System V"
 
 
+def test_cart_macho():
+    """A Mach-O MH_EXECUTE inside a CaRT container is loaded as the main object.
+
+    The container registers itself as the loader's main object while the child loads, so the child
+    sees ``is_main_bin=False`` and used to trip an assertion in the MachO backend before the loader
+    could promote it through ``force_main_object``.
+    """
+    cartfile = os.path.join(
+        TEST_BASE,
+        "tests",
+        "x86_64",
+        "fauxware.macho.cart",
+    )
+    ld = cle.Loader(
+        cartfile, auto_load_libs=False, main_opts={"arc4_key": b"\x02\xf53asdf\x00\x00\x00\x00\x00\x00\x00\x00\x00"}
+    )
+    assert isinstance(ld.main_object, cle.MachO)
+    assert ld.main_object.os == "macos"
+    # same placement and entry point as the direct load in test_macho.py::test_fauxware
+    assert ld.main_object.mapped_base == 0x100000000
+    assert ld.main_object.entry == 0x100000DE0
+
+
 def test_cart_elf_with_load_options():
     cartfile = os.path.join(
         TEST_BASE,
@@ -119,6 +142,7 @@ def test_cart_find_object_containing_excludes_wrapper():
 if __name__ == "__main__":
     test_cart_pe()
     test_cart_elf()
+    test_cart_macho()
     test_cart_elf_with_load_options()
     test_cart_blob_with_load_options()
     test_cart_find_object_containing_excludes_wrapper()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A Mach-O executable inside a container cannot be loaded. On
`binaries/tests/x86_64/fauxware.macho.cart`:

```
EXCEPTION: AssertionError: An file of type MH_EXECUTE should be the main bin, this should not happen
  raised at: File ".../cle/backends/macho/macho.py", line 182, in __init__
```

Every CaRT-wrapped Mach-O executable fails this way, and the assertion fires
during construction, so nothing about the image is available afterwards.

### Root cause

```python
            if self.pic and self.filetype == MachoFiletype.MH_EXECUTE:
                assert self.is_main_bin, "An file of type MH_EXECUTE should be the main bin, this should not happen"
```

The premise is false for a child of a container backend. The container registers
itself as `loader._main_object` before it loads its children, so a child is always
constructed with `is_main_bin=False` and is promoted only afterwards, through
`force_main_object`. The assertion therefore fires on exactly the images the
container exists to load.

### Fix

Delete the assertion. Nothing in the branch it guards needs main-ness -- it sets
`linked_base` and `mapped_base` to `0x100000000`, which is right either way. It
was also wrong on its own terms: cle refuses loads with `CLEError`, and a bare
`assert` disappears under `python -O`, so the loader's answer on this input
depended on an interpreter flag.

```
main object: MachO os=macos mapped_base=0x100000000 entry=0x100000de0
```

`universal2.py` carries a workaround for the same assertion which becomes
unnecessary, but removing it moves fat-binary placement and belongs in its own
change.

### Testing

`tests/test_cart.py::test_cart_macho` loads the CaRT fixture and asserts the main
object is a `MachO`, that `os` is `macos`, and that the base and entry match the
direct load in `test_macho.py::test_fauxware` -- `0x100000000` and `0x100000de0`.
It raises `AssertionError` on the merge base.

Validation: https://github.com/angr/cle/pull/780#issuecomment-5390459122

sync: angr/binaries#190

session: sharpen
