### PR TITLE
Use SimData types for untyped externs

### DIFF
--- a/cle/backends/externs/__init__.py
+++ b/cle/backends/externs/__init__.py
@@ -102,15 +102,33 @@ class ExternObject(Backend):
         self.segments.append(ExternSegment(self.map_size))
         super().rebase(new_base)
 
+    @staticmethod
+    def _check_simdata_type(symbol: SimData, requested_type: SymbolType) -> None:
+        if requested_type in (SymbolType.TYPE_NONE, symbol.type):
+            return
+
+        mismatch = (requested_type, symbol.type)
+        warned_mismatches = getattr(symbol, "_warned_symbol_type_mismatches", None)
+        if warned_mismatches is None:
+            warned_mismatches = set()
+            setattr(symbol, "_warned_symbol_type_mismatches", warned_mismatches)
+        if mismatch not in warned_mismatches:
+            warned_mismatches.add(mismatch)
+            log.warning(
+                "Symbol type mismatch between export request and response for %s. What's going on?", symbol.name
+            )
+
     def make_extern(
         self, name, size=0, alignment=None, thumb=False, sym_type=SymbolType.TYPE_FUNCTION, point_to=None, libname=None
     ) -> Symbol:
         try:
-            return self._symbol_cache[name]
+            symbol = self._symbol_cache[name]
+            if isinstance(symbol, SimData):
+                self._check_simdata_type(symbol, sym_type)
+            return symbol
         except KeyError:
             pass
 
-        tls = sym_type == SymbolType.TYPE_TLS_OBJECT
         SymbolCls = Symbol
         if point_to is not None:
             simdata = PointToPrecise
@@ -119,9 +137,10 @@ class ExternObject(Backend):
         if simdata is not None:
             SymbolCls = simdata
             size = simdata.static_size(self)
-            if sym_type != simdata.type:
-                log.warning("Symbol type mismatch between export request and response for %s. What's going on?", name)
+            if sym_type == SymbolType.TYPE_NONE:
+                sym_type = simdata.type
 
+        tls = sym_type == SymbolType.TYPE_TLS_OBJECT
         real_size = max(size, 1)
 
         if alignment is None:
@@ -164,6 +183,8 @@ class ExternObject(Backend):
         self._symbol_cache[name] = new_symbol
         self.symbols.add(new_symbol)
         self._init_symbol(new_symbol)
+        if isinstance(new_symbol, SimData):
+            self._check_simdata_type(new_symbol, sym_type)
 
         if make_toc:
             # write the pointer to the func into the toc

--- a/tests/test_extern.py
+++ b/tests/test_extern.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import os
+import pickle
 import unittest
 
 import cle
 from cle.backends.elf.relocation.ppc64 import R_PPC64_JMP_SLOT
+from cle.backends.externs import ExternObject
 from cle.backends.symbol import SymbolType
 
 TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
@@ -78,6 +80,188 @@ def test_ppc64_abiv1_untyped_function_import():
     expected = descriptors(pristine)
     assert expected, "the pristine fixture has no jump slots to compare"
     assert descriptors(untyped) == expected
+
+
+class TestSimDataExternTypes(unittest.TestCase):
+    """Test that untyped extern requests use definitive SimData types."""
+
+    def test_untyped_imports_adopt_simdata_type(self):
+        path = os.path.join(TESTS_BASE, "tests", "x86_64", "decompiler", "sort.o")
+
+        with self.assertNoLogs("cle.backends.externs", level="WARNING"):
+            ld = cle.Loader(path, auto_load_libs=False)
+
+        for name in ("stdin", "stdout", "stderr", "optind", "optarg"):
+            import_symbol = ld.main_object.get_symbol(name)
+            self.assertIsNotNone(import_symbol)
+            assert import_symbol is not None
+            extern_symbol = import_symbol.resolvedby
+            self.assertIsNotNone(extern_symbol)
+            assert extern_symbol is not None
+            self.assertIs(extern_symbol.type, SymbolType.TYPE_OBJECT)
+            self.assertIs(extern_symbol._type, SymbolType.TYPE_OBJECT)
+
+    def test_untyped_tls_simdata_uses_tls_storage(self):
+        path = os.path.join(
+            TESTS_BASE,
+            "tests_src",
+            "i2c_master_read-nucleol152re",
+            "mbed",
+            "TARGET_NUCLEO_L152RE",
+            "TOOLCHAIN_GCC_ARM",
+            "mbed_retarget.o",
+        )
+        ld = cle.Loader(path, auto_load_libs=False)
+
+        import_symbol = ld.main_object.get_symbol("errno")
+        self.assertIsNotNone(import_symbol)
+        assert import_symbol is not None
+        self.assertIs(import_symbol.type, SymbolType.TYPE_NONE)
+
+        errno = import_symbol.resolvedby
+        self.assertIsNotNone(errno)
+        assert errno is not None
+        self.assertIsInstance(errno.owner, ExternObject)
+        owner = errno.owner
+        assert isinstance(owner, ExternObject)
+
+        self.assertIs(errno.type, SymbolType.TYPE_TLS_OBJECT)
+        self.assertIs(errno._type, SymbolType.TYPE_TLS_OBJECT)
+        self.assertEqual(errno.relative_addr, 0)
+        self.assertEqual(owner.tls_next_addr, errno.size)
+        self.assertEqual(owner.tls_data_size, errno.size)
+        self.assertEqual(owner.tls_block_size, errno.size)
+        self.assertTrue(owner.tls_used)
+        self.assertIn(owner, ld.tls.modules)
+        self.assertIsNotNone(owner.tls_module_id)
+        self.assertIsNotNone(getattr(owner, "tls_block_offset", None))
+
+    def test_definite_simdata_type_conflict_still_warns(self):
+        path = os.path.join(TESTS_BASE, "tests", "x86_64", "fauxware")
+        ld = cle.Loader(path, auto_load_libs=False)
+        root = ld.extern_object
+
+        with self.assertLogs("cle.backends.externs", level="WARNING") as logs:
+            progname = root.make_extern("__progname", sym_type=SymbolType.TYPE_FUNCTION)
+
+        self.assertEqual(sum("Symbol type mismatch" in message for message in logs.output), 1)
+        with self.assertNoLogs("cle.backends.externs", level="WARNING"):
+            repeated = root.make_extern("__progname", sym_type=SymbolType.TYPE_FUNCTION)
+
+        self.assertIs(repeated, progname)
+        self.assertIs(progname.type, SymbolType.TYPE_OBJECT)
+        # SimData.type describes the implementation, while _type retains the caller's definite request.
+        self.assertIs(progname._type, SymbolType.TYPE_FUNCTION)
+        self.assertIsInstance(progname.owner, ExternObject)
+        owner = progname.owner
+        assert isinstance(owner, ExternObject)
+        self.assertIsNot(owner, root)
+        self.assertEqual(owner.tls_next_addr, 0)
+        assert owner.tls_data_start is not None
+        self.assertGreaterEqual(progname.relative_addr, owner.tls_data_start + owner.tls_data_size)
+        self.assertLessEqual(progname.relative_addr + progname.size, owner.next_addr)
+
+    def test_cached_simdata_validates_later_definite_conflict(self):
+        path = os.path.join(TESTS_BASE, "tests", "x86_64", "fauxware")
+        ld = cle.Loader(path, auto_load_libs=False)
+
+        progname = ld.extern_object.make_extern("__progname", sym_type=SymbolType.TYPE_NONE)
+        self.assertIsInstance(progname.owner, ExternObject)
+        owner = progname.owner
+        assert isinstance(owner, ExternObject)
+        layout = (
+            progname.relative_addr,
+            progname.size,
+            owner.next_addr,
+            owner.tls_next_addr,
+            len(owner.symbols),
+            len(ld.all_objects),
+        )
+
+        with self.assertLogs("cle.backends.externs", level="WARNING") as logs:
+            conflicting = owner.make_extern("__progname", sym_type=SymbolType.TYPE_FUNCTION)
+        self.assertEqual(sum("Symbol type mismatch" in message for message in logs.output), 1)
+        with self.assertNoLogs("cle.backends.externs", level="WARNING"):
+            repeated = owner.make_extern("__progname", sym_type=SymbolType.TYPE_FUNCTION)
+            repeated_from_root = ld.extern_object.make_extern("__progname", sym_type=SymbolType.TYPE_FUNCTION)
+
+        self.assertIs(conflicting, progname)
+        self.assertIs(repeated, progname)
+        self.assertIs(repeated_from_root, progname)
+        self.assertIs(progname.type, SymbolType.TYPE_OBJECT)
+        self.assertIs(progname._type, SymbolType.TYPE_OBJECT)
+        self.assertEqual(
+            (
+                progname.relative_addr,
+                progname.size,
+                owner.next_addr,
+                owner.tls_next_addr,
+                len(owner.symbols),
+                len(ld.all_objects),
+            ),
+            layout,
+        )
+
+    def test_dynamic_load_simdata_conflicts_are_per_symbol(self):
+        path = os.path.join(TESTS_BASE, "tests", "x86_64", "decompiler", "sort.o")
+        ld = cle.Loader(path, auto_load_libs=False)
+
+        old_import = ld.main_object.get_symbol("stdout")
+        self.assertIsNotNone(old_import)
+        assert old_import is not None
+        old_stdout = old_import.resolvedby
+        self.assertIsNotNone(old_stdout)
+        assert old_stdout is not None
+        old_progname = ld.extern_object.make_extern("__progname", sym_type=SymbolType.TYPE_NONE)
+
+        with open(path, "rb") as binary:
+            loaded = ld.dynamic_load(binary)
+        self.assertIsNotNone(loaded)
+        assert loaded is not None
+        loaded_elf = next(obj for obj in loaded if isinstance(obj, cle.ELF))
+        new_import = loaded_elf.get_symbol("stdout")
+        self.assertIsNotNone(new_import)
+        assert new_import is not None
+        new_stdout = new_import.resolvedby
+        self.assertIsNotNone(new_stdout)
+        assert new_stdout is not None
+        self.assertIsNot(new_stdout, old_stdout)
+        self.assertIsInstance(old_stdout.owner, ExternObject)
+        old_owner = old_stdout.owner
+        assert isinstance(old_owner, ExternObject)
+        self.assertIsInstance(new_stdout.owner, ExternObject)
+        new_owner = new_stdout.owner
+        assert isinstance(new_owner, ExternObject)
+
+        with self.assertLogs("cle.backends.externs", level="WARNING") as logs:
+            found_progname = ld.extern_object.make_extern("__progname", sym_type=SymbolType.TYPE_FUNCTION)
+        self.assertEqual(sum("Symbol type mismatch" in message for message in logs.output), 1)
+        self.assertIs(found_progname, old_progname)
+
+        with self.assertLogs("cle.backends.externs", level="WARNING") as logs:
+            old_owner.make_extern("stdout", sym_type=SymbolType.TYPE_FUNCTION)
+            new_owner.make_extern("stdout", sym_type=SymbolType.TYPE_FUNCTION)
+        self.assertEqual(sum("Symbol type mismatch" in message for message in logs.output), 2)
+        with self.assertNoLogs("cle.backends.externs", level="WARNING"):
+            old_owner.make_extern("stdout", sym_type=SymbolType.TYPE_FUNCTION)
+            new_owner.make_extern("stdout", sym_type=SymbolType.TYPE_FUNCTION)
+
+    def test_cached_simdata_conflict_survives_legacy_pickle(self):
+        path = os.path.join(TESTS_BASE, "tests", "x86_64", "fauxware")
+        ld = cle.Loader(path, auto_load_libs=False)
+        progname = ld.extern_object.make_extern("__progname", sym_type=SymbolType.TYPE_NONE)
+        self.assertFalse(hasattr(progname, "_warned_symbol_type_mismatches"))
+
+        restored = pickle.loads(pickle.dumps(ld))
+        with self.assertLogs("cle.backends.externs", level="WARNING") as logs:
+            cached = restored.extern_object.make_extern("__progname", sym_type=SymbolType.TYPE_FUNCTION)
+        self.assertEqual(sum("Symbol type mismatch" in message for message in logs.output), 1)
+        with self.assertNoLogs("cle.backends.externs", level="WARNING"):
+            repeated = restored.extern_object.make_extern("__progname", sym_type=SymbolType.TYPE_FUNCTION)
+
+        self.assertIs(repeated, cached)
+        self.assertIs(cached.type, SymbolType.TYPE_OBJECT)
+        self.assertIs(cached._type, SymbolType.TYPE_OBJECT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

On `tests/x86_64/decompiler/sort.o`, untyped imports such as `stdin` and `stdout` resolve to object `SimData` but remain stored as `TYPE_NONE`. On `mbed_retarget.o`, the untyped `errno` import is consequently allocated in ordinary extern storage instead of TLS.

### Root cause

`make_extern` chose storage from the caller's requested type before consulting the definitive `SimData` declaration, then cached that choice. Later conflicts could therefore preserve the wrong layout or repeat warnings.

### Fix

When the request is untyped, adopt the `SimData` type before choosing ordinary or TLS storage. Explicit conflicts keep the caller's layout and warn once per symbol/type pair, including cached and restored symbols.

### Testing

Regressions load `sort.o`, `mbed_retarget.o`, and `fauxware` and cover object typing, TLS allocation, cached conflicts, dynamic loads, and legacy pickle state. Exact-head hosted CI passed all 18 named jobs. Validation: https://github.com/angr/cle/pull/786#issuecomment-5403585138

session: sharpen
