### PR TITLE
PE: Separate GNU EH-frame hints from unwind entries

### DIFF
--- a/cle/backends/backend.py
+++ b/cle/backends/backend.py
@@ -35,6 +35,7 @@ class FunctionHintSource:
     EXTERNAL_EH_FRAME = 1
     EXPORT_TABLE = 2
     MACHO_FUNCTION_STARTS = 3
+    EXCEPTION_DIRECTORY = 4
 
 
 class FunctionHint:

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -6,10 +6,14 @@ import os
 import re
 import struct
 from collections.abc import Callable
+from io import BytesIO
 from typing import Any
 
 import archinfo
 import pefile
+from elftools.common.exceptions import DWARFError, ELFParseError
+from elftools.dwarf import callframe
+from elftools.dwarf.structs import DWARFStructs
 
 try:
     import pyxdia
@@ -480,9 +484,39 @@ class PE(Backend):
                     FunctionHint(
                         entry.struct.BeginAddress + self.linked_base,
                         entry.struct.EndAddress - entry.struct.BeginAddress,
-                        FunctionHintSource.EH_FRAME,
+                        FunctionHintSource.EXCEPTION_DIRECTORY,
                     )
                 )
+
+        self._load_function_hints_from_gnu_eh_frame()
+
+    def _load_function_hints_from_gnu_eh_frame(self):
+        for section in self._pe.sections:
+            if self._get_section_name(section) != ".eh_frame":
+                continue
+
+            section_data = section.get_data()
+            section_size = min(section.Misc_VirtualSize or section.SizeOfRawData, len(section_data))
+            cfi = callframe.CallFrameInfo(
+                BytesIO(section_data),
+                section_size,
+                self.linked_base + section.VirtualAddress,
+                DWARFStructs(little_endian=True, dwarf_format=32, address_size=self.arch.bytes),
+                for_eh_frame=True,
+            )
+            try:
+                for entry in cfi.get_entries():
+                    if isinstance(entry, callframe.FDE):
+                        self.function_hints.append(
+                            FunctionHint(
+                                entry.header["initial_location"],
+                                entry.header["address_range"],
+                                FunctionHintSource.EH_FRAME,
+                            )
+                        )
+            except (DWARFError, ELFParseError, ValueError):
+                log.warning("An exception occurred while loading PE .eh_frame FDE information.", exc_info=True)
+            break
 
     def _parse_meta_regions(self):
         """
@@ -1100,19 +1134,28 @@ class PE(Backend):
         offset += self._pe.FILE_HEADER.PointerToSymbolTable + self._pe.FILE_HEADER.NumberOfSymbols * 18
         return extract_null_terminated_bytestr(self._raw_data, offset).decode(encoding)
 
+    def _get_section_name(self, pe_section) -> str:
+        """
+        The name of a PE section, resolving the indirect form.
+
+        A section header holds eight bytes of name, so a longer name is stored in the COFF string table and
+        the header carries a forward slash and a decimal byte offset into it instead.
+        """
+        name = pe_section.Name.rstrip(b"\x00").decode("latin-1")
+        # Match indirect section names given by a forward slash and a
+        # decimal byte offset into the string table.
+        str_tbl_offset_match = SECTION_NAME_STRING_TABLE_OFFSET_RE.fullmatch(name)
+        if str_tbl_offset_match:
+            return self._read_from_string_table(int(str_tbl_offset_match.group(1)))
+        return name
+
     def _register_sections(self):
         """
         Wrap self._pe.sections in PESection objects, and add them to self.sections.
         """
 
         for pe_section in self._pe.sections:
-            name = pe_section.Name.rstrip(b"\x00").decode("latin-1")
-            # Match indirect section names given by a forward slash and a
-            # decimal byte offset into the string table.
-            str_tbl_offset_match = SECTION_NAME_STRING_TABLE_OFFSET_RE.fullmatch(name)
-            if str_tbl_offset_match:
-                str_tbl_offset = int(str_tbl_offset_match.group(1))
-                name = self._read_from_string_table(str_tbl_offset)
+            name = self._get_section_name(pe_section)
             section = PESection(pe_section, remap_offset=self.linked_base, name=name)
             self.sections.append(section)
             self.sections_map[section.name] = section

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -114,6 +114,34 @@ class TestPEBackend(unittest.TestCase):
         )
         assert ld.main_object.provides is None
 
+    def test_gnu_eh_frame_function_hints(self):
+        exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "eh-frame-occupied-start.exe")
+        ld = cle.Loader(exe, auto_load_libs=False)
+
+        self.assertIn(".eh_frame", ld.main_object.sections_map)
+        hints = [
+            (hint.addr, hint.size)
+            for hint in ld.main_object.function_hints
+            if hint.source == cle.FunctionHintSource.EH_FRAME
+        ]
+        self.assertEqual([(0x40100A, 6)], hints)
+
+    def test_exception_directory_function_hint_source(self):
+        exe = os.path.join(
+            TEST_BASE,
+            "tests",
+            "x86_64",
+            "windows",
+            "7995a0325b446c462bdb6ae10b692eee2ecadd8e888e9d7729befe4412007afb",
+        )
+        ld = cle.Loader(exe, auto_load_libs=False)
+
+        self.assertEqual(4219, len(ld.main_object.function_hints))
+        self.assertEqual(
+            {cle.FunctionHintSource.EXCEPTION_DIRECTORY},
+            {hint.source for hint in ld.main_object.function_hints},
+        )
+
     def test_tls(self):
         exe = os.path.join(TEST_BASE, "tests", "x86", "windows", "TLS.exe")
         ld = cle.Loader(exe, auto_load_libs=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

CLE does not read a PE's GNU `.eh_frame` at all, and it labels native exception-directory records `EH_FRAME`, which is the name angr reserves for something else.

Both halves reproduce on binaries already on `angr/binaries` master, so this needs nothing unmerged to see:

```python
import cle
# a 32-bit MinGW PE with a .eh_frame section and no exception directory
o = cle.Loader("binaries/tests/i386/windows/known_patterns_wdk_ksud.exe", auto_load_libs=False).main_object
print(len(o.function_hints))          # master: 0        this branch: 81, all EH_FRAME

o = cle.Loader("binaries/tests/x86_64/windows/7995a0325b446c462bdb6ae10b692eee2ecadd8e888e9d7729befe4412007afb",
               auto_load_libs=False).main_object
print({h.source for h in o.function_hints})   # master: {EH_FRAME}   this branch: {EXCEPTION_DIRECTORY}
```

The `.eh_frame` of `known_patterns_wdk_ksud.exe` is not visible to a grep of its section headers: the name is nine characters, a header field is eight, so it is stored as `/4` and resolved through the COFF string table.

The new fixture on angr/binaries#196 covers the case those two cannot: an FDE whose start address CFGFast has already assigned to an enclosing function. In it the wrapper at `0x401006` tail-jumps to an unnamed six-byte function at `0x40100a` whose FDE is the only record that it is a function at all.

### Root cause

The PE backend never parsed GNU `.eh_frame`. Its only function hints came from the native unwind directory, so downstream angr could not distinguish the precise GNU FDE start from lower-confidence native unwind entries.

### Fix

Parse GNU PE FDEs as `EH_FRAME` hints and classify native unwind records as `EXCEPTION_DIRECTORY`. This gives angr the source distinction needed to preserve an occupied authoritative boundary.

This has a merge order: it must not land ahead of angr's pull request 6948. With this change and without that one, separating the two CLE hint sources turns all 4,219 exception-directory records of `tests/x86_64/windows/7995a0325b446c462bdb6ae10b692eee2ecadd8e888e9d7729befe4412007afb` into named function hints, and angr's existing assertion that `0x140032fd3` is not recovered fails. Land angr 6948 first, or land the two together. `EXCEPTION_DIRECTORY` is 4 rather than 3 because 3 is `MACHO_FUNCTION_STARTS`, which cle#810 added to this same class.

### Testing

`test_gnu_eh_frame_function_hints` asserts `FunctionHint(0x40100a, 6, EH_FRAME)` on the angr/binaries#196 fixture, and `test_exception_directory_function_hint_source` preserves all 4,219 native hints as `EXCEPTION_DIRECTORY` on a binary already on binaries master. The coordinated angr regression preserves a separate function and decompiles `return 42;`. Validation: https://github.com/angr/cle/pull/789#issuecomment-5419632095

sync: angr/angr#6948
sync: angr/binaries#196

session: sharpen