### PR TITLE
PE: Back the whole image the section table declares

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -179,12 +179,14 @@ class PE(Backend):
         self.linking = "dynamic" if self.deps else "static"
         self.jmprel = self._get_jmprel()
         mapped_image = self._get_memory_mapped_image()
-        if self.max_addr - self.min_addr < len(mapped_image):
+        # max_addr is the last address the object covers, not one past it.
+        mapped_size = self.max_addr - self.min_addr + 1
+        if mapped_size < len(mapped_image):
             # we are loading more bytes than max_addr would allow (there is data at the end of the file that is not
             # covered by any sections), so we need to truncate mapped_image.
             # this is actually caused by PE.get_memory_mapped_image() not passing ignore_padding=True to
             # section.get_data().
-            mapped_image = mapped_image[: self.max_addr - self.min_addr]
+            mapped_image = mapped_image[:mapped_size]
         self.memory.add_backer(0, mapped_image)
 
         if debug_symbols or self.loader._load_debug_info:

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -305,6 +305,7 @@ class PE(Backend):
 
         mapped_data_lst: list[bytes] = [self._pe.header]
         mapped_data_len = len(self._pe.header)
+        image_end = mapped_data_len
         for sec in self._pe.sections:
             if sec.Misc_VirtualSize == 0 and sec.SizeOfRawData == 0:
                 # skip empty sections
@@ -344,6 +345,16 @@ class PE(Backend):
             sec_data = sec.get_data()
             mapped_data_lst.append(sec_data)
             mapped_data_len += len(sec_data)
+
+            if size == sec.SizeOfRawData:
+                # a section is mapped over its whole virtual size, and the part of it the file holds no raw data for
+                # is zero. A section the file cuts short is not this case: those bytes are unknown, not zero.
+                image_end = max(image_end, va_adj + sec.Misc_VirtualSize)
+
+        if mapped_data_len < image_end:
+            # the padding that precedes a section is what backs the previous one's virtual size, so the last section
+            # of all has nothing to back its own
+            mapped_data_lst.append(b"\x00" * (image_end - mapped_data_len))
 
         return b"".join(mapped_data_lst)
 

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -325,6 +325,14 @@ class TestPEBackend(unittest.TestCase):
         assert ld.main_object.arch.name == "RISCV64"
         assert ld.main_object.os == "uefi"
 
+    def test_mapped_image_covers_max_addr(self):
+        exe = os.path.join(TEST_BASE, "tests", "i386", "simple_windows.exe")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        obj = ld.main_object
+
+        mapped_size = obj.max_addr - obj.min_addr + 1
+        assert len(ld.memory.load(obj.min_addr, mapped_size)) == mapped_size
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -333,6 +333,20 @@ class TestPEBackend(unittest.TestCase):
         mapped_size = obj.max_addr - obj.min_addr + 1
         assert len(ld.memory.load(obj.min_addr, mapped_size)) == mapped_size
 
+    def test_mapped_image_covers_uninitialized_tail(self):
+        exe = os.path.join(TEST_BASE, "tests", "i386", "windows", "rain32.upx")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        obj = ld.main_object
+
+        rsrc = ld.main_object.sections_map[".rsrc"]
+        assert rsrc.memsize == 0x1000
+        assert rsrc.filesize == 0x600
+        tail = rsrc.memsize - rsrc.filesize
+        assert ld.memory.load(rsrc.vaddr + rsrc.filesize, tail) == bytes(tail)
+
+        mapped_size = obj.max_addr - obj.min_addr + 1
+        assert len(ld.memory.load(obj.min_addr, mapped_size)) == mapped_size
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

cle backs less of a PE than the object says it covers. On `binaries/tests/i386/windows/rain32.upx`, whose `.rsrc` declares `memsize=0x1000` over `filesize=0x600`:

```
<PE Object rain32.upx, maps [0x400000:0x40afff]>
declares                      : 0x400000 .. 0x40afff  (0xb000 bytes)
mapped image the backend built: 0xa600 bytes

ld.memory.load(0x40afff, 1)  -> KeyError: 4239359    # last address the object declares
ld.memory.load(0x40a600, 1)  -> KeyError: 4236800    # the .rsrc tail
```

Every PE loses the last byte of its image this way, and a section whose virtual size exceeds its raw data loses that whole tail: 106 of the 106 PEs `angr/binaries` tracks at `fc07821c` back less than they declare. A base relocation whose field lands in the gap then gets a short buffer and `IMAGE_REL_BASED_HIGHLOW` raises `struct.error` out of `Loader`, losing the object entirely.

### Root cause

Two independent off-by-a-region errors in `cle/backends/pe/pe.py`.

`Backend.max_addr` is the last address an object covers, not one past it, but the clamp read `if self.max_addr - self.min_addr < len(mapped_image)` and truncated to `mapped_image[: self.max_addr - self.min_addr]`, one byte short of the declared range.

`_get_memory_mapped_image()` separately stops at the last section's raw data. A section is mapped over its whole `Misc_VirtualSize`, but the zero padding that backs that is emitted ahead of the *next* section, so the last section of all gets none. `.rsrc` is last in `rain32.upx`, which is why the 0xa00 bytes it declares beyond its raw data are in no object at all.

### Fix

The clamp spans `max_addr - min_addr + 1`, and the image is zero-padded up to the highest `virtual address + Misc_VirtualSize` of any section whose raw data the file holds in full. Same binary, same commands:

```
declares                      : 0x400000 .. 0x40afff  (0xb000 bytes)
mapped image the backend built: 0xb000 bytes

ld.memory.load(0x40afff, 1)  -> 00
ld.memory.load(0x40a600, 1)  -> 00
```

Deliberately not done: a section whose raw data lies outside the file keeps its unbacked tail, because those bytes are unknown rather than zero. `test_loading_incomplete_pe_file` pins that behaviour, and widening the fix to cover it fails that test.

### Testing

`tests/test_pe.py::test_mapped_image_covers_max_addr` requires `ld.memory.load(min_addr, max_addr - min_addr + 1)` on `binaries/tests/i386/simple_windows.exe` to return the full declared length; `test_mapped_image_covers_uninitialized_tail` requires `rain32.upx`'s `.rsrc` tail to read as zeroes. Both fail on the commit before them and `tests/test_pe.py` is 17 passed here. Across those same 106 PEs, 1 still backs less than it declares, and that is the out-of-file-section case above; `CFGFast(normalize=True)` over the public PE fixtures the change touches returns identical function and node address sets on both revisions.

One consumer, flagged rather than changed: zero-filling a section's unmapped tail removes the `None` return from `CFGFast._load_a_byte_as_int` for those addresses, which the open angr pull request 6943 depends on in its `is_sz = False` branch, so the two decide the recovered string set between them and merge order matters. Detail in the coupling note on this PR. cle#835 edits the same PE code and its description says this change's `image_end` becomes too small once it lands; measured, the two are independent and neither loses a byte, which the second coupling note records.

Validation: https://github.com/angr/cle/pull/790#issuecomment-5420513120

session: sharpen
