### PR TITLE
ELF: Survive a GNU hash table that declares no buckets

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1029,6 +1029,76 @@ class ELF(MetaELF):
         for seg in type_to_seg_mapping["PT_GNU_RELRO"]:
             self.__register_relro(seg)
 
+    # Tags whose value is an address. The fallback below compares them against DT_SYMTAB, so a tag
+    # holding a size or a string-table offset must not take part.
+    __DYNAMIC_POINTER_TAGS = frozenset(
+        {
+            "DT_PLTGOT",
+            "DT_HASH",
+            "DT_STRTAB",
+            "DT_SYMTAB",
+            "DT_RELA",
+            "DT_INIT",
+            "DT_FINI",
+            "DT_REL",
+            "DT_JMPREL",
+            "DT_INIT_ARRAY",
+            "DT_FINI_ARRAY",
+            "DT_PREINIT_ARRAY",
+            "DT_GNU_HASH",
+            "DT_VERSYM",
+            "DT_VERDEF",
+            "DT_VERNEED",
+            "DT_RELR",
+            "DT_MOVETAB",
+            "DT_SYMINFO",
+            "DT_CONFIG",
+            "DT_DEPAUDIT",
+            "DT_AUDIT",
+            "DT_TLSDESC_PLT",
+            "DT_TLSDESC_GOT",
+        }
+    )
+
+    def __num_dynamic_symbols(self, seg_readelf) -> int:
+        """
+        How many entries DT_SYMTAB holds.
+
+        pyelftools reads this out of DT_GNU_HASH or DT_HASH and has no answer when the table it
+        picks is malformed: a GNU hash table whose bucket array is empty makes it raise ValueError,
+        which aborts the whole load. Both tables only accelerate lookup by name, so a broken one is
+        no reason to give up on the symbol table itself. Fall back to the same bound pyelftools uses
+        when a file has neither table -- the nearest address above DT_SYMTAB -- restricted to tags
+        that really do hold addresses.
+        """
+        try:
+            return seg_readelf.num_symbols()
+        except (ELFError, ValueError) as ex:
+            log.warning("%s: hash table does not give a dynamic symbol count (%s)", self.binary, ex)
+
+        symtab = self._dynamic["DT_SYMTAB"]
+        entsize = self._dynamic["DT_SYMENT"]
+        if entsize <= 0:
+            return 0
+
+        end = None
+        for tagstr, val in self._dynamic.items():
+            if tagstr in self.__DYNAMIC_POINTER_TAGS and val > symtab and (end is None or val < end):
+                end = val
+        if end is None:
+            # No table follows it, so the symbol table runs to the end of whatever segment holds it.
+            for seg in self._reader.iter_segments():
+                if seg.header.p_type != "PT_LOAD":
+                    continue
+                start = seg.header.p_vaddr
+                if start <= symtab <= start + seg.header.p_filesz:
+                    end = start + seg.header.p_filesz
+                    break
+        if end is None:
+            log.warning("%s: cannot find the end of DT_SYMTAB; assuming it is empty", self.binary)
+            return 0
+        return (end - symtab) // entsize
+
     def __register_dyn(self, seg_readelf):
         """
         Parse the dynamic section for dynamically linked objects.
@@ -1076,7 +1146,7 @@ class ELF(MetaELF):
         # TODO: pyelftools is less bad than it used to be. how much of this can go away?
         # None of the following things make sense without a string table or a symbol table
         if "DT_STRTAB" in self._dynamic and "DT_SYMTAB" in self._dynamic and "DT_SYMENT" in self._dynamic:
-            num_symbols = seg_readelf.num_symbols()  # this is not actually reliable
+            num_symbols = self.__num_dynamic_symbols(seg_readelf)
 
             # Construct our own symbol table to hack around pyreadelf assuming section headers are around
             entsize = self._dynamic["DT_SYMENT"]

--- a/cle/backends/elf/hashtable.py
+++ b/cle/backends/elf/hashtable.py
@@ -96,6 +96,10 @@ class GNUHashTable:
 
         :param k:        The string to look up
         """
+        if self.nbuckets == 0:
+            # An empty bucket array hashes nothing, so no name is in this table. ELFHashTable.get
+            # already says so; without this the modulo below divides by zero.
+            return None, None
         h = self.gnu_hash(k)
         if not self._matches_bloom(h):
             return None, None

--- a/tests/test_gnu_hash_resiliency.py
+++ b/tests/test_gnu_hash_resiliency.py
@@ -1,0 +1,34 @@
+# pylint:disable=no-self-use,missing-class-docstring
+from __future__ import annotations
+
+import os
+from unittest import TestCase, main
+
+import cle
+
+TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries", "tests"))
+
+
+class TestGnuHashResiliency(TestCase):
+    def test_zeroed_hash_tables(self):
+        """
+        A hash table of all zeroes declares no buckets, which is not a reason to give up on the file.
+
+        gnu_hash_resiliency_0 is test_killing_ref with the bytes of its DT_HASH and DT_GNU_HASH
+        tables zeroed, the way some stripping and obfuscation tools leave a binary. Everything the
+        loader actually needs survives that, so the two must come out the same.
+        """
+        corrupt = cle.Loader(os.path.join(TESTS_BASE, "x86_64", "gnu_hash_resiliency_0"), auto_load_libs=False)
+        intact = cle.Loader(os.path.join(TESTS_BASE, "x86_64", "test_killing_ref"), auto_load_libs=False)
+
+        assert corrupt.main_object.entry == intact.main_object.entry
+        assert sorted(corrupt.main_object.imports) == sorted(intact.main_object.imports)
+        assert len(corrupt.main_object.relocs) == len(intact.main_object.relocs)
+        assert sorted((s.name, s.relative_addr) for s in corrupt.main_object.symbols) == sorted(
+            (s.name, s.relative_addr) for s in intact.main_object.symbols
+        )
+        assert corrupt.main_object.get_symbol("main") is not None
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

An ELF whose GNU hash table declares no buckets aborts the whole load. On `binaries/tests/x86_64/gnu_hash_resiliency_0`, the fixture in the linked binaries pull request — `test_killing_ref` with the 96 bytes of its `DT_HASH` and `DT_GNU_HASH` tables zeroed, the way some stripping and obfuscation tools leave a binary:

```
  File "cle/backends/elf/elf.py", line 1079, in __register_dyn
    num_symbols = seg_readelf.num_symbols()  # this is not actually reliable
  File "elftools/elf/dynamic.py", line 321, in _num_symbols
    return gnu_hash_section.get_number_of_symbols()
  File "elftools/elf/hash.py", line 160, in get_number_of_symbols
    max_idx = max(self.params['buckets'])
ValueError: max() iterable argument is empty
```

Nothing else about such a file need be broken. Its symbol table, relocations and version tables can be entirely intact, and both hash tables only accelerate lookup by name, so cle refuses a file it could read.

### Root cause

`ELF.__register_dyn` calls `seg_readelf.num_symbols()` unguarded. pyelftools sizes `DT_SYMTAB` from whichever hash table it finds, and `GnuHashSection.get_number_of_symbols` does `max(self.params['buckets'])` on an array that is empty here. The exception escapes `__register_dyn`, `__register_segments` and `ELF.__init__`, so a malformed lookup accelerator costs the entire load.

The same shape reaches cle's own table one step later: `GNUHashTable.get` does `h % self.nbuckets`, which is `ZeroDivisionError` when `nbuckets == 0`. `ELFHashTable.get` already returned no match for that case, so the two siblings disagreed.

### Fix

`ELF.__num_dynamic_symbols` catches `ELFError` and `ValueError` from `num_symbols()` and falls back to the bound pyelftools itself uses for a file with no hash table at all: the nearest dynamic pointer above `DT_SYMTAB`, restricted to tags that really do hold addresses rather than sizes or string-table offsets. `GNUHashTable.get` returns no match when `nbuckets == 0`. Same file, this head:

```
gnu_hash_resiliency_0: hash table does not give a dynamic symbol count (max() iterable argument is empty)
loaded : <ELF Object gnu_hash_resiliency_0, maps [0x400000:0x404017]>
entry 0x401070   symbols 56   sections 30   relocations 11   PLT 4   deps ['libc.so.6']
```

The fallback bound is exact rather than merely plausible, and checkable from the file: `DT_SYMTAB` is `0x3d0` and `DT_STRTAB` is `0x4a8`, so at `DT_SYMENT` 24 the table holds 9 entries with no remainder, and independently `DT_VERSYM 0x5fe` plus two bytes per symbol for 9 symbols reaches `0x610`, which is exactly `DT_VERNEED`.

### Testing

`tests/test_gnu_hash_resiliency.py::test_zeroed_hash_tables` loads the corrupted fixture and the uncorrupted `test_killing_ref` and requires the same entry, the same imports, the same relocation count and the same `(name, relative_addr)` symbol set. It fails on the baseline with the `ValueError` above and passes here; `pytest tests` reports 240 passed and 9 skipped against 239 and 9 on the baseline.

No linker emits an empty bucket array, checked positively: across 8,424 ELF files from a distribution's package closure the smallest `nbuckets` is 1, and a shared object exporting nothing links to `nbuckets = 1` under GNU ld 2.46 and under LLD 21.1.8 alike. Every ELF in `angr/binaries` was loaded on both revisions and compared on backend, entry, dependencies and digests of the symbol, section, segment, relocation and PLT tables: 831 files, 0 differences.

Validation: https://github.com/angr/cle/pull/792#issuecomment-5423536254

sync: angr/binaries#200

session: sharpen