### PR TITLE
Make loader memory reads side-effect free

### DIFF
--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -525,7 +525,9 @@ class ELFCore(ELF):
                     while cursor < seg.filesize:
                         child_cursor = cursor + seg.vaddr - base_addr
                         try:
-                            child_offset, child_backer = next(obj.memory.backers(child_cursor))
+                            child_offset, child_backer = next(
+                                obj.memory._backers_for_reading(child_cursor)  # pylint: disable=protected-access
+                            )
                         except StopIteration:
                             # is this right? is there any behavior we need to account for in the case that there is
                             # somehow no backer past a point mapped by the core?

--- a/cle/backends/macho/encrypted_sentinel_backer.py
+++ b/cle/backends/macho/encrypted_sentinel_backer.py
@@ -111,9 +111,13 @@ class CryptSentinel(Clemory):
                 continue
 
             if start < interval[0] and addr < interval[0]:
-                yield start, backer[: interval[0] - start], owner
+                yield start, self._slice_for_reading(backer, 0, interval[0] - start), owner
             if end > interval[1]:
-                yield interval[1], backer[interval[1] - start :], owner
+                yield interval[1], self._slice_for_reading(backer, interval[1] - start, len(backer)), owner
+
+    @staticmethod
+    def _slice_for_reading(backer, start: int, end: int):
+        return backer[start:end] if isinstance(backer, list) else memoryview(backer)[start:end]
 
     def _assert_read_access(self, addr: int, size: int) -> None:
         self._assert_unencrypted_access(addr, size)

--- a/cle/backends/macho/encrypted_sentinel_backer.py
+++ b/cle/backends/macho/encrypted_sentinel_backer.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from mmap import mmap
+
 from cle.memory import Clemory
 
 
@@ -16,33 +19,115 @@ class CryptSentinel(Clemory):
 
     def __init__(self, arch, root=False):
         super().__init__(arch, root)
-        self._crypt_start = None
-        self._crypt_end = None
+        self._crypt_start: int | None = None
+        self._crypt_end: int | None = None
         self._is_encrypted: bool = False
+
+    def _effective_crypt_interval(self) -> tuple[int, int] | None:
+        if not self._is_encrypted:
+            return None
+        assert self._crypt_start is not None
+        assert self._crypt_end is not None
+        return self._crypt_start, self._crypt_end
 
     def load(self, addr, n):
         self._assert_unencrypted_access(addr, n)
+        interval = self._effective_crypt_interval()
+        if n == 0 and interval is not None and interval[0] <= addr < interval[1]:
+            try:
+                start, backer, _ = next(super()._backers_with_owners(addr))
+            except StopIteration:
+                raise KeyError(addr)  # pylint: disable=raise-missing-from
+            if start > addr:
+                raise KeyError(addr)
+            if isinstance(backer, list):
+                raise TypeError("Can't load bytes from Clemory backed by list[int]")
+            return b""
         return super().load(addr, n)
+
+    def __getitem__(self, addr):
+        self._assert_unencrypted_access(addr, 1)
+        return super().__getitem__(addr)
+
+    def __setitem__(self, addr, value):
+        self._assert_unencrypted_access(addr, 1)
+        return super().__setitem__(addr, value)
 
     def store(self, addr, data):
         self._assert_unencrypted_access(addr, len(data))
+        interval = self._effective_crypt_interval()
+        if not data and interval is not None and interval[0] <= addr < interval[1]:
+            try:
+                start, backer, _ = next(super()._backers_with_owners(addr))
+            except StopIteration:
+                raise KeyError(addr)  # pylint: disable=raise-missing-from
+            if not start <= addr < start + len(backer):
+                raise KeyError(addr)
+            return None
         return super().store(addr, data)
 
     def find(self, data, search_min=None, search_max=None):
-        if self._is_encrypted:
-            raise EncryptedDataAccessException("Cannot search encrypted memory region", self._crypt_start)
+        interval = self._effective_crypt_interval()
+        if interval is not None:
+            raise EncryptedDataAccessException("Cannot search encrypted memory region", interval[0])
         return super().find(data, search_min, search_max)
 
-    def set_crypt_info(self, cryptid, start, size):
+    def set_crypt_info(self, cryptid: int, start: int, size: int) -> None:
+        old_interval = self._effective_crypt_interval()
         self._is_encrypted = cryptid != 0 and size > 0
         self._crypt_start = start
         self._crypt_end = start + size
+        if self._effective_crypt_interval() != old_interval:
+            self._semantic_change(structural=True)
 
-    def backers(self, addr=0):
-        if self._is_encrypted:
-            if self._crypt_start <= addr < self._crypt_end:
-                raise EncryptedDataAccessException("Accessing encrypted memory region", addr)
-        return super().backers(addr)
+    def __getstate__(self):
+        state = super().__getstate__()
+        state.update(
+            {
+                "crypt_start": self._crypt_start,
+                "crypt_end": self._crypt_end,
+                "is_encrypted": self._is_encrypted,
+            }
+        )
+        return state
+
+    def __setstate__(self, state) -> None:
+        super().__setstate__(state)
+        self._crypt_start = state.get("crypt_start")
+        self._crypt_end = state.get("crypt_end")
+        self._is_encrypted = state.get("is_encrypted", False)
+
+    def _backers_with_owners_for_reading(
+        self, addr=0
+    ) -> Iterator[tuple[int, bytes | bytearray | memoryview | mmap | list[int], Clemory]]:
+        interval = self._effective_crypt_interval()
+        if interval is not None and interval[0] <= addr < interval[1]:
+            raise EncryptedDataAccessException("Accessing encrypted memory region", addr)
+
+        for start, backer, owner in super()._backers_with_owners_for_reading(addr):
+            end = start + len(backer)
+            if interval is None or end <= interval[0] or start >= interval[1]:
+                yield start, backer, owner
+                continue
+
+            if start < interval[0] and addr < interval[0]:
+                yield start, backer[: interval[0] - start], owner
+            if end > interval[1]:
+                yield interval[1], backer[interval[1] - start :], owner
+
+    def _assert_read_access(self, addr: int, size: int) -> None:
+        self._assert_unencrypted_access(addr, size)
+        super()._assert_read_access(addr, size)
+
+    def _backers_with_owners_for_writing(
+        self, addr: int, size: int
+    ) -> Iterator[tuple[int, bytearray | memoryview | mmap | list[int], Clemory]]:
+        self._assert_unencrypted_access(addr, size)
+        yield from super()._backers_with_owners_for_writing(addr, size)
+
+    def _backers_for_reading(self, addr=0) -> Iterator[tuple[int, bytes | bytearray | memoryview | mmap | list[int]]]:
+        for start, backer, _ in self._backers_with_owners_for_reading(addr):
+            yield start, backer
 
     def _assert_unencrypted_access(self, addr, size):
         """
@@ -58,11 +143,11 @@ class CryptSentinel(Clemory):
         :param size:
         :return:
         """
-        if not self._is_encrypted:
+        interval = self._effective_crypt_interval()
+        if interval is None:
             return
 
-        encrypted_range = range(self._crypt_start, self._crypt_end)
-        if addr in encrypted_range or (addr + size) in encrypted_range or (addr < self._crypt_start < addr + size):
+        if size > 0 and addr < interval[1] and addr + size > interval[0]:
             raise EncryptedDataAccessException("Accessing encrypted memory region", addr)
 
 

--- a/cle/memory.py
+++ b/cle/memory.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import bisect
+import copy
+import heapq
 import itertools
 import struct
-from collections.abc import Iterator
+import uuid
+import weakref
+from collections.abc import Iterator, Sized
+from contextlib import contextmanager
 from mmap import mmap
 from typing import Any, cast
 
@@ -11,13 +16,40 @@ import archinfo
 
 __all__ = ("ClemoryBase", "Clemory", "ClemoryView", "ClemoryTranslator", "UninitializedClemory")
 
+_UNMAPPED = object()
+
+
+def _contents_equal(left, right) -> bool:
+    try:
+        return bool(left == right)
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Arbitrary list-backed memory values may have unusual equality implementations.
+        return False
+
+
+class _SemanticChangeEvent:
+    """One byte/layout mutation propagated through a Clemory ownership graph."""
+
+    __slots__ = ("_seen", "semantic", "structural")
+
+    def __init__(self, structural: bool = False, semantic: bool = True):
+        self._seen = weakref.WeakSet()
+        self.semantic = semantic
+        self.structural = structural
+
+    def visit(self, memory: Clemory) -> bool:
+        if memory in self._seen:
+            return False
+        self._seen.add(memory)
+        return True
+
 
 class ClemoryBase:
     """
     The base class of all Clemory classes.
     """
 
-    __slots__ = ("_arch", "_pointer")
+    __slots__ = ("_arch", "_pointer", "__weakref__")
 
     def __init__(self, arch):
         self._arch = arch
@@ -38,8 +70,31 @@ class ClemoryBase:
     def store(self, addr, data):
         raise NotImplementedError
 
-    def backers(self, addr=0):
+    @property
+    def semantic_token(self) -> str:
+        """A stable identity for the current byte-level semantics of this memory."""
         raise NotImplementedError
+
+    @property
+    def layout_token(self) -> str:
+        """A stable identity for the current backing layout of this memory."""
+        raise NotImplementedError
+
+    def _backers_for_reading(self, addr=0):
+        """Yield private backing storage to trusted, read-only implementation code.
+
+        Callers must never retain or mutate the returned objects. Public consumers must
+        use :meth:`backers`, which returns immutable snapshots.
+        """
+        raise NotImplementedError
+
+    def _assert_read_access(self, addr: int, size: int) -> None:
+        """Validate a read before any bytes are returned. Subclasses may impose access policies."""
+
+    def backers(self, addr=0):
+        """Iterate over immutable snapshots of the mapped backers at or after ``addr``."""
+        for start, backer in self._backers_for_reading(addr):
+            yield start, tuple(backer) if isinstance(backer, list) else bytes(backer)
 
     def find(self, data, search_min=None, search_max=None) -> Iterator[int]:
         raise NotImplementedError
@@ -49,8 +104,9 @@ class ClemoryBase:
         Use the ``struct`` module to unpack the data at address `addr` with the format `fmt`.
         """
 
+        self._assert_read_access(addr, struct.calcsize(fmt))
         try:
-            start, backer = next(self.backers(addr))
+            start, backer = next(self._backers_for_reading(addr))
         except StopIteration:
             raise KeyError(addr)  # pylint: disable=raise-missing-from
 
@@ -120,19 +176,24 @@ class ClemoryBase:
         """
 
         try:
-            start, backer = next(self.backers(addr))
+            start, backer = next(self._backers_for_reading(addr))
         except StopIteration:
             raise KeyError(addr)  # pylint: disable=raise-missing-from
 
         if start > addr:
             raise KeyError(addr)  # pylint: disable=raise-missing-from
 
-        try:
-            return struct.pack_into(fmt, backer, addr - start, *data)
-        except struct.error as e:
-            if len(backer) - (addr - start) >= struct.calcsize(fmt):
-                raise e
-            raise KeyError(addr)  # pylint: disable=raise-missing-from
+        offset = addr - start
+        size = struct.calcsize(fmt)
+        if len(backer) - offset < size:
+            raise KeyError(addr)
+        if isinstance(backer, list):
+            packed = bytearray(backer)
+            struct.pack_into(fmt, packed, offset, *data)
+            self.store(addr, packed[offset : offset + size])
+            return None
+        self.store(addr, struct.pack(fmt, *data))
+        return None
 
     def pack_word(
         self,
@@ -195,7 +256,19 @@ class Clemory(ClemoryBase):
     Accesses can be made with [index] notation.
     """
 
-    __slots__ = ("_backers", "_root", "consecutive", "min_addr", "max_addr")
+    __slots__ = (
+        "_backers",
+        "_root",
+        "consecutive",
+        "min_addr",
+        "max_addr",
+        "_semantic_epoch",
+        "_semantic_revision",
+        "_layout_epoch",
+        "_layout_revision",
+        "_semantic_observers",
+        "_semantic_suppression_depth",
+    )
 
     def __init__(self, arch: archinfo.Arch, root: bool = False):
         super().__init__(arch)
@@ -204,6 +277,208 @@ class Clemory(ClemoryBase):
         self.consecutive: bool = True
         self.min_addr: int = 0
         self.max_addr: int = 0
+        self._semantic_epoch = uuid.uuid4().hex
+        self._semantic_revision = 0
+        self._layout_epoch = uuid.uuid4().hex
+        self._layout_revision = 0
+        self._semantic_observers: dict[int, weakref.WeakMethod] = {}
+        self._semantic_suppression_depth = 0
+
+    @property
+    def semantic_token(self) -> str:
+        return f"{self._semantic_epoch}:{self._semantic_revision}"
+
+    @property
+    def layout_token(self) -> str:
+        return f"{self._layout_epoch}:{self._layout_revision}"
+
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, memo):
+        if self.__class__ is not Clemory:
+            raise TypeError(f"Independent copies of {self.__class__.__name__} are not supported")
+        existing = memo.get(id(self))
+        if existing is not None:
+            return existing
+
+        clone = self.__class__.__new__(self.__class__)
+        memo[id(self)] = clone
+
+        cloned_backers = []
+        for start, backer in self._backers:
+            if isinstance(backer, mmap | memoryview):
+                raise TypeError("Independent copies of mmap-backed Clemory objects are not supported")
+            cloned_backer = copy.deepcopy(backer, memo)
+            cloned_backers.append((start, cloned_backer))
+
+        state = self.__getstate__()
+        state["_arch"] = self._arch
+        state["_backers"] = cloned_backers
+        state["semantic_epoch"] = uuid.uuid4().hex
+        state["semantic_revision"] = 0
+        state["layout_epoch"] = uuid.uuid4().hex
+        state["layout_revision"] = 0
+        clone.__setstate__(state)
+        return clone
+
+    def _semantic_change(
+        self, event=None, *, structural: bool = False, semantic: bool = True, force_forward: bool = False
+    ) -> None:
+        if self._semantic_suppression_depth:
+            return
+        if event is None:
+            event = _SemanticChangeEvent(structural=structural, semantic=semantic)
+        else:
+            if structural:
+                event.structural = True
+            if semantic:
+                event.semantic = True
+        first_visit = event.visit(self)
+        if not first_visit and not force_forward:
+            return
+        if first_visit:
+            if event.semantic:
+                self._semantic_revision += 1
+            if event.structural:
+                self._layout_revision += 1
+
+        stale_observers = []
+        for owner_id, observer_ref in self._semantic_observers.items():
+            observer = observer_ref()
+            if observer is None:
+                stale_observers.append(owner_id)
+            else:
+                observer(event)
+        for owner_id in stale_observers:
+            self._semantic_observers.pop(owner_id, None)
+
+    @contextmanager
+    def _suppress_semantic_changes(self):
+        self._semantic_suppression_depth += 1
+        try:
+            yield
+        finally:
+            self._semantic_suppression_depth -= 1
+
+    def _nested_semantic_change(self, event) -> None:
+        metadata_before = self.min_addr, self.max_addr, self.consecutive
+        if event.structural:
+            self._update_min_max()
+        metadata_changed = metadata_before != (self.min_addr, self.max_addr, self.consecutive)
+        self._semantic_change(event, semantic=False, force_forward=metadata_changed)
+
+    def _contains_nested_clemory(self, candidate: Clemory) -> bool:
+        if self is candidate:
+            return True
+        return any(
+            isinstance(backer, Clemory) and backer._contains_nested_clemory(candidate) for _, backer in self._backers
+        )
+
+    @staticmethod
+    def _backer_end(start, backer) -> int:
+        return start + (backer.max_addr if isinstance(backer, Clemory) else len(cast(Sized, backer)))
+
+    @staticmethod
+    def _slice_backer(backer, start: int, end: int):
+        sliced = backer[start:end]
+        return bytearray(sliced) if isinstance(backer, mmap) else sliced
+
+    def _prepare_overwrite_backers(self, start: int, data) -> tuple[list[tuple[int, Any]], tuple[Clemory, ...]]:
+        end = start + len(cast(Sized, data))
+        replacement_backers = []
+        removed_children = []
+
+        for backer_start, backer in self._backers:
+            backer_end = self._backer_end(backer_start, backer)
+            if backer_end <= start or end <= backer_start:
+                replacement_backers.append((backer_start, backer))
+                continue
+
+            if isinstance(backer, Clemory):
+                if start <= backer_start and backer_end <= end:
+                    removed_children.append(backer)
+                    continue
+                raise ValueError("Cannot partially overwrite a backer which is itself a Clemory")
+
+            if backer_start < start:
+                replacement_backers.append((backer_start, self._slice_backer(backer, 0, start - backer_start)))
+            if end < backer_end:
+                replacement_backers.append((end, self._slice_backer(backer, end - backer_start, len(backer))))
+
+        replacement_backers.append((start, data))
+        replacement_backers.sort(key=lambda item: item[0])
+        return replacement_backers, tuple(removed_children)
+
+    def _observe_nested_clemory(self, child: Clemory) -> None:
+        child._semantic_observers[id(self)] = weakref.WeakMethod(self._nested_semantic_change)
+
+    def _stop_observing_nested_clemory(self, child: Clemory) -> None:
+        if not any(backer is child for _, backer in self._backers):
+            child._semantic_observers.pop(id(self), None)
+
+    def _snapshot_range(self, start: int, size: int) -> tuple:
+        """Snapshot the visible contents and mapped shape of a range without per-address lookups."""
+        if size <= 0:
+            return ()
+
+        end = start + size
+        segments = []
+        for priority, (backer_start, backer, _) in enumerate(self._iter_all_backers_with_owners()):
+            backer_end = backer_start + len(backer)
+            visible_start = max(start, backer_start)
+            visible_end = min(end, backer_end)
+            if visible_start < visible_end:
+                segments.append((visible_start, visible_end, priority, backer_start, backer))
+
+        if not segments:
+            return ()
+
+        additions = {}
+        removals = {}
+        positions = {start, end}
+        for index, (visible_start, visible_end, _, _, _) in enumerate(segments):
+            additions.setdefault(visible_start, []).append(index)
+            removals.setdefault(visible_end, []).append(index)
+            positions.add(visible_start)
+            positions.add(visible_end)
+
+        active = set()
+        active_priorities = []
+        pieces = []
+        sorted_positions = sorted(positions)
+        for position, next_position in itertools.pairwise(sorted_positions):
+            active.difference_update(removals.get(position, ()))
+            for index in additions.get(position, ()):
+                active.add(index)
+                heapq.heappush(active_priorities, (segments[index][2], index))
+            while active_priorities and active_priorities[0][1] not in active:
+                heapq.heappop(active_priorities)
+            if not active_priorities or position == next_position:
+                continue
+
+            _, index = active_priorities[0]
+            _, _, _, backer_start, backer = segments[index]
+            offset = position - backer_start
+            length = next_position - position
+            if isinstance(backer, list):
+                pieces.append((position - start, "list", tuple(backer[offset : offset + length])))
+            else:
+                pieces.append((position - start, "bytes", bytes(memoryview(backer)[offset : offset + length])))
+
+        groups = []
+        for relative_start, kind, payload in pieces:
+            if groups and groups[-1][1] == kind and groups[-1][3] == relative_start:
+                groups[-1][2].append(payload)
+                groups[-1] = groups[-1][:3] + (relative_start + len(payload),)
+            else:
+                groups.append((relative_start, kind, [payload], relative_start + len(payload)))
+
+        snapshot = []
+        for relative_start, kind, payloads, _ in groups:
+            payload = tuple(itertools.chain.from_iterable(payloads)) if kind == "list" else b"".join(payloads)
+            snapshot.append((relative_start, kind, payload))
+        return tuple(snapshot)
 
     def add_backer(
         self, start: int, data: bytes | bytearray | memoryview | list[int] | Clemory | mmap, overwrite: bool = False
@@ -220,70 +495,104 @@ class Clemory(ClemoryBase):
         if not data:
             raise ValueError("Backer is empty!")
 
-        if not isinstance(data, bytes | bytearray | list | Clemory | mmap):
+        if not isinstance(data, bytes | bytearray | memoryview | list | Clemory | mmap):
             raise TypeError("Data must be a bytes, list, or Clemory object.")
-        if overwrite:
-            if isinstance(data, Clemory):
-                raise TypeError("Cannot perform an overwrite-add with a Clemory")
-            self.split_backer(start)
-            self.split_backer(start + len(data))
-            try:
-                self.remove_backer(start)
-            except ValueError:
-                pass
-            try:
-                existing, _ = next(self.backers(start + len(data)))
-            except StopIteration:
-                pass
-            else:
-                if existing < start + len(data):
-                    self.remove_backer(existing)
-        else:
-            try:
-                existing, _ = next(self.backers(start))
-            except StopIteration:
-                pass
-            else:
-                if existing <= start:
-                    raise ValueError(f"Address {start:#x} is already backed!")
         if isinstance(data, Clemory) and data._root:
             raise ValueError("Cannot add a root clemory as a backer!")
-        if isinstance(data, bytes):
+        if isinstance(data, Clemory) and data._contains_nested_clemory(self):
+            raise ValueError("Cannot create a cycle of nested Clemory backers")
+        if overwrite and isinstance(data, Clemory):
+            raise TypeError("Cannot perform an overwrite-add with a Clemory")
+        if isinstance(data, list):
+            data = list(data)
+        elif not isinstance(data, Clemory):
             data = bytearray(data)
-        bisect.insort(self._backers, (start, data), key=lambda x: x[0])
-        self._update_min_max()
+
+        data_size = len(cast(Sized, data)) if overwrite else 0
+        before = self._snapshot_range(start, data_size) if overwrite else None
+        layout_before = tuple((backer_start, id(backer)) for backer_start, backer in self._backers)
+        inserted = False
+        try:
+            with self._suppress_semantic_changes():
+                if overwrite:
+                    replacement_backers, removed_children = self._prepare_overwrite_backers(start, data)
+                    self._backers = replacement_backers
+                    for removed_child in removed_children:
+                        self._stop_observing_nested_clemory(removed_child)
+                    self._update_min_max()
+                    inserted = True
+                else:
+                    try:
+                        existing, _ = next(self._backers_for_reading(start))
+                    except StopIteration:
+                        pass
+                    else:
+                        if existing <= start:
+                            raise ValueError(f"Address {start:#x} is already backed!")
+                    bisect.insort(self._backers, (start, data), key=lambda x: x[0])
+                    inserted = True
+                    if isinstance(data, Clemory):
+                        self._observe_nested_clemory(data)
+                    self._update_min_max()
+        finally:
+            if overwrite:
+                after = self._snapshot_range(start, data_size)
+                layout_changed = layout_before != tuple(
+                    (backer_start, id(backer)) for backer_start, backer in self._backers
+                )
+                if layout_changed:
+                    self._semantic_change(
+                        structural=True,
+                        semantic=not _contents_equal(before, after),
+                    )
+            elif inserted:
+                self._semantic_change(structural=True)
 
     def split_backer(self, addr: int):
         """
         Ensures that ``addr`` is the start of a backer, if it is backed.
         """
-        try:
-            start_addr, backer = next(self.backers(addr))
-        except StopIteration:
-            return
-        if addr <= start_addr:
-            return
-        if isinstance(backer, ClemoryBase):
-            raise ValueError("Cannot split a backer which is itself a clemory")
-        if addr >= start_addr + len(backer):
+        for start_addr, backer in self._backers:
+            end_addr = start_addr + (backer.max_addr if isinstance(backer, Clemory) else len(backer))
+            if not start_addr < addr < end_addr:
+                continue
+            if isinstance(backer, ClemoryBase):
+                raise ValueError("Cannot split a backer which is itself a clemory")
+            break
+        else:
             return
 
-        self.remove_backer(start_addr)
-        b0, b1 = backer[: addr - start_addr], backer[addr - start_addr :]
-        self.add_backer(start_addr, b0)
-        self.add_backer(addr, b1)
+        track_semantics = self._semantic_suppression_depth == 0
+        before = self._snapshot_range(start_addr, len(backer)) if track_semantics else None
+        rewired = False
+        try:
+            with self._suppress_semantic_changes():
+                self.remove_backer(start_addr)
+                rewired = True
+                b0, b1 = backer[: addr - start_addr], backer[addr - start_addr :]
+                self.add_backer(start_addr, b0)
+                self.add_backer(addr, b1)
+        finally:
+            if track_semantics and rewired:
+                after = self._snapshot_range(start_addr, len(backer))
+                self._semantic_change(structural=True, semantic=not _contents_equal(before, after))
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} [{hex(self.min_addr)}:{hex(self.max_addr)}]>"
 
     def remove_backer(self, start):
-        backer_idx = bisect.bisect(self._backers, start, key=lambda x: x[0])
+        backer_idx = bisect.bisect_left(self._backers, start, key=lambda x: x[0])
 
         if len(self._backers) <= backer_idx or self._backers[backer_idx][0] != start:
             raise ValueError("Can't find backer to remove")
 
-        self._backers.pop(backer_idx)
-        self._update_min_max()
+        removed = self._backers.pop(backer_idx)[1]
+        try:
+            self._update_min_max()
+        finally:
+            if isinstance(removed, Clemory):
+                self._stop_observing_nested_clemory(removed)
+            self._semantic_change(structural=True)
 
     def __iter__(self):
         for start, string in self._backers:
@@ -311,8 +620,18 @@ class Clemory(ClemoryBase):
         for start, data in self._backers:
             if isinstance(data, bytearray | list):
                 if 0 <= k - start < len(data):
-                    data[k - start] = v
-                    return
+                    offset = k - start
+                    before = data[offset]
+                    try:
+                        data[offset] = v
+                        return
+                    finally:
+                        try:
+                            after = data[offset]
+                        except Exception:  # pylint: disable=broad-exception-caught
+                            after = _UNMAPPED
+                        if not _contents_equal(before, after):
+                            self._semantic_change()
             elif isinstance(data, Clemory):
                 if data.min_addr <= k - start < data.max_addr:
                     try:
@@ -350,6 +669,10 @@ class Clemory(ClemoryBase):
             "consecutive": self.consecutive,
             "min_addr": self.min_addr,
             "max_addr": self.max_addr,
+            "semantic_epoch": self._semantic_epoch,
+            "semantic_revision": self._semantic_revision,
+            "layout_epoch": self._layout_epoch,
+            "layout_revision": self._layout_revision,
         }
 
         return s
@@ -362,35 +685,81 @@ class Clemory(ClemoryBase):
         self.consecutive = s["consecutive"]
         self.min_addr = s["min_addr"]
         self.max_addr = s["max_addr"]
+        self._semantic_epoch = uuid.uuid4().hex
+        self._semantic_revision = s.get("semantic_revision", 0)
+        self._layout_epoch = uuid.uuid4().hex
+        self._layout_revision = s.get("layout_revision", 0)
+        self._semantic_observers = {}
+        self._semantic_suppression_depth = 0
+        for _, backer in self._backers:
+            if isinstance(backer, Clemory):
+                self._observe_nested_clemory(backer)
 
-    def backers(self, addr=0) -> Iterator[tuple[int, bytearray | memoryview | mmap | list[int]]]:
+    def _iter_all_backers_with_owners(
+        self,
+    ) -> Iterator[tuple[int, bytearray | memoryview | mmap | list[int], Clemory]]:
+        for start, backer in self._backers:
+            if isinstance(backer, Clemory):
+                for child_start, child_backer, owner in backer._iter_all_backers_with_owners():
+                    yield child_start + start, child_backer, owner
+            else:
+                yield start, backer, self
+
+    def _assert_read_access(self, addr: int, size: int) -> None:
+        for start, backer in self._backers:
+            if isinstance(backer, Clemory):
+                backer._assert_read_access(addr - start, size)
+
+    def _iter_all_backers_with_owners_for_reading(
+        self,
+        addr: int,
+    ) -> Iterator[tuple[int, bytes | bytearray | memoryview | mmap | list[int], Clemory]]:
+        for start, backer in self._backers:
+            if isinstance(backer, Clemory):
+                for child_start, child_backer, owner in backer._backers_with_owners_for_reading(addr - start):
+                    yield child_start + start, child_backer, owner
+            else:
+                yield start, backer, self
+
+    def _iter_all_backers_with_owners_for_writing(
+        self, addr: int, size: int
+    ) -> Iterator[tuple[int, bytearray | memoryview | mmap | list[int], Clemory]]:
+        for start, backer in self._backers:
+            if isinstance(backer, Clemory):
+                for child_start, child_backer, owner in backer._backers_with_owners_for_writing(addr - start, size):
+                    yield child_start + start, child_backer, owner
+            else:
+                yield start, backer, self
+
+    def _backers_with_owners(self, addr=0) -> Iterator[tuple[int, bytearray | memoryview | mmap | list[int], Clemory]]:
+        for start, backer, owner in self._iter_all_backers_with_owners():
+            if start + len(backer) > addr:
+                yield start, backer, owner
+
+    def _backers_with_owners_for_reading(
+        self, addr=0
+    ) -> Iterator[tuple[int, bytes | bytearray | memoryview | mmap | list[int], Clemory]]:
+        for start, backer, owner in self._iter_all_backers_with_owners_for_reading(addr):
+            if start + len(backer) > addr:
+                yield start, backer, owner
+
+    def _backers_with_owners_for_writing(
+        self, addr: int, size: int
+    ) -> Iterator[tuple[int, bytearray | memoryview | mmap | list[int], Clemory]]:
+        for start, backer, owner in self._iter_all_backers_with_owners_for_writing(addr, size):
+            if start + len(backer) > addr:
+                yield start, backer, owner
+
+    def _backers_for_reading(self, addr=0) -> Iterator[tuple[int, bytes | bytearray | memoryview | mmap | list[int]]]:
         """
-        Iterate through each backer for this clemory and all its children, yielding tuples of
-        ``(start_addr, backer)`` where each backer is a bytearray.
+        Iterate through each private backer for this clemory and all its children.
 
         :param addr:    An optional starting address - all backers before and not including this
                         address will be skipped.
         """
 
-        def calculate_end(backer: tuple[int, bytes | bytearray | memoryview | mmap | Clemory | list[int]]):
-            start, data = backer
-
-            if isinstance(data, Clemory):
-                return start + data.max_addr
-
-            return start + len(data)
-
-        if self.max_addr < addr:  # All the backers are smaller than addr
-            return
-
-        start_index = bisect.bisect(self._backers, addr, key=calculate_end)
-
-        for start, backer in itertools.islice(self._backers, start_index, None):
-            if isinstance(backer, Clemory):
-                for s, b in backer.backers(addr - start):
-                    yield s + start, b
-            else:
-                yield start, backer
+        for start, backer, _ in self._backers_with_owners_for_reading(addr):
+            yield start, backer
 
     def load(self, addr, n):
         """
@@ -399,9 +768,19 @@ class Clemory(ClemoryBase):
         Reading will stop at the beginning of the first unallocated region found, or when
         `n` bytes have been read.
         """
+        self._assert_read_access(addr, n)
+        if n == 0:
+            for start, backer, _ in self._backers_with_owners(addr):
+                if start > addr:
+                    break
+                if start <= addr < start + len(backer):
+                    if isinstance(backer, list):
+                        raise TypeError("Can't load bytes from Clemory backed by list[int]")
+                    return b""
+            raise KeyError(addr)
         views = []
 
-        for start, backer in self.backers(addr):
+        for start, backer in self._backers_for_reading(addr):
             if start > addr:
                 break
             if isinstance(backer, list):
@@ -429,21 +808,42 @@ class Clemory(ClemoryBase):
         Note: If the store runs off the end of a backer and into unbacked space, this function
         will update the backer but also raise ``KeyError``.
         """
-        for start, backer in self.backers(addr):
-            if start > addr:
+        changed_owners = set()
+        try:
+            # Materialize the policy-aware traversal before changing bytes. A nested memory can reject the write based
+            # on its own access policy, and that rejection must happen before an earlier sibling backer is modified.
+            backers = tuple(self._backers_with_owners_for_writing(addr, len(data)))
+            for start, backer, owner in backers:
+                if start > addr:
+                    raise KeyError(addr)
+                offset = addr - start
+                size = len(backer) - offset
+                write_size = min(len(data), size)
+                before = tuple(backer[offset : offset + write_size])
+                try:
+                    backer[offset : offset + len(data)] = data if len(data) <= size else data[:size]
+                finally:
+                    try:
+                        after = tuple(backer[offset : offset + write_size])
+                    except Exception:  # pylint: disable=broad-exception-caught
+                        changed_owners.add(owner)
+                    else:
+                        if not _contents_equal(before, after):
+                            changed_owners.add(owner)
+
+                addr += size
+                data = data[size:]
+
+                if not data:
+                    break
+
+            if data:
                 raise KeyError(addr)
-            offset = addr - start
-            size = len(backer) - offset
-            backer[offset : offset + len(data)] = data if len(data) <= size else data[:size]
-
-            addr += size
-            data = data[size:]
-
-            if not data:
-                break
-
-        if data:
-            raise KeyError(addr)
+        finally:
+            if changed_owners:
+                event = _SemanticChangeEvent()
+                for owner in changed_owners:
+                    owner._semantic_change(event)
 
     def find(self, data, search_min=None, search_max=None) -> Iterator[int]:
         """
@@ -481,6 +881,12 @@ class Clemory(ClemoryBase):
         """
         Update the three properties of Clemory: consecutive, min_addr, and max_addr.
         """
+
+        if not self._backers:
+            self.consecutive = True
+            self.min_addr = 0
+            self.max_addr = 0
+            return
 
         is_consecutive = True
         next_start = None
@@ -545,6 +951,14 @@ class ClemoryView(ClemoryBase):
         self._endoffset = offset + (end - start)
         self._rebase = self._start - self._offset
 
+    @property
+    def semantic_token(self) -> str:
+        return self._backer.semantic_token
+
+    @property
+    def layout_token(self) -> str:
+        return self._backer.layout_token
+
     def __getitem__(self, k):
         if not self._offset <= k < self._endoffset:
             raise KeyError(k)
@@ -553,15 +967,15 @@ class ClemoryView(ClemoryBase):
     def __setitem__(self, k, v):
         if not self._offset <= k < self._endoffset:
             raise KeyError(k)
-        return self._backer[k + self._rebase]
+        self._backer[k + self._rebase] = v
 
     def __contains__(self, k):
         if not self._offset <= k < self._endoffset:
             raise KeyError(k)
         return k + self._rebase in self._backer
 
-    def backers(self, addr=0):
-        for oaddr, backer in self._backer.backers(addr=addr + self._rebase):
+    def _backers_for_reading(self, addr=0):
+        for oaddr, backer in self._backer._backers_for_reading(addr=addr + self._rebase):
             taddr = oaddr - self._rebase
             if self._offset <= taddr < self._endoffset and self._offset <= taddr + len(backer) - 1 < self._endoffset:
                 yield taddr, backer
@@ -619,6 +1033,14 @@ class ClemoryTranslator(ClemoryBase):
         self.backer = backer
         self.func = func
 
+    @property
+    def semantic_token(self) -> str:
+        return self.backer.semantic_token
+
+    @property
+    def layout_token(self) -> str:
+        return self.backer.layout_token
+
     def __getitem__(self, k):
         return self.backer[self.func(k)]
 
@@ -634,7 +1056,10 @@ class ClemoryTranslator(ClemoryBase):
     def store(self, addr, data):
         self.backer.store(self.func(addr), data)
 
-    def backers(self, addr=0):
+    def pack(self, addr: int, fmt: str, *data):
+        return self.backer.pack(self.func(addr), fmt, *data)
+
+    def _backers_for_reading(self, addr=0):
         raise TypeError("Cannot access backers through address translation")
 
     def find(self, data, search_min=None, search_max=None) -> Iterator[int]:
@@ -662,7 +1087,7 @@ class UninitializedClemory(Clemory):
     def remove_backer(self, start):
         raise ValueError("This is an uninitialized clemory, backers cannot be removed")
 
-    def backers(self, addr=0):
+    def _backers_for_reading(self, addr=0):
         """
         Technically this object has no real backer
         We could create a fake backer on demand, but that would be a waste of memory, and code like the
@@ -700,10 +1125,28 @@ class ClemoryReadOnlyView(ClemoryBase):
 
         # cache
         self._last_backer_pos: int | None = None
+        self._layout_token = clemory.layout_token
 
         self._flatten_backers()
 
+    @property
+    def semantic_token(self) -> str:
+        return self._clemory.semantic_token
+
+    @property
+    def layout_token(self) -> str:
+        return self._clemory.layout_token
+
+    def _refresh_if_stale(self) -> None:
+        if getattr(self, "_layout_token", None) != self._clemory.layout_token:
+            self._flattened_backers.clear()
+            self._last_backer_pos = None
+            self._flatten_backers()
+            self._layout_token = self._clemory.layout_token
+
     def __getitem__(self, k) -> int:
+        self._assert_read_access(k, 1)
+        self._refresh_if_stale()
         # check cache first
         if self._last_backer_pos is not None:
             start, data = self._flattened_backers[self._last_backer_pos]
@@ -731,6 +1174,10 @@ class ClemoryReadOnlyView(ClemoryBase):
         Reading will stop at the beginning of the first unallocated region found, or when
         `n` bytes have been read.
         """
+        self._assert_read_access(addr, n)
+        if n == 0:
+            return self._clemory.load(addr, 0)
+        self._refresh_if_stale()
         # check cache first
         if self._last_backer_pos is not None:
             start, data = self._flattened_backers[self._last_backer_pos]
@@ -748,6 +1195,8 @@ class ClemoryReadOnlyView(ClemoryBase):
             if start > addr:
                 break
             offset = addr - start
+            if not 0 <= offset < len(data):
+                break
             if not views and offset + n < len(data):
                 # only cache if we do not need to read across backers
                 self._last_backer_pos = i
@@ -768,7 +1217,8 @@ class ClemoryReadOnlyView(ClemoryBase):
     def store(self, addr, data):
         raise NotImplementedError("ClemoryReadOnlyView does not support storing")
 
-    def backers(self, addr: int = 0):
+    def _backers_for_reading(self, addr: int = 0):
+        self._refresh_if_stale()
         start_pos = bisect.bisect_right(self._flattened_backers, addr, key=lambda x: x[0])
         if start_pos > 0:
             start_pos -= 1
@@ -780,6 +1230,8 @@ class ClemoryReadOnlyView(ClemoryBase):
                 yield start, data
 
     def unpack(self, addr, fmt):
+        self._assert_read_access(addr, struct.calcsize(fmt))
+        self._refresh_if_stale()
         if self._last_backer_pos is not None:
             start, data = self._flattened_backers[self._last_backer_pos]
             if 0 <= addr - start < len(data):
@@ -807,8 +1259,11 @@ class ClemoryReadOnlyView(ClemoryBase):
                 raise ex
             raise KeyError(addr) from ex
 
+    def _assert_read_access(self, addr: int, size: int) -> None:
+        self._clemory._assert_read_access(addr, size)
+
     def _flatten_backers(self):
-        for start, backer in self._clemory.backers():
+        for start, backer in self._clemory._backers_for_reading():
             if isinstance(backer, bytearray):
                 self._flattened_backers.append((start, backer))
             elif isinstance(backer, list):

--- a/cle/memory.py
+++ b/cle/memory.py
@@ -49,11 +49,42 @@ class ClemoryBase:
     The base class of all Clemory classes.
     """
 
-    __slots__ = ("_arch", "_pointer", "__weakref__")
+    __slots__ = (
+        "_arch",
+        "_pointer",
+        "_public_backer_snapshot_token",
+        "_public_backer_snapshots",
+        "__weakref__",
+    )
 
     def __init__(self, arch):
         self._arch = arch
         self._pointer = 0
+        self._public_backer_snapshot_token = None
+        self._public_backer_snapshots = {}
+
+    def _reset_public_backer_snapshot_cache(self) -> None:
+        self._public_backer_snapshot_token = None
+        self._public_backer_snapshots = {}
+
+    def _snapshot_public_backer(self, start, backer):
+        if isinstance(backer, list):
+            return list(backer)
+        if isinstance(backer, bytes):
+            return backer
+
+        token = (self.semantic_token, self.layout_token)
+        if self._public_backer_snapshot_token != token:
+            self._public_backer_snapshot_token = token
+            self._public_backer_snapshots.clear()
+
+        source = backer.obj if isinstance(backer, memoryview) else backer
+        key = start, id(source), len(backer)
+        cached = self._public_backer_snapshots.get(key)
+        if cached is None or cached[0] is not source:
+            cached = source, bytes(backer)
+            self._public_backer_snapshots[key] = cached
+        return cached[1]
 
     def __getitem__(self, k):
         raise NotImplementedError
@@ -84,7 +115,7 @@ class ClemoryBase:
         """Yield private backing storage to trusted, read-only implementation code.
 
         Callers must never retain or mutate the returned objects. Public consumers must
-        use :meth:`backers`, which returns immutable snapshots.
+        use :meth:`backers`, which returns detached snapshots.
         """
         raise NotImplementedError
 
@@ -92,9 +123,9 @@ class ClemoryBase:
         """Validate a read before any bytes are returned. Subclasses may impose access policies."""
 
     def backers(self, addr=0):
-        """Iterate over immutable snapshots of the mapped backers at or after ``addr``."""
+        """Iterate over detached snapshots of the mapped backers at or after ``addr``."""
         for start, backer in self._backers_for_reading(addr):
-            yield start, tuple(backer) if isinstance(backer, list) else bytes(backer)
+            yield start, self._snapshot_public_backer(start, backer)
 
     def find(self, data, search_min=None, search_max=None) -> Iterator[int]:
         raise NotImplementedError
@@ -338,6 +369,8 @@ class Clemory(ClemoryBase):
         if not first_visit and not force_forward:
             return
         if first_visit:
+            if event.semantic or event.structural:
+                self._reset_public_backer_snapshot_cache()
             if event.semantic:
                 self._semantic_revision += 1
             if event.structural:
@@ -681,6 +714,7 @@ class Clemory(ClemoryBase):
         self._arch = s["_arch"]
         self._backers = s["_backers"]
         self._pointer = s["_pointer"]
+        self._reset_public_backer_snapshot_cache()
         self._root = s["_root"]
         self.consecutive = s["consecutive"]
         self.min_addr = s["min_addr"]
@@ -1121,7 +1155,7 @@ class ClemoryReadOnlyView(ClemoryBase):
     def __init__(self, arch, clemory: Clemory):
         super().__init__(arch)
         self._clemory = clemory
-        self._flattened_backers: list[tuple[int, bytearray]] = []
+        self._flattened_backers: list[tuple[int, bytearray | memoryview]] = []
 
         # cache
         self._last_backer_pos: int | None = None
@@ -1264,7 +1298,7 @@ class ClemoryReadOnlyView(ClemoryBase):
 
     def _flatten_backers(self):
         for start, backer in self._clemory._backers_for_reading():
-            if isinstance(backer, bytearray):
+            if isinstance(backer, bytearray | memoryview):
                 self._flattened_backers.append((start, backer))
             elif isinstance(backer, list):
                 raise TypeError("ClemoryReadOnlyView does not support list-backed clemories")

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -165,7 +165,7 @@ def test_clemory_semantic_token_tracks_public_mutations():
     assert clemory.load(2, 2) == b"34"
 
 
-def test_clemory_mutable_backer_aliases_are_detached_and_public_backers_are_immutable():
+def test_clemory_mutable_backer_aliases_and_public_backers_are_detached():
     def assert_bytes_detached(source, mutate_source):
         clemory = cle.Clemory(None, root=True)
         clemory.add_backer(0, source)
@@ -176,6 +176,7 @@ def test_clemory_mutable_backer_aliases_are_detached_and_public_backers_are_immu
 
         _, exposed = next(clemory.backers())
         assert isinstance(exposed, bytes)
+        assert next(clemory.backers())[1] is exposed
         try:
             exposed[0] = ord("z")
         except TypeError:
@@ -203,13 +204,12 @@ def test_clemory_mutable_backer_aliases_are_detached_and_public_backers_are_immu
     assert list_memory.semantic_token == token
     assert list_memory[0] == 1
     _, exposed_list = next(list_memory.backers())
-    assert exposed_list == (1, 2, 3, 4)
-    try:
-        exposed_list[0] = 9
-    except TypeError:
-        pass
-    else:
-        raise AssertionError("List-backed public memory must be immutable")
+    assert exposed_list == [1, 2, 3, 4]
+    exposed_list[0] = 9
+    assert next(list_memory.backers())[1] == [1, 2, 3, 4]
+    assert next(list_memory.backers())[1] is not exposed_list
+    assert list_memory.semantic_token == token
+    assert list_memory[0] == 1
 
     child = cle.Clemory(None)
     child.add_backer(0, b"abcd")
@@ -219,6 +219,33 @@ def test_clemory_mutable_backer_aliases_are_detached_and_public_backers_are_immu
         _, exposed = next(memory.backers())
         assert isinstance(exposed, bytes)
         assert exposed == b"abcd"
+
+
+def test_public_backer_snapshot_cache_tracks_mutations_copies_and_pickle():
+    child = cle.Clemory(None)
+    child.add_backer(0, b"a" * 32)
+    parent = cle.Clemory(None, root=True)
+    parent.add_backer(0, child)
+
+    first = next(parent.backers())[1]
+    assert next(parent.backers())[1] is first
+    child.store(0, b"b")
+    changed = next(parent.backers())[1]
+    assert changed == b"b" + b"a" * 31
+    assert changed is not first
+
+    parent.store(0, b"b")
+    assert next(parent.backers())[1] is changed
+
+    independent = copy.deepcopy(parent)
+    restored = pickle.loads(pickle.dumps(parent, -1))
+    for clone in (independent, restored):
+        snapshot = next(clone.backers())[1]
+        assert snapshot == changed
+        assert snapshot is next(clone.backers())[1]
+        clone.store(1, b"c")
+        assert next(clone.backers())[1] == b"bc" + b"a" * 30
+        assert next(parent.backers())[1] is changed
 
 
 def test_crypt_sentinel_guards_public_and_trusted_backer_iterators():
@@ -240,6 +267,11 @@ def test_crypt_sentinel_guards_public_and_trusted_backer_iterators():
                 pass
             else:
                 raise AssertionError("Encrypted memory must not be exposed through a backer iterator")
+
+    public_before = list(memory.backers(0))
+    public_after = list(memory.backers(0))
+    assert [backer for _, backer in public_before] == [b"a", b"d"]
+    assert all(left is right for (_, left), (_, right) in zip(public_before, public_after))
 
     assert memory.load(0, 1) == b"a"
     assert memory.load(3, 1) == b"d"

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -1,12 +1,20 @@
+# These tests intentionally exercise dynamically typed backers, invalid mutation attempts, and arch-less memories.
+# pyright: reportArgumentType=false, reportAttributeAccessIssue=false, reportIndexIssue=false, reportOptionalOperand=false
 from __future__ import annotations
 
+import copy
+import pickle
+import struct
 import sys
 import timeit
 import unittest
+from mmap import mmap
 
+import archinfo
 import cffi
 
 import cle
+from cle.backends.macho.encrypted_sentinel_backer import CryptSentinel, EncryptedDataAccessException
 
 
 @unittest.skipIf(sys.platform == "emscripten", "runtime CFFI compilation is unavailable in Pyodide")
@@ -58,14 +66,14 @@ def test_clemory():
     assert len(clemory._backers) == 2
     try:
         clemory.store(0, b"")
-    except KeyError:
+    except (KeyError, EncryptedDataAccessException):
         assert True
     else:
         assert False
     assert len(clemory._backers) == 2
     try:
         clemory.load(0, 25)
-    except KeyError:
+    except (KeyError, EncryptedDataAccessException):
         assert True
     else:
         assert False
@@ -116,6 +124,615 @@ def test_clemory_contains():
     assert clemory.min_addr == 0
     assert clemory.max_addr == 70
     assert clemory.consecutive is True
+
+
+def test_clemory_semantic_token_tracks_public_mutations():
+    clemory = cle.Clemory(archinfo.ArchAMD64(), root=True)
+    token = clemory.semantic_token
+    clemory.add_backer(0, b"abcd")
+    assert clemory.semantic_token != token
+
+    token = clemory.semantic_token
+    clemory.store(0, b"abcd")
+    clemory[0] = ord("a")
+    clemory.pack(1, "B", ord("b"))
+    clemory.pack_word(2, ord("c"), size=1)
+    clemory.add_backer(0, b"abcd", overwrite=True)
+    assert clemory.semantic_token == token
+
+    for mutate, expected in (
+        (lambda: clemory.store(0, b"xbcd"), b"xbcd"),
+        (lambda: clemory.__setitem__(1, ord("y")), b"xycd"),
+        (lambda: clemory.pack(2, "B", ord("z")), b"xyzd"),
+        (lambda: clemory.pack_word(3, ord("!"), size=1), b"xyz!"),
+        (lambda: clemory.add_backer(0, b"1234", overwrite=True), b"1234"),
+    ):
+        token = clemory.semantic_token
+        mutate()
+        assert clemory.semantic_token != token
+        assert clemory.load(0, 4) == expected
+
+    token = clemory.semantic_token
+    layout_token = clemory.layout_token
+    clemory.split_backer(2)
+    assert clemory.semantic_token == token
+    assert clemory.layout_token != layout_token
+    assert clemory.load(0, 4) == b"1234"
+
+    token = clemory.semantic_token
+    clemory.remove_backer(0)
+    assert clemory.semantic_token != token
+    assert clemory.load(2, 2) == b"34"
+
+
+def test_clemory_mutable_backer_aliases_are_detached_and_public_backers_are_immutable():
+    def assert_bytes_detached(source, mutate_source):
+        clemory = cle.Clemory(None, root=True)
+        clemory.add_backer(0, source)
+        token = clemory.semantic_token
+        mutate_source()
+        assert clemory.semantic_token == token
+        assert clemory.load(0, 4) == b"abcd"
+
+        _, exposed = next(clemory.backers())
+        assert isinstance(exposed, bytes)
+        try:
+            exposed[0] = ord("z")
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("Public backers must not expose writable memory")
+        assert clemory.semantic_token == token
+        assert clemory.load(0, 4) == b"abcd"
+
+    bytearray_source = bytearray(b"abcd")
+    assert_bytes_detached(bytearray_source, lambda: bytearray_source.__setitem__(0, ord("x")))
+
+    memoryview_source = bytearray(b"abcd")
+    assert_bytes_detached(memoryview(memoryview_source), lambda: memoryview_source.__setitem__(0, ord("x")))
+
+    with mmap(-1, 4) as mmap_source:
+        mmap_source[:] = b"abcd"
+        assert_bytes_detached(mmap_source, lambda: mmap_source.__setitem__(0, ord("x")))
+
+    list_source = [1, 2, 3, 4]
+    list_memory = cle.Clemory(None, root=True)
+    list_memory.add_backer(0, list_source)
+    token = list_memory.semantic_token
+    list_source[0] = 9
+    assert list_memory.semantic_token == token
+    assert list_memory[0] == 1
+    _, exposed_list = next(list_memory.backers())
+    assert exposed_list == (1, 2, 3, 4)
+    try:
+        exposed_list[0] = 9
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("List-backed public memory must be immutable")
+
+    child = cle.Clemory(None)
+    child.add_backer(0, b"abcd")
+    parent = cle.Clemory(None, root=True)
+    parent.add_backer(0, child)
+    for memory in (parent, cle.ClemoryView(parent, 0, 4), cle.ClemoryReadOnlyView(None, parent)):
+        _, exposed = next(memory.backers())
+        assert isinstance(exposed, bytes)
+        assert exposed == b"abcd"
+
+
+def test_crypt_sentinel_guards_public_and_trusted_backer_iterators():
+    memory = CryptSentinel(None)
+    memory.add_backer(0, b"abcd")
+    memory.set_crypt_info(1, 1, 2)
+
+    for iterator in (memory.backers, memory._backers_for_reading):
+        before = [(start, bytes(backer)) for start, backer in iterator(0)]
+        after = [(start, bytes(backer)) for start, backer in iterator(3)]
+        assert before == [(0, b"a"), (3, b"d")]
+        assert after == [(3, b"d")]
+        assert all(end <= 1 or start >= 3 for start, backer in before for end in (start + len(backer),))
+
+        for addr in (1, 2):
+            try:
+                next(iterator(addr))
+            except EncryptedDataAccessException:
+                pass
+            else:
+                raise AssertionError("Encrypted memory must not be exposed through a backer iterator")
+
+    assert memory.load(0, 1) == b"a"
+    assert memory.load(3, 1) == b"d"
+    assert memory.load(1, 0) == b""
+    memory.store(0, b"A")
+    memory.store(3, b"D")
+    token = memory.semantic_token
+    memory.store(1, b"")
+    assert memory.semantic_token == token
+
+    for addr, size in ((0, 2), (1, 1), (2, 1), (2, 2)):
+        try:
+            memory.load(addr, size)
+        except EncryptedDataAccessException:
+            pass
+        else:
+            raise AssertionError("Loads overlapping encrypted memory must fail")
+
+        try:
+            memory.store(addr, b"x" * size)
+        except EncryptedDataAccessException:
+            pass
+        else:
+            raise AssertionError("Stores overlapping encrypted memory must fail")
+
+    assert memory.load(0, 1) == b"A"
+    assert memory.load(3, 1) == b"D"
+
+    parent = cle.Clemory(None, root=True)
+    parent.add_backer(0x1000, memory)
+    for operation in (
+        lambda: memory[1],
+        lambda: memory.__setitem__(1, ord("X")),
+        lambda: parent[0x1001],
+        lambda: parent.__setitem__(0x1001, ord("X")),
+        lambda: parent.store(0x1001, b"X"),
+    ):
+        try:
+            operation()
+        except EncryptedDataAccessException:
+            pass
+        else:
+            raise AssertionError("Encrypted bytes must not be accessible through item or nested store APIs")
+
+    memory.set_crypt_info(0, 1, 2)
+    assert parent.load(0x1000, 4) == b"AbcD"
+
+
+def test_nested_policy_aware_backers_preserve_negative_child_addresses():
+    child = cle.Clemory(None)
+    child.add_backer(-4, b"abcd")
+    parent = cle.Clemory(None, root=True)
+    parent.add_backer(0x1000, child)
+
+    assert parent.load(0xFFC, 4) == b"abcd"
+    assert list(parent.backers(0xFFC)) == [(0xFFC, b"abcd")]
+
+
+def test_crypt_sentinel_metadata_changes_refresh_nested_owners_and_views():
+    memory = CryptSentinel(archinfo.ArchAMD64())
+    memory.add_backer(0, b"abcd")
+    parent = cle.Clemory(archinfo.ArchAMD64(), root=True)
+    parent.add_backer(0x1000, memory)
+    read_only = cle.ClemoryReadOnlyView(parent._arch, parent)
+    assert read_only.load(0x1000, 4) == b"abcd"
+
+    memory_semantic_token = memory.semantic_token
+    memory_layout_token = memory.layout_token
+    parent_semantic_token = parent.semantic_token
+    parent_layout_token = parent.layout_token
+    memory.set_crypt_info(1, 1, 2)
+    assert memory.semantic_token != memory_semantic_token
+    assert memory.layout_token != memory_layout_token
+    assert parent.semantic_token != parent_semantic_token
+    assert parent.layout_token != parent_layout_token
+    first_enabled_token = memory.semantic_token
+    zero_length_tokens = tuple(owner.semantic_token for owner in (memory, parent, read_only))
+    assert memory.load(1, 0) == parent.load(0x1001, 0) == read_only.load(0x1001, 0) == b""
+    assert tuple(owner.semantic_token for owner in (memory, parent, read_only)) == zero_length_tokens
+    assert read_only.load(0x1000, 1) == b"a"
+    assert read_only.load(0x1003, 1) == b"d"
+    for owner in (parent, read_only):
+        try:
+            owner.load(0x1000, 4)
+        except EncryptedDataAccessException:
+            pass
+        else:
+            raise AssertionError("A nested read crossing encrypted bytes must fail before returning a prefix")
+    for owner in (parent, read_only):
+        try:
+            owner.load(0x1001, 1)
+        except (KeyError, EncryptedDataAccessException):
+            pass
+        else:
+            raise AssertionError("Nested encrypted bytes must not be exposed by an owner")
+
+    # The crypt identifier itself is not semantic when the effective interval is unchanged.
+    memory.set_crypt_info(2, 1, 2)
+    assert memory.semantic_token == first_enabled_token
+
+    parent_token = parent.semantic_token
+    memory.set_crypt_info(1, 2, 2)
+    assert parent.semantic_token != parent_token
+    assert read_only.load(0x1001, 1) == b"b"
+    try:
+        read_only.load(0x1002, 1)
+    except (KeyError, EncryptedDataAccessException):
+        pass
+    else:
+        raise AssertionError("Moving the encrypted interval must refresh cached owner views")
+
+    parent_token = parent.semantic_token
+    memory.set_crypt_info(0, 2, 2)
+    assert parent.semantic_token != parent_token
+    assert read_only.load(0x1000, 4) == b"abcd"
+
+    memory.set_crypt_info(1, 1, 2)
+    assert memory.semantic_token != first_enabled_token
+    try:
+        read_only.load(0x1001, 1)
+    except (KeyError, EncryptedDataAccessException):
+        pass
+    else:
+        raise AssertionError("Crypt interval ABA must not reuse stale view state")
+
+    restored = pickle.loads(pickle.dumps(memory, -1))
+    assert restored.semantic_token != memory.semantic_token
+    assert restored.layout_token != memory.layout_token
+    assert restored.load(0, 1) == b"a"
+    try:
+        restored.load(1, 1)
+    except EncryptedDataAccessException:
+        pass
+    else:
+        raise AssertionError("Pickling an active sentinel must preserve its encrypted interval")
+
+    try:
+        copy.deepcopy(memory)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("Independent CryptSentinel copies are intentionally unsupported")
+
+    legacy_state = memory.__getstate__()
+    legacy_state.pop("crypt_start")
+    legacy_state.pop("crypt_end")
+    legacy_state.pop("is_encrypted")
+    legacy = CryptSentinel.__new__(CryptSentinel)
+    legacy.__setstate__(legacy_state)
+    assert legacy.load(0, 4) == b"abcd"
+
+
+def test_clemory_partial_store_and_delegating_views_track_semantics():
+    clemory = cle.Clemory(archinfo.ArchAMD64(), root=True)
+    clemory.add_backer(0, b"ab")
+
+    token = clemory.semantic_token
+    try:
+        clemory.store(0, b"xy!")
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("A partial store into an unmapped range must fail")
+    assert clemory.load(0, 2) == b"xy"
+    assert clemory.semantic_token != token
+
+    token = clemory.semantic_token
+    try:
+        clemory.store(0, b"xy!")
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("A partial store into an unmapped range must fail")
+    assert clemory.semantic_token == token
+
+    view = cle.ClemoryView(clemory, 0, 2)
+    translator = cle.ClemoryTranslator(clemory, lambda addr: addr)
+    read_only = cle.ClemoryReadOnlyView(None, clemory)
+    assert view.semantic_token == translator.semantic_token == read_only.semantic_token == clemory.semantic_token
+
+    token = clemory.semantic_token
+    view[0] = ord("v")
+    assert clemory.semantic_token != token
+    token = clemory.semantic_token
+    translator.store(1, b"t")
+    assert clemory.semantic_token != token
+    token = clemory.semantic_token
+    view.pack(0, "B", ord("p"))
+    assert clemory.semantic_token != token
+    token = clemory.semantic_token
+    translator.pack(0, "B", ord("q"))
+    assert clemory.semantic_token != token
+    token = clemory.semantic_token
+    translator.pack_word(1, ord("r"), size=1)
+    assert clemory.semantic_token != token
+
+
+def test_nested_clemory_mutations_propagate_once_to_all_owners():
+    child = cle.Clemory(None)
+    child.add_backer(0, b"ab")
+    first = cle.Clemory(None, root=True)
+    second = cle.Clemory(None, root=True)
+    first.add_backer(0, child)
+    first.add_backer(2, b"cd")
+    second.add_backer(10, child)
+
+    first_revision = first._semantic_revision
+    second_revision = second._semantic_revision
+    child_revision = child._semantic_revision
+    first.store(0, b"wxyz")
+    assert first.load(0, 4) == b"wxyz"
+    assert second.load(10, 2) == b"wx"
+    assert first._semantic_revision == first_revision + 1
+    assert second._semantic_revision == second_revision + 1
+    assert child._semantic_revision == child_revision + 1
+
+    first_revision = first._semantic_revision
+    second_revision = second._semantic_revision
+    child_revision = child._semantic_revision
+    first.pack(0, "H", struct.unpack("H", b"12")[0])
+    assert first._semantic_revision == first_revision + 1
+    assert second._semantic_revision == second_revision + 1
+    assert child._semantic_revision == child_revision + 1
+
+    first.remove_backer(0)
+    first_revision = first._semantic_revision
+    second_revision = second._semantic_revision
+    child.store(0, b"zz")
+    assert first._semantic_revision == first_revision
+    assert second._semantic_revision == second_revision + 1
+
+
+def test_nested_clemory_structural_changes_recompute_diamond_ancestors():
+    leaf = cle.Clemory(None)
+    leaf.add_backer(0, b"ab")
+    left = cle.Clemory(None)
+    right = cle.Clemory(None)
+    left.add_backer(0, leaf)
+    right.add_backer(3, leaf)
+    root = cle.Clemory(None)
+    root.add_backer(0, left)
+    root.add_backer(10, right)
+    grandroot = cle.Clemory(None, root=True)
+    grandroot.add_backer(100, root)
+
+    memories = leaf, left, right, root, grandroot
+    revisions = tuple(memory._semantic_revision for memory in memories)
+    layout_revisions = tuple(memory._layout_revision for memory in memories)
+    leaf.add_backer(2, b"cd")
+
+    assert tuple(memory._semantic_revision for memory in memories) == tuple(revision + 1 for revision in revisions)
+    assert tuple(memory._layout_revision for memory in memories) == tuple(revision + 1 for revision in layout_revisions)
+    assert (left.min_addr, left.max_addr, left.consecutive) == (0, 4, True)
+    assert (right.min_addr, right.max_addr, right.consecutive) == (3, 7, True)
+    assert (root.min_addr, root.max_addr, root.consecutive) == (0, 17, False)
+    assert (grandroot.min_addr, grandroot.max_addr, grandroot.consecutive) == (100, 117, False)
+    assert root.load(13, 4) == b"abcd"
+    assert grandroot.load(113, 4) == b"abcd"
+    assert 16 in root and 116 in grandroot
+
+    revisions = tuple(memory._semantic_revision for memory in memories)
+    layout_revisions = tuple(memory._layout_revision for memory in memories)
+    leaf.add_backer(0, b"XY", overwrite=True)
+
+    assert tuple(memory._semantic_revision for memory in memories) == tuple(revision + 1 for revision in revisions)
+    assert tuple(memory._layout_revision for memory in memories) == tuple(revision + 1 for revision in layout_revisions)
+    assert (root.min_addr, root.max_addr) == (0, 17)
+    assert (grandroot.min_addr, grandroot.max_addr) == (100, 117)
+    assert root.load(13, 4) == b"XYcd"
+    assert grandroot.load(113, 4) == b"XYcd"
+
+    revisions = tuple(memory._semantic_revision for memory in memories)
+    layout_revisions = tuple(memory._layout_revision for memory in memories)
+    leaf.remove_backer(2)
+
+    assert tuple(memory._semantic_revision for memory in memories) == tuple(revision + 1 for revision in revisions)
+    assert tuple(memory._layout_revision for memory in memories) == tuple(revision + 1 for revision in layout_revisions)
+    assert (left.min_addr, left.max_addr, left.consecutive) == (0, 2, True)
+    assert (right.min_addr, right.max_addr, right.consecutive) == (3, 5, True)
+    assert (root.min_addr, root.max_addr, root.consecutive) == (0, 15, False)
+    assert (grandroot.min_addr, grandroot.max_addr, grandroot.consecutive) == (100, 115, False)
+    assert root.load(13, 2) == b"XY"
+    assert grandroot.load(113, 2) == b"XY"
+    assert 14 in root and 114 in grandroot
+    assert 15 not in root and 115 not in grandroot
+
+
+def test_nested_clemory_cycles_are_rejected_without_mutation():
+    first = cle.Clemory(None)
+    first.add_backer(0, b"a")
+    second = cle.Clemory(None)
+    second.add_backer(0, first)
+
+    token = first.semantic_token
+    backers = list(first._backers)
+    try:
+        first.add_backer(2, second)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Nested Clemory ownership cycles must be rejected")
+
+    assert first.semantic_token == token
+    assert first._backers == backers
+    assert first.load(0, 1) == b"a"
+
+
+def test_nested_clemory_duplicate_child_observers_detach_only_after_last_backer():
+    child = cle.Clemory(None)
+    child.add_backer(0, b"ab")
+    parent = cle.Clemory(None, root=True)
+    parent.add_backer(0, child)
+    parent.add_backer(10, child)
+    restored = pickle.loads(pickle.dumps(parent, -1))
+
+    for owner in (parent, restored):
+        owned_child = owner._backers[0][1]
+        assert owned_child is owner._backers[1][1]
+        revision = owner._semantic_revision
+        owned_child.store(0, b"xy")
+        assert owner._semantic_revision == revision + 1
+
+        owner.add_backer(0, b"QQ", overwrite=True)
+        revision = owner._semantic_revision
+        owned_child.store(0, b"12")
+        assert owner._semantic_revision == revision + 1
+        assert owner.load(10, 2) == b"12"
+
+        owner.remove_backer(10)
+        revision = owner._semantic_revision
+        owned_child.store(0, b"zz")
+        assert owner._semantic_revision == revision
+
+
+def test_clemory_read_only_view_refreshes_after_layout_only_changes():
+    child = cle.Clemory(None)
+    child.add_backer(0, b"abcd")
+    root = cle.Clemory(None, root=True)
+    root.add_backer(0, child)
+    read_only = cle.ClemoryReadOnlyView(None, root)
+
+    semantic_token = root.semantic_token
+    layout_token = root.layout_token
+    root.add_backer(0, b"abcd", overwrite=True)
+    assert root.semantic_token == semantic_token
+    assert root.layout_token != layout_token
+    child.store(0, b"xy")
+    assert root.semantic_token == semantic_token
+    assert root.load(0, 4) == read_only.load(0, 4) == b"abcd"
+
+    raw_root = cle.Clemory(None, root=True)
+    raw_root.add_backer(0, b"abcd")
+    raw_read_only = cle.ClemoryReadOnlyView(None, raw_root)
+    semantic_token = raw_root.semantic_token
+    layout_token = raw_root.layout_token
+    raw_root.split_backer(2)
+    assert raw_root.semantic_token == semantic_token
+    assert raw_root.layout_token != layout_token
+    raw_root.store(0, b"12")
+    assert raw_root.load(0, 4) == raw_read_only.load(0, 4) == b"12cd"
+
+    del raw_read_only._layout_token
+    legacy_read_only = pickle.loads(pickle.dumps(raw_read_only, -1))
+    assert legacy_read_only.load(0, 4) == b"12cd"
+    assert legacy_read_only.layout_token != raw_root.layout_token
+
+
+def test_clemory_overwrite_snapshot_handles_overlap_priority_and_negative_addresses():
+    overlapping = cle.Clemory(None, root=True)
+    overlapping.add_backer(20, b"B" * 40)
+    overlapping.add_backer(10, b"C" * 5)
+    overlapping.add_backer(0, b"A" * 100)
+    assert overlapping.load(50, 1) == b"A"
+
+    token = overlapping.semantic_token
+    overlapping.add_backer(50, b"Z", overwrite=True)
+    assert overlapping.semantic_token != token
+    assert overlapping.load(50, 1) == b"Z"
+    assert len([backer for start, backer in overlapping._backers if start == 50]) == 1
+
+    negative = cle.Clemory(None, root=True)
+    negative.add_backer(-4, b"abcd")
+    semantic_token = negative.semantic_token
+    layout_token = negative.layout_token
+    negative.add_backer(-4, b"abcd", overwrite=True)
+    assert negative.semantic_token == semantic_token
+    assert negative.layout_token != layout_token
+
+    semantic_token = negative.semantic_token
+    negative.add_backer(-4, b"wxyz", overwrite=True)
+    assert negative.semantic_token != semantic_token
+    assert negative.load(-4, 4) == b"wxyz"
+
+
+def test_clemory_overwrite_preflights_partial_nested_backers_atomically():
+    child = cle.Clemory(None)
+    child.add_backer(0, b"abcd")
+    parent = cle.Clemory(None, root=True)
+    parent.add_backer(10, child)
+    semantic_token = parent.semantic_token
+    layout_token = parent.layout_token
+    backers = list(parent._backers)
+
+    try:
+        parent.add_backer(11, b"X", overwrite=True)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("A partial nested-Clemory overwrite must be rejected")
+
+    assert parent.semantic_token == semantic_token
+    assert parent.layout_token == layout_token
+    assert parent._backers == backers
+    assert parent.load(10, 4) == b"abcd"
+    child.store(0, b"wxyz")
+    assert parent.semantic_token != semantic_token
+    assert parent.load(10, 4) == b"wxyz"
+
+
+def test_clemory_overwrite_snapshot_uses_bulk_backers_not_address_lookups():
+    class NoAddressLookupsClemory(cle.Clemory):
+        def __getitem__(self, _):
+            raise AssertionError("Overwrite snapshots must not perform one lookup per address")
+
+    clemory = NoAddressLookupsClemory(None, root=True)
+    data = b"A" * (2 * 1024 * 1024)
+    clemory.add_backer(0, data)
+    semantic_token = clemory.semantic_token
+    clemory.add_backer(0, data, overwrite=True)
+    assert clemory.semantic_token == semantic_token
+    assert clemory.load(0, len(data)) == data
+
+
+def test_clemory_semantic_token_pickle_and_legacy_state():
+    child = cle.Clemory(None)
+    child.add_backer(0, b"ab")
+    clemory = cle.Clemory(None, root=True)
+    clemory.add_backer(0x1000, child)
+    token = clemory.semantic_token
+    layout_token = clemory.layout_token
+
+    restored = pickle.loads(pickle.dumps(clemory, -1))
+    assert restored.semantic_token != token
+    assert restored.layout_token != layout_token
+    assert restored.load(0x1000, 2) == b"ab"
+    restored_child = restored._backers[0][1]
+    restored_token = restored.semantic_token
+    restored_child.store(0, b"xy")
+    assert restored.semantic_token != restored_token
+    assert clemory.load(0x1000, 2) == b"ab"
+
+    child.store(0, b"12")
+    assert clemory.semantic_token != restored.semantic_token
+    assert clemory.load(0x1000, 2) == b"12"
+    assert restored.load(0x1000, 2) == b"xy"
+
+    legacy_state = clemory.__getstate__()
+    legacy_state.pop("semantic_epoch")
+    legacy_state.pop("semantic_revision")
+    legacy_state.pop("layout_epoch")
+    legacy_state.pop("layout_revision")
+    legacy = cle.Clemory.__new__(cle.Clemory)
+    legacy.__setstate__(legacy_state)
+    legacy_token = legacy.semantic_token
+    legacy.store(0x1000, b"34")
+    assert legacy.semantic_token != legacy_token
+
+
+def test_clemory_copy_contract_freshens_pickle_and_deepcopies_independently():
+    child = cle.Clemory(None)
+    child.add_backer(0, b"ab")
+    source = cle.Clemory(None, root=True)
+    source.add_backer(0, child)
+    source.add_backer(10, child)
+
+    assert copy.copy(source) is source
+
+    cloned = copy.deepcopy(source)
+    assert cloned.semantic_token != source.semantic_token
+    assert cloned.layout_token != source.layout_token
+    assert cloned._semantic_revision == 0
+    assert cloned.load(0, 2) == cloned.load(10, 2) == b"ab"
+    cloned_child = cloned._backers[0][1]
+    assert cloned_child is cloned._backers[1][1]
+    assert cloned_child is not child
+
+    source_token = source.semantic_token
+    cloned_token = cloned.semantic_token
+    cloned_child.store(0, b"xy")
+    assert cloned.semantic_token != cloned_token
+    assert source.semantic_token == source_token
+    assert cloned.load(0, 2) == cloned.load(10, 2) == b"xy"
+    assert source.load(0, 2) == source.load(10, 2) == b"ab"
 
 
 def main():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`next(memory.backers())[1]` exposes mutable loader storage. Mutating that object can change later reads.

### Root cause

Public and trusted internal readers shared the same iterator.

### Fix

Return detached snapshots from public `backers()` while retaining a protected zero-copy iterator for trusted reads. Cache snapshots by semantic and layout identity, and propagate valid nested-memory changes to owners exactly once.

### Testing

`tests/test_clemory.py` covers detached aliases, address `0x1000` nested reads, encrypted ranges, overlap and cycle rejection, copies, pickle restoration, and legacy state. Validation: https://github.com/angr/cle/pull/788#issuecomment-5434740634

session: sharpen
