### PR TITLE
ELF: Take the word size from the machine, not the container

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -368,8 +368,14 @@ class ELF(MetaELF):
             if e_flags & EF_MIPS_ABI2 or (e_flags & EF_MIPS_ABI) == E_MIPS_ABI_O64:
                 return archinfo.ArchMIPSN32(archinfo.Endness.LE if reader.little_endian else archinfo.Endness.BE)
 
+        # The class gives the pointer width and the machine gives the instruction
+        # set, and the x32 ABI is where they disagree: an ELFCLASS32 container of
+        # EM_X86_64 code. Resolving that by the class picks 32-bit X86 and none of
+        # the instruction stream decodes.
+        bits = "64" if arch_str == "EM_X86_64" else reader.elfclass
+
         try:
-            return archinfo.arch_from_id(arch_str, "le" if reader.little_endian else "be", reader.elfclass)
+            return archinfo.arch_from_id(arch_str, "le" if reader.little_endian else "be", bits)
         except archinfo.ArchNotFound:
             arch = ELF._extract_pcode_arch(reader)
             if arch:

--- a/tests/test_arch_detect.py
+++ b/tests/test_arch_detect.py
@@ -22,6 +22,15 @@ class TestArchPcodeDetect(unittest.TestCase):
     Test architecture detection.
     """
 
+    def test_elf_x32(self):
+        # The x32 ABI puts x86-64 code in an ELFCLASS32 container: the class gives the pointer width
+        # and the machine gives the instruction set. Resolving by the class alone picks 32-bit X86,
+        # and none of the instruction stream decodes.
+        path = os.path.join(test_location, "x86_64", "x32_relocatable.o")
+        ld = cle.Loader(path, main_opts={"backend": "elf"}, auto_load_libs=False)
+
+        assert isinstance(ld.main_object.arch, archinfo.ArchAMD64)
+
     def test_elf_m68k(self):
         binpath = os.path.join(test_location, "m68k/mul_add_sub_xor_m68k_be")
         ld = cle.Loader(binpath, auto_load_libs=True)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ELF.extract_arch` takes the machine name from `e_machine` and the width from
`reader.elfclass`, which agree for every ordinary object. The x32 ABI is where
they do not: an ELFCLASS32 container holding `EM_X86_64` code, so the class
gives the pointer width and the machine gives the instruction set. Resolved by
the class, `arch_from_id` returns 32-bit X86 and the instruction stream is
decoded as x86. On `tests/x86_64/x32_relocatable.o`:

```
arch: <Arch X86 (LE)>
  0x00400000  55       push ebp
  0x00400003  8d0437   lea eax, [edi + esi]
```

where the same bytes are `push rbp` and `lea eax, [rdi + rsi]`. On a real x32
object the divergence is not cosmetic — the effect on block and function
recovery is in the validation record.

### Root cause

The width comes from the container:

```python
return archinfo.arch_from_id(arch_str, "le" if reader.little_endian else "be", reader.elfclass)
```

`reader.elfclass` is the pointer width, which for x32 is genuinely 32. The
instruction set is a property of `e_machine`, and nothing consults it.

### Fix

Take the width from the machine for `EM_X86_64`. That fixes the decode and
leaves the pointer width modelled as 64-bit where the ABI has 32, which is a
real approximation with a real cost: relocation slots are then written eight
bytes wide into four-byte slots, which loses roughly one object in forty to a
failed load. That cost is measured in the validation record. A faithful x32
architecture — x86-64 instructions with 32-bit pointers — would fix both and is
a larger piece of work than this repair.

### Testing

`tests/test_arch_detect.py::TestArchDetect::test_elf_x32` asserts
`isinstance(ld.main_object.arch, archinfo.ArchAMD64)` on the fixture in
angr/binaries#198 and fails that assertion on master. Across 17 x32 ELFs,
unwind-table function starts covered by no recovered block go from 69,664 to 2;
the population, the whole-suite results and the relocation-width measurement
are in the validation record.

Validation: https://github.com/angr/cle/pull/791#issuecomment-5420567833

sync: angr/binaries#198

session: sharpen