### PR TITLE
Load a Mach-O relocatable object

### DIFF
--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -203,6 +203,11 @@ class MachO(Backend):
                 # We can't set the linked base to request this, because the MachO Backend implementation
                 # uses this to recalculate the addresses
                 self._custom_base_addr = 0
+            elif self.filetype == MachoFiletype.MH_OBJECT:
+                # A relocatable object is linked against 0, and carries one unnamed segment holding every
+                # section. Nothing is bound yet, so this is the same base-address situation as a dylib
+                # loaded as the main object.
+                self._custom_base_addr = 0
             elif self.filetype == MachoFiletype.MH_DYLIB and not self.is_main_bin:
                 # A Library is loaded as a dependency, this is fine, the loader will map it to somewhere above the main
                 # binary, so we don't need to do anything
@@ -1144,7 +1149,7 @@ class MachO(Backend):
                 self._dyld_imports.append(sym)
             else:
                 raise NotImplementedError(
-                    f"Multiple symbols with name {sym_name}" f"for library {self.imported_libraries[imp.lib_ordinal]}."
+                    f"Multiple symbols with name {sym_name}for library {self.imported_libraries[imp.lib_ordinal]}."
                 )
 
     def _parse_dyld_chained_fixups(self):

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -10,7 +10,7 @@ import pytest
 
 import cle
 from cle import MachO
-from cle.backends.macho.macho_enums import LoadCommands, SectionAttributes, SectionType
+from cle.backends.macho.macho_enums import LoadCommands, MachoFiletype, SectionAttributes, SectionType
 from cle.backends.macho.section import MachOSection
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
@@ -426,3 +426,27 @@ if __name__ == "__main__":
     test_instruction_sections()
     test_zero_vmsize_segment()
     test_filesize_larger_than_vmsize()
+
+
+def test_relocatable_object():
+    """
+    A relocatable object is linked against 0 and holds every section in one unnamed segment, so its
+    base-address situation is the same as a dylib loaded as the main object. It used to be refused
+    outright as an unsupported file type.
+    """
+    for arch, name in (("aarch64", "AARCH64"), ("x86_64", "AMD64")):
+        machofile = os.path.join(TEST_BASE, "tests", arch, "relocatable_object.macho")
+        ld = cle.Loader(machofile, auto_load_libs=False)
+        obj = ld.main_object
+        assert isinstance(obj, MachO)
+        assert obj.filetype == MachoFiletype.MH_OBJECT
+        assert obj.arch.name == name
+        assert obj.mapped_base == 0
+
+        text = next(sec for sec in obj.sections if sec.name == "__text")
+        assert text.is_executable
+        assert text.memsize > 0
+
+        # The defined symbols carry real section-relative addresses; undefined externals stay at 0.
+        defined = {sym.name for sym in obj.symbols if sym.rebased_addr}
+        assert defined, "no defined symbol carries an address"


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A Mach-O `MH_OBJECT` is refused outright. On the aarch64 and x86_64
relocatable-object fixtures added by angr/binaries#193 the load ends here:

```
tests/aarch64/relocatable_object.macho:
  CLECompatibilityError: Unsupported Mach-O file type: 1. Please open an issue if you need support for this
tests/x86_64/relocatable_object.macho:
  CLECompatibilityError: Unsupported Mach-O file type: 1. Please open an issue if you need support for this
```

Nothing downstream sees the file at all — no sections, no symbols, no arch.

### Root cause

The gate that raises only chooses a base-address policy; every load command,
segment and section path after it is already shared with the filetypes that do
load. A relocatable object is linked against 0 and carries one unnamed segment
holding every section, so its situation is the same as a dylib loaded as the
main object, which that same gate already admits.

### Fix

Admit `MH_OBJECT` on the dylib branch of that gate. Relocations are
deliberately not applied, so an intra-object call still reads as a branch to
itself; that matches how ELF `ET_REL` and COFF objects are already handled
here, rather than being new behaviour.

### Testing

`tests/test_macho.py::test_relocatable_object` loads both fixtures and asserts
the sections and symbols; on master it fails with the
`CLECompatibilityError` above. After the change the aarch64 object maps
`[0x0:0x1e7]` and the x86_64 one `[0x0:0x1c7]`, each with `__text` followed by
`__bss` and the four symbols `_keccak_init`, `_keccak_absorb`,
`_keccak_squeeze` and `_state`.

Needs those fixtures.

These three Mach-O changes complement rather than replace each other; the
intended order is cle 728, then cle 674, then cle 787, and each closes a case
the others leave standing.

Validation: https://github.com/angr/cle/pull/787#issuecomment-5440299177

session: sharpen
