### PR TITLE
ELF: Read EF_ARM_BE8

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -19,6 +19,7 @@ from elftools.dwarf.dwarf_expr import DWARFExprParser
 from elftools.dwarf.dwarfinfo import DWARFInfo
 from elftools.dwarf.ranges import BaseAddressEntry, RangeEntry
 from elftools.elf import dynamic, elffile, enums, sections
+from elftools.elf.constants import E_FLAGS
 from elftools.elf.relocation import RelocationSection, RelrRelocationSection
 from sortedcontainers import SortedDict
 
@@ -347,10 +348,16 @@ class ELF(MetaELF):
                 cpu_name = arm_attrs["TAG_CPU_NAME"]
                 if "Cortex-M" in cpu_name or "-M" in cpu_name:
                     return archinfo.ArchARMCortexM("Iend_LE")
+            endness = archinfo.Endness.LE if reader.little_endian else archinfo.Endness.BE
+            # BE8 keeps instruction words little-endian while data stays big-endian. The flag is
+            # independent of the float-ABI bits below, so read it alongside them rather than after.
+            instruction_endness = archinfo.Endness.LE if reader.header.e_flags & E_FLAGS.EF_ARM_BE8 else None
             if reader.header.e_flags & 0x200:
-                return archinfo.ArchARMEL("Iend_LE" if reader.little_endian else "Iend_BE")
+                return archinfo.ArchARMEL(endness, instruction_endness=instruction_endness)
             elif reader.header.e_flags & 0x400:
-                return archinfo.ArchARMHF("Iend_LE" if reader.little_endian else "Iend_BE")
+                return archinfo.ArchARMHF(endness, instruction_endness=instruction_endness)
+            elif instruction_endness is not None:
+                return archinfo.ArchARM(endness, instruction_endness=instruction_endness)
 
         try:
             return archinfo.arch_from_id(arch_str, "le" if reader.little_endian else "be", reader.elfclass)

--- a/tests/test_arch_detect.py
+++ b/tests/test_arch_detect.py
@@ -30,5 +30,25 @@ class TestArchPcodeDetect(unittest.TestCase):
         assert arch.name == "68000:BE:32:default"
 
 
+class TestArmArchDetect(unittest.TestCase):
+    """
+    Test ARM architecture detection.
+    """
+
+    def test_elf_arm_be8(self):
+        binpath = os.path.join(test_location, "armeb/be8_loop")
+        arch = cle.Loader(binpath, auto_load_libs=False).main_object.arch
+        assert arch.name == "ARMHF"
+        assert arch.memory_endness == archinfo.Endness.BE
+        assert arch.instruction_endness == archinfo.Endness.LE
+
+    def test_elf_arm_be32(self):
+        binpath = os.path.join(test_location, "armeb/be32_loop")
+        arch = cle.Loader(binpath, auto_load_libs=False).main_object.arch
+        assert arch.name == "ARMHF"
+        assert arch.memory_endness == archinfo.Endness.BE
+        assert arch.instruction_endness == archinfo.Endness.BE
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`extract_arch` reads the ARM attributes to spot Cortex-M and reads `e_flags` for the float ABI, but never reads `EF_ARM_BE8` (`0x00800000`). A BE8 object — big-endian data, little-endian instructions, which is the normal layout for modern big-endian ARM — is therefore loaded as plain BE32 and every instruction decodes as garbage. On one such file `_finiarray` holds `ldr r3, [pc, #0x44]` and angr reports `ldrtmi sb, [r0], #-0xfe5`.

This reads the flag and selects an architecture whose instruction endness is little-endian. With it, capstone and the p-code lifter both disassemble the same site correctly, and the p-code language resolves to `ARM:LEBE:32:v7LEInstruction` rather than `ARM:BE:32:v7`.

Fixes #610.

**Two dependencies, and one limitation that matters more than either.**

It needs angr/archinfo#373, which adds the `instruction_endness` argument this uses; without it the branch cannot construct the architecture, and cle's own Typecheck job will fail on the missing parameter. It needs angr/binaries#192 for the fixtures — the repository has no big-endian ARM ELF at all, so the two new tests reference files that do not exist yet.

The limitation: **this does not make BE8 binaries analysable.** libVEX takes a single endness for both instruction fetch and data, so `instruction_endness` never reaches it and VEX still refuses these instructions exactly as before. That is angr/pyvex#565, and it lives in the `vex` submodule rather than here.

The honest consequence is that CFG recovery on a BE8 object gets *smaller* with this change, not larger — on a corpus sample, 329 blocks and 156 functions before, 259 and 143 after. That is the correct direction: with the right instruction endness the prologue scan and the ARM undefined-instruction check stop accepting byte-swapped noise, and nothing correct replaces it until VEX can decode. I would rather say that than present a shrinking number as an improvement.

What is unambiguously better today is disassembly, which is what `block.disassembly` and the p-code path use. Ordinary ARM is untouched: on ten targets, including a little-endian ARM, a Cortex-M, a real BE32 object and the same BE8 object with the flag cleared, every architecture field, both prologue sets, the VEX output and the disassembly are identical before and after.
