### PR TITLE
ELF: Size imported objects from DWARF declarations

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -57,6 +57,14 @@ _NON_ALLOCATED_SECTION_NAMES = {  # Sections that do not occupy memory at runtim
     "SHT_MIPS_REGINFO",
 }
 
+_DWARF_SIZE_TRANSPARENT_TYPE_TAGS = {
+    "DW_TAG_const_type",
+    "DW_TAG_immutable_type",
+    "DW_TAG_restrict_type",
+    "DW_TAG_typedef",
+    "DW_TAG_volatile_type",
+}
+
 
 # MIPS e_flags bits that name the ABI. binutils include/elf/mips.h.
 EF_MIPS_ABI2 = 0x20  # n32
@@ -80,7 +88,8 @@ class ELF(MetaELF):
 
     Useful backend options:
 
-    - ``debug_symbols``: Provides the path to a separate file which contains the binary's debug symbols
+    - ``debug_symbols``: Provides the path to a separate file which contains the binary's debug symbols. Supplying it
+            explicitly loads its symbol, line, and external-size information independently of ``load_debug_info``.
     - ``discard_section_headers``: Do not parse section headers. Use this if they are corrupted or malicious.
     - ``discard_program_headers``: Do not parse program headers. Use this if the binary is for a platform whose ELF
             loader only looks at section headers, but whose toolchain generates program headers anyway.
@@ -186,7 +195,7 @@ class ELF(MetaELF):
         self.is_relocatable = self._reader.header.e_type == "ET_REL"
         self.pic = self.pic or self._reader.header.e_type in ("ET_REL", "ET_DYN")
         self.tls_block_offset = None  # this is an ELF-only attribute
-        self.extern_size_hints: dict[str, int] = {}  # maps symbol name to a size based on reloc addends
+        self.extern_size_hints: dict[str, int] = {}  # maps symbol names to inferred minimum allocation sizes
         self._dynamic = {}
         self.deps = []
 
@@ -776,6 +785,69 @@ class ELF(MetaELF):
             return lowpc, None
         return lowpc + base_addr, highpc + base_addr
 
+    @staticmethod
+    def _dwarf_type_size(die: DIE, max_size: int) -> int | None:
+        """Read an explicit size through representation-preserving qualifiers without inferring arrays or pointers."""
+        seen = set()
+        while True:
+            unit_offset = getattr(die.cu, "cu_offset", getattr(die.cu, "tu_offset", id(die.cu)))
+            identity = (id(die.cu.dwarfinfo), type(die.cu), unit_offset, die.offset)
+            if identity in seen:
+                return None
+            seen.add(identity)
+
+            byte_size = die.attributes.get("DW_AT_byte_size")
+            if byte_size is not None:
+                if type(byte_size.value) is int and 0 < byte_size.value <= max_size:
+                    return byte_size.value
+                return None
+
+            if die.tag not in _DWARF_SIZE_TRANSPARENT_TYPE_TAGS or "DW_AT_type" not in die.attributes:
+                return None
+
+            try:
+                die = die.get_DIE_from_attribute("DW_AT_type")
+            except (DWARFError, KeyError, NotImplementedError):
+                return None
+
+    def _load_dwarf_extern_size_hint(self, die: DIE) -> None:
+        declaration = die.attributes.get("DW_AT_declaration")
+        if declaration is None or not declaration.value or "DW_AT_type" not in die.attributes:
+            return
+
+        name_attr = die.attributes.get("DW_AT_linkage_name") or die.attributes.get("DW_AT_MIPS_linkage_name")
+        if name_attr is None:
+            external = die.attributes.get("DW_AT_external")
+            if external is None or not external.value:
+                return
+            name_attr = die.attributes.get("DW_AT_name")
+        if name_attr is None:
+            return
+
+        name = maybedecode(name_attr.value)
+        if name not in self.imports:
+            return
+
+        try:
+            type_die = die.get_DIE_from_attribute("DW_AT_type")
+        except (DWARFError, KeyError, NotImplementedError):
+            return
+
+        from cle.backends.externs import ExternObject  # pylint: disable=import-outside-toplevel
+
+        size = self._dwarf_type_size(type_die, ExternObject.default_map_size(self.arch))
+        if size is not None:
+            self.extern_size_hints[name] = max(self.extern_size_hints.get(name, 0), size)
+
+    def _load_dwarf_extern_size_hints(self, dwarf: DWARFInfo) -> None:
+        for cu in dwarf.iter_CUs():
+            try:
+                for die in cu.iter_DIEs():
+                    if die.tag == "DW_TAG_variable":
+                        self._load_dwarf_extern_size_hint(die)
+            except (DWARFError, KeyError, NotImplementedError):
+                continue
+
     def _load_dies(self, dwarf: DWARFInfo):
         """
         Load DIEs and CUs from DWARF.
@@ -797,8 +869,10 @@ class ELF(MetaELF):
                         var_type = VariableType.read_from_die(die, self)
                         if var_type is not None:
                             type_list[die.offset] = var_type
-            except KeyError:
-                # pyelftools is not very resilient - we need to catch KeyErrors here
+                    elif die.tag == "DW_TAG_variable":
+                        self._load_dwarf_extern_size_hint(die)
+            except (DWARFError, KeyError, NotImplementedError):
+                # pyelftools is not very resilient - skip compilation units it cannot parse
                 continue
 
             top_die = cu.get_top_DIE()
@@ -1611,6 +1685,7 @@ class ELF(MetaELF):
 
                 # debug symbols don't have eh_frame ever from what I can tell
                 if dwarf:
+                    self._load_dwarf_extern_size_hints(dwarf)
                     self._load_line_info(dwarf)
 
     @staticmethod

--- a/cle/backends/externs/__init__.py
+++ b/cle/backends/externs/__init__.py
@@ -56,6 +56,14 @@ class TOCRelocation(Relocation):
 
 
 class ExternObject(Backend):
+    @staticmethod
+    def default_map_size(arch):
+        if arch.bits < 32:
+            return 0x200
+        if arch.bits == 32:
+            return 0x8000
+        return 0x80000
+
     def __init__(self, loader, map_size=0, tls_size=0):
         super().__init__("cle##externs", None, loader=loader)
         self._next_object = None

--- a/cle/backends/relocation.py
+++ b/cle/backends/relocation.py
@@ -93,7 +93,7 @@ class Relocation:
         if self.symbol.is_weak:
             return
 
-        # Use extern_size_hints if available (computed from relocation addends)
+        # Use any external size inferred by the owning backend.
         extern_size_hints = getattr(self.owner, "extern_size_hints", {})
         min_size = extern_size_hints.get(self.symbol.name, 0)
 

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -313,14 +313,14 @@ class Loader:
         3) All requests for size are passed down the chain until they reach an object which has the space to service
             it or an object which has not yet been mapped. If all objects have been mapped and are full, a new extern
             object is mapped with a fixed size.
+
+        The architecture-dependent default capacity also bounds individual optional metadata hints, preventing one
+        hint from forcing a larger-than-normal extern reservation.
+        The bound applies per hint; aggregate extern allocation may still grow beyond this capacity when many symbols
+        are allocated.
         """
         if self._extern_object is None:
-            if self.main_object.arch.bits < 32:
-                extern_size = 0x200
-            elif self.main_object.arch.bits == 32:
-                extern_size = 0x8000
-            else:
-                extern_size = 0x80000
+            extern_size = ExternObject.default_map_size(self.main_object.arch)
             self._extern_object = ExternObject(self, map_size=extern_size)
             self._internal_load(self._extern_object)
         return self._extern_object

--- a/tests/test_extern.py
+++ b/tests/test_extern.py
@@ -2,12 +2,68 @@ from __future__ import annotations
 
 import os
 import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from elftools.common.exceptions import DWARFError
+from elftools.elf.elffile import ELFFile
 
 import cle
 from cle.backends.elf.relocation.ppc64 import R_PPC64_JMP_SLOT
+from cle.backends.externs import ExternObject
 from cle.backends.symbol import SymbolType
 
 TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
+
+
+class _TestCompilationUnit:
+    """Minimal compilation-unit identity used by type-reference tests."""
+
+    def __init__(self, dwarfinfo, cu_offset=0):
+        self.dwarfinfo = dwarfinfo
+        self.cu_offset = cu_offset
+
+
+class _TestTypeUnit:
+    """Minimal type-unit identity used by type-reference tests."""
+
+    def __init__(self, dwarfinfo, tu_offset=0):
+        self.dwarfinfo = dwarfinfo
+        self.tu_offset = tu_offset
+
+
+def _test_die(
+    tag,
+    offset,
+    *,
+    byte_size=None,
+    referenced=None,
+    dwarfinfo=None,
+    unit_type: type[_TestCompilationUnit] | type[_TestTypeUnit] = _TestCompilationUnit,
+):
+    die = Mock()
+    die.tag = tag
+    die.offset = offset
+    die.cu = unit_type(dwarfinfo if dwarfinfo is not None else object())
+    die.attributes = {}
+    if byte_size is not None:
+        die.attributes["DW_AT_byte_size"] = SimpleNamespace(value=byte_size)
+    if referenced is not None:
+        die.attributes["DW_AT_type"] = SimpleNamespace()
+        if isinstance(referenced, Exception):
+            die.get_DIE_from_attribute.side_effect = referenced
+        else:
+            die.get_DIE_from_attribute.return_value = referenced
+    return die
+
+
+def _test_declaration(name, type_die, *, external=False, linkage=False):
+    die = _test_die("DW_TAG_variable", 0, referenced=type_die)
+    die.attributes["DW_AT_declaration"] = SimpleNamespace(value=True)
+    die.attributes["DW_AT_linkage_name" if linkage else "DW_AT_name"] = SimpleNamespace(value=name.encode())
+    if external:
+        die.attributes["DW_AT_external"] = SimpleNamespace(value=True)
+    return die
 
 
 def test_f_finale_extern_size_hints():
@@ -78,6 +134,187 @@ def test_ppc64_abiv1_untyped_function_import():
     expected = descriptors(pristine)
     assert expected, "the pristine fixture has no jump slots to compare"
     assert descriptors(untyped) == expected
+
+
+def test_dwarf_extern_size_hints():
+    path = os.path.join(TESTS_BASE, "tests", "x86_64", "decompiler", "sort.o")
+    expected_sizes = {
+        "Version": 8,
+        "argmatch_die": 8,
+        "exit_failure": 4,
+        "program_name": 8,
+    }
+
+    ld = cle.Loader(path, auto_load_libs=False)
+    obj = ld.main_object
+    extern_sizes = {symbol.name: symbol.size for symbol in ld.symbols if symbol.is_extern}
+    for name in expected_sizes:
+        assert name not in obj.extern_size_hints  # type: ignore[attr-defined]
+        assert extern_sizes[name] == 0
+
+    ld = cle.Loader(path, auto_load_libs=False, load_debug_info=True)
+    obj = ld.main_object
+    extern_sizes = {symbol.name: symbol.size for symbol in ld.symbols if symbol.is_extern}
+    for name, size in expected_sizes.items():
+        assert obj.extern_size_hints[name] == size  # type: ignore[attr-defined]
+        assert extern_sizes[name] == size
+
+    assert extern_sizes["__assert_fail"] == 0
+
+    allocated_symbols = sorted(ld.extern_object.symbols, key=lambda symbol: symbol.relative_addr)
+    for symbol, next_symbol in zip(allocated_symbols, allocated_symbols[1:]):
+        allocated_size = (
+            8
+            if symbol.size == 0
+            and symbol.type in (SymbolType.TYPE_NONE, SymbolType.TYPE_OBJECT, SymbolType.TYPE_TLS_OBJECT)
+            else max(symbol.size, 1)
+        )
+        assert symbol.relative_addr + allocated_size <= next_symbol.relative_addr
+
+    final_symbol = allocated_symbols[-1]
+    final_size = (
+        8
+        if final_symbol.size == 0
+        and final_symbol.type in (SymbolType.TYPE_NONE, SymbolType.TYPE_OBJECT, SymbolType.TYPE_TLS_OBJECT)
+        else max(final_symbol.size, 1)
+    )
+    assert final_symbol.relative_addr + final_size <= ld.extern_object.map_size
+
+
+def test_dwarf_extern_size_hints_are_conservative():
+    path = os.path.join(TESTS_BASE, "tests", "x86_64", "decompiler", "sort.o")
+    obj = cle.Loader(path, auto_load_libs=False).main_object
+    max_size = ExternObject.default_map_size(obj.arch)
+
+    dwarfinfo = object()
+    base_type = _test_die("DW_TAG_base_type", 1, byte_size=8, dwarfinfo=object())
+    type_unit_alias = _test_die("DW_TAG_typedef", 1, referenced=base_type, dwarfinfo=dwarfinfo, unit_type=_TestTypeUnit)
+    compilation_unit_alias = _test_die("DW_TAG_const_type", 1, referenced=type_unit_alias, dwarfinfo=dwarfinfo)
+    assert obj._dwarf_type_size(compilation_unit_alias, max_size) == 8  # type: ignore[attr-defined]
+
+    unsupported_array = _test_die("DW_TAG_array_type", 2, referenced=base_type)
+    implicit_pointer = _test_die("DW_TAG_pointer_type", 3, referenced=base_type)
+    malformed_qualifier = _test_die("DW_TAG_volatile_type", 5, referenced=DWARFError("bad reference"))
+    assert obj._dwarf_type_size(unsupported_array, max_size) is None  # type: ignore[attr-defined]
+    assert obj._dwarf_type_size(implicit_pointer, max_size) is None  # type: ignore[attr-defined]
+    assert obj._dwarf_type_size(malformed_qualifier, max_size) is None  # type: ignore[attr-defined]
+
+    for offset, size in enumerate((True, False, -1, 0, max_size + 1), start=10):
+        invalid_type = _test_die("DW_TAG_base_type", offset, byte_size=size)
+        assert obj._dwarf_type_size(invalid_type, max_size) is None  # type: ignore[attr-defined]
+    capped_type = _test_die("DW_TAG_base_type", 20, byte_size=max_size)
+    assert obj._dwarf_type_size(capped_type, max_size) == max_size  # type: ignore[attr-defined]
+
+    first = _test_die("DW_TAG_const_type", 6, dwarfinfo=dwarfinfo)
+    second = _test_die("DW_TAG_typedef", 7, referenced=first, dwarfinfo=dwarfinfo)
+    first.attributes["DW_AT_type"] = SimpleNamespace()
+    first.get_DIE_from_attribute.return_value = second
+    assert obj._dwarf_type_size(first, max_size) is None  # type: ignore[attr-defined]
+
+
+def test_dwarf_extern_size_hint_declaration_identity():
+    path = os.path.join(TESTS_BASE, "tests", "x86_64", "decompiler", "sort.o")
+    obj = cle.Loader(path, auto_load_libs=False).main_object
+    pointer_type = _test_die("DW_TAG_pointer_type", 1, byte_size=obj.arch.bytes)
+
+    obj._load_dwarf_extern_size_hint(_test_declaration("Version", pointer_type))  # type: ignore[attr-defined]
+    assert "Version" not in obj.extern_size_hints  # type: ignore[attr-defined]
+
+    obj._load_dwarf_extern_size_hint(  # type: ignore[attr-defined]
+        _test_declaration("Version", pointer_type, external=True)
+    )
+    assert obj.extern_size_hints.pop("Version") == obj.arch.bytes  # type: ignore[attr-defined]
+
+    obj._load_dwarf_extern_size_hint(  # type: ignore[attr-defined]
+        _test_declaration("Version", pointer_type, linkage=True)
+    )
+    assert obj.extern_size_hints["Version"] == obj.arch.bytes  # type: ignore[attr-defined]
+
+
+def test_dwarf_extern_size_hint_only_scan():
+    path = os.path.join(TESTS_BASE, "tests", "x86_64", "decompiler", "sort.o")
+    obj = cle.Loader(path, auto_load_libs=False).main_object
+
+    with open(path, "rb") as binary:
+        obj._load_dwarf_extern_size_hints(ELFFile(binary).get_dwarf_info())  # type: ignore[attr-defined]
+
+    assert obj.extern_size_hints["Version"] == 8  # type: ignore[attr-defined]
+    assert obj.extern_size_hints["argmatch_die"] == 8  # type: ignore[attr-defined]
+    assert obj.extern_size_hints["exit_failure"] == 4  # type: ignore[attr-defined]
+    assert obj.extern_size_hints["program_name"] == 8  # type: ignore[attr-defined]
+
+
+def test_dwarf_extern_size_hint_scan_contains_known_cu_errors():
+    path = os.path.join(TESTS_BASE, "tests", "x86_64", "decompiler", "sort.o")
+    obj = cle.Loader(path, auto_load_libs=False).main_object
+    pointer_type = _test_die("DW_TAG_pointer_type", 1, byte_size=obj.arch.bytes)
+
+    for error in (DWARFError("bad DIE"), KeyError("bad reference"), NotImplementedError("imported unit")):
+        obj.extern_size_hints.pop("Version", None)  # type: ignore[attr-defined]
+        bad_cu = Mock()
+        bad_cu.iter_DIEs.side_effect = error
+        good_cu = Mock()
+        good_cu.iter_DIEs.return_value = [_test_declaration("Version", pointer_type, external=True)]
+        dwarf = Mock()
+        dwarf.iter_CUs.return_value = [bad_cu, good_cu]
+
+        obj._load_dwarf_extern_size_hints(dwarf)  # type: ignore[attr-defined]
+        assert obj.extern_size_hints["Version"] == obj.arch.bytes  # type: ignore[attr-defined]
+
+    unexpected_cu = Mock()
+    unexpected_cu.iter_DIEs.side_effect = RuntimeError("unexpected failure")
+    dwarf = Mock()
+    dwarf.iter_CUs.return_value = [unexpected_cu]
+    with unittest.TestCase().assertRaisesRegex(RuntimeError, "unexpected failure"):
+        obj._load_dwarf_extern_size_hints(dwarf)  # type: ignore[attr-defined]
+
+
+def test_embedded_dwarf_scan_contains_known_cu_errors():
+    path = os.path.join(TESTS_BASE, "tests", "x86_64", "decompiler", "sort.o")
+    obj = cle.Loader(path, auto_load_libs=False).main_object
+    pointer_type = _test_die("DW_TAG_pointer_type", 1, byte_size=obj.arch.bytes)
+
+    with open(path, "rb") as binary:
+        dwarf = ELFFile(binary).get_dwarf_info()
+        structs = next(dwarf.iter_CUs()).structs
+
+    for error in (DWARFError("bad DIE"), KeyError("bad reference"), NotImplementedError("imported unit")):
+        obj.extern_size_hints.pop("Version", None)  # type: ignore[attr-defined]
+        bad_cu = Mock(structs=structs)
+        bad_cu.iter_DIEs.side_effect = error
+        good_cu = Mock(structs=structs)
+        good_cu.iter_DIEs.return_value = [_test_declaration("Version", pointer_type, external=True)]
+        good_cu.get_top_DIE.return_value = SimpleNamespace(tag="DW_TAG_partial_unit")
+        dwarf = Mock()
+        dwarf.range_lists.return_value = None
+        dwarf.iter_CUs.return_value = [bad_cu, good_cu]
+
+        obj._load_dies(dwarf)  # type: ignore[attr-defined]
+        assert obj.extern_size_hints["Version"] == obj.arch.bytes  # type: ignore[attr-defined]
+
+    unexpected_cu = Mock(structs=structs)
+    unexpected_cu.iter_DIEs.side_effect = RuntimeError("unexpected failure")
+    dwarf = Mock()
+    dwarf.range_lists.return_value = None
+    dwarf.iter_CUs.return_value = [unexpected_cu]
+    with unittest.TestCase().assertRaisesRegex(RuntimeError, "unexpected failure"):
+        obj._load_dies(dwarf)  # type: ignore[attr-defined]
+
+
+def test_explicit_debug_symbols_load_extern_size_hints():
+    path = os.path.join(TESTS_BASE, "tests", "x86_64", "decompiler", "sort.o")
+    ld = cle.Loader(path, auto_load_libs=False, main_opts={"debug_symbols": path})
+
+    expected_sizes = {
+        "Version": 8,
+        "argmatch_die": 8,
+        "exit_failure": 4,
+        "program_name": 8,
+    }
+    extern_sizes = {symbol.name: symbol.size for symbol in ld.symbols if symbol.is_extern}
+    for name, size in expected_sizes.items():
+        assert ld.main_object.extern_size_hints[name] == size  # type: ignore[attr-defined]
+        assert extern_sizes[name] == size
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Loading `tests/x86_64/decompiler/sort.o` leaves the imported objects `Version`, `argmatch_die`, `exit_failure`, and `program_name` at size zero even though DWARF declares sizes `8`, `8`, `4`, and `8`.

### Root cause

CLE only fed relocation-addend estimates into the extern-size hint path. It read DWARF for symbols and lines but ignored explicit sizes on external variable declarations, including declarations reached through representation-preserving qualifiers.

### Fix

Read explicit positive DWARF sizes through typedef, const, volatile, restrict, and immutable wrappers; reject inferred pointer and array sizes; and bound each hint by the existing architecture-dependent extern capacity. Apply the scan to embedded and explicitly supplied separate debug information.

### Testing

The `sort.o` regression checks the exact four sizes, disabled debug loading, malformed and cyclic references, allocation bounds, and separate debug symbols. Exact-head hosted CI passed all 18 named jobs. Validation: https://github.com/angr/cle/pull/785#issuecomment-5403561709

session: sharpen
