### PR TITLE
ELF: Select the ARM BE8 architecture when EF_ARM_BE8 is set

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -58,6 +58,11 @@ _NON_ALLOCATED_SECTION_NAMES = {  # Sections that do not occupy memory at runtim
     "SHT_MIPS_REGINFO",
 }
 
+# The SLEIGH language for ARM BE8, declared endian="big" instructionEndian="little", which Ghidra's
+# own ARM ELF opinion selects on EF_ARM_BE8. It is the v7 language because that is the one archinfo
+# already names for 32-bit ARM; Ghidra publishes no big-endian-data variant below it.
+ARM_BE8_PCODE_LANGUAGE = "ARM:LEBE:32:v7LEInstruction"
+
 
 # MIPS e_flags bits that name the ABI. binutils include/elf/mips.h.
 EF_MIPS_ABI2 = 0x20  # n32
@@ -354,16 +359,18 @@ class ELF(MetaELF):
                 cpu_name = arm_attrs["TAG_CPU_NAME"]
                 if "Cortex-M" in cpu_name or "-M" in cpu_name:
                     return archinfo.ArchARMCortexM("Iend_LE")
-            endness = archinfo.Endness.LE if reader.little_endian else archinfo.Endness.BE
-            # EF_ARM_BE8 marks big-endian data with little-endian instruction words, the layout
-            # ARMv6 introduced. It is independent of the float-ABI bits, so read it alongside them.
-            instruction_endness = archinfo.Endness.LE if reader.header.e_flags & E_FLAGS.EF_ARM_BE8 else None
+            if reader.header.e_flags & E_FLAGS.EF_ARM_BE8:
+                # EF_ARM_BE8 marks big-endian data with little-endian instruction words, the layout
+                # ARMv6 introduced. No archinfo ARM architecture describes it, because Arch carries
+                # one endness and VEX uses it both to fetch instructions and to tag the accesses it
+                # lifts; SLEIGH separates the two, so the object goes to the p-code lifter instead.
+                if pypcode is not None:
+                    return archinfo.ArchPcode(ARM_BE8_PCODE_LANGUAGE)
+                log.warning("pypcode is not installed, so an ARM BE8 object is loaded as big-endian ARM")
             if reader.header.e_flags & 0x200:
-                return archinfo.ArchARMEL(endness, instruction_endness=instruction_endness)
-            if reader.header.e_flags & 0x400:
-                return archinfo.ArchARMHF(endness, instruction_endness=instruction_endness)
-            if instruction_endness is not None:
-                return archinfo.ArchARM(endness, instruction_endness=instruction_endness)
+                return archinfo.ArchARMEL("Iend_LE" if reader.little_endian else "Iend_BE")
+            elif reader.header.e_flags & 0x400:
+                return archinfo.ArchARMHF("Iend_LE" if reader.little_endian else "Iend_BE")
 
         if arch_str == "EM_MIPS" and reader.elfclass == 32:
             # The n32 and O64 ABIs put a 64-bit MIPS instruction stream in an ELFCLASS32

--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -19,6 +19,7 @@ from elftools.dwarf.dwarf_expr import DWARFExprParser
 from elftools.dwarf.dwarfinfo import DWARFInfo
 from elftools.dwarf.ranges import BaseAddressEntry, RangeEntry
 from elftools.elf import dynamic, elffile, enums, sections
+from elftools.elf.constants import E_FLAGS
 from elftools.elf.relocation import RelocationSection, RelrRelocationSection
 from sortedcontainers import SortedDict
 
@@ -353,10 +354,16 @@ class ELF(MetaELF):
                 cpu_name = arm_attrs["TAG_CPU_NAME"]
                 if "Cortex-M" in cpu_name or "-M" in cpu_name:
                     return archinfo.ArchARMCortexM("Iend_LE")
+            endness = archinfo.Endness.LE if reader.little_endian else archinfo.Endness.BE
+            # EF_ARM_BE8 marks big-endian data with little-endian instruction words, the layout
+            # ARMv6 introduced. It is independent of the float-ABI bits, so read it alongside them.
+            instruction_endness = archinfo.Endness.LE if reader.header.e_flags & E_FLAGS.EF_ARM_BE8 else None
             if reader.header.e_flags & 0x200:
-                return archinfo.ArchARMEL("Iend_LE" if reader.little_endian else "Iend_BE")
-            elif reader.header.e_flags & 0x400:
-                return archinfo.ArchARMHF("Iend_LE" if reader.little_endian else "Iend_BE")
+                return archinfo.ArchARMEL(endness, instruction_endness=instruction_endness)
+            if reader.header.e_flags & 0x400:
+                return archinfo.ArchARMHF(endness, instruction_endness=instruction_endness)
+            if instruction_endness is not None:
+                return archinfo.ArchARM(endness, instruction_endness=instruction_endness)
 
         if arch_str == "EM_MIPS" and reader.elfclass == 32:
             # The n32 and O64 ABIs put a 64-bit MIPS instruction stream in an ELFCLASS32

--- a/cle/backends/elf/relocation/__init__.py
+++ b/cle/backends/elf/relocation/__init__.py
@@ -19,6 +19,7 @@ ALL_RELOCATIONS = {
     "AARCH64": relocation_table_arm64,
     "ARMEL": relocation_table_arm,
     "ARMHF": relocation_table_arm,
+    "ARM:LEBE:32:v7LEInstruction": relocation_table_arm,
     "X86": relocation_table_i386,
     "MIPS32": relocation_table_mips,
     "MIPS64": relocation_table_mips,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ cle = ["py.typed"]
 py_limited_api = "cp312"
 
 [tool.uv.sources]
-archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
+archinfo = { git = "https://github.com/angr/archinfo.git", branch = "be8/arch" }
 bitarray = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
 cffi = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
 pycryptodome = { index = "pyodide", marker = "sys_platform == 'emscripten'" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ cle = ["py.typed"]
 py_limited_api = "cp312"
 
 [tool.uv.sources]
-archinfo = { git = "https://github.com/angr/archinfo.git", branch = "be8/arch" }
+archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
 bitarray = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
 cffi = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
 pycryptodome = { index = "pyodide", marker = "sys_platform == 'emscripten'" }

--- a/tests/test_arch_detect.py
+++ b/tests/test_arch_detect.py
@@ -35,12 +35,13 @@ class TestArmArchDetect(unittest.TestCase):
     Test ARM architecture detection, including the BE8 instruction/data endianness split.
     """
 
+    @unittest.skipIf(pypcode is None, "pypcode not installed")
     def test_elf_arm_be8(self):
         binpath = os.path.join(test_location, "armeb/be8_loop")
         arch = cle.Loader(binpath, auto_load_libs=False).main_object.arch
-        assert arch.name == "ARMHF"
+        assert isinstance(arch, archinfo.ArchPcode)
+        assert arch.name == "ARM:LEBE:32:v7LEInstruction"
         assert arch.memory_endness == archinfo.Endness.BE
-        assert arch.instruction_endness == archinfo.Endness.LE
 
     def test_elf_arm_be32(self):
         binpath = os.path.join(test_location, "armeb/be32_loop")
@@ -48,6 +49,18 @@ class TestArmArchDetect(unittest.TestCase):
         assert arch.name == "ARMHF"
         assert arch.memory_endness == archinfo.Endness.BE
         assert arch.instruction_endness == archinfo.Endness.BE
+
+    def test_elf_armhf_le(self):
+        binpath = os.path.join(test_location, "armhf/fauxware")
+        arch = cle.Loader(binpath, auto_load_libs=False).main_object.arch
+        assert arch.name == "ARMHF"
+        assert arch.memory_endness == archinfo.Endness.LE
+
+    def test_elf_armel_le(self):
+        binpath = os.path.join(test_location, "armel/test_arrays")
+        arch = cle.Loader(binpath, auto_load_libs=False).main_object.arch
+        assert arch.name == "ARMEL"
+        assert arch.memory_endness == archinfo.Endness.LE
 
 
 if __name__ == "__main__":

--- a/tests/test_arch_detect.py
+++ b/tests/test_arch_detect.py
@@ -30,5 +30,25 @@ class TestArchPcodeDetect(unittest.TestCase):
         assert arch.name == "68000:BE:32:default"
 
 
+class TestArmArchDetect(unittest.TestCase):
+    """
+    Test ARM architecture detection, including the BE8 instruction/data endianness split.
+    """
+
+    def test_elf_arm_be8(self):
+        binpath = os.path.join(test_location, "armeb/be8_loop")
+        arch = cle.Loader(binpath, auto_load_libs=False).main_object.arch
+        assert arch.name == "ARMHF"
+        assert arch.memory_endness == archinfo.Endness.BE
+        assert arch.instruction_endness == archinfo.Endness.LE
+
+    def test_elf_arm_be32(self):
+        binpath = os.path.join(test_location, "armeb/be32_loop")
+        arch = cle.Loader(binpath, auto_load_libs=False).main_object.arch
+        assert arch.name == "ARMHF"
+        assert arch.memory_endness == archinfo.Endness.BE
+        assert arch.instruction_endness == archinfo.Endness.BE
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

**Parked as a draft; do not review or merge in this shape.** The checks above
are green only because `[tool.uv.sources]` pins `archinfo` to the `be8/arch`
branch of archinfo 374, which has been closed. The branch still resolves, so CI
still passes against a change that is not going to land; against archinfo
master this diff raises `TypeError` on every ARM load, not only on BE8 objects,
because it passes `instruction_endness=` on all ARM paths. What has to happen
before this is ready is in Fix.

### Problem

`ELF.extract_arch` reads the ARM float-ABI bits out of `e_flags` but not
`EF_ARM_BE8`, so a BE8 object — big-endian data with little-endian
instructions, which ARMv6 introduced — is indistinguishable from a BE32 one.
The fixture pair in binaries 202 makes the difference visible: `be8_loop` has
`e_flags=0x05800400` with `EF_ARM_BE8` set, `be32_loop` has `0x05000400` with
it clear, and their `.text` sections are exact four-byte reversals of each
other. A BE8 object is loaded as fully big-endian, VEX fetches every
instruction byte-swapped, and across 48 BE8 ARM ELFs the baseline covers 4.892%
of the bytes marked as ARM code by `$a` mapping symbols.

### Root cause

`e_flags` is consulted for the ABI bits and not for `EF_ARM_BE8`, and
`arch_from_id` has no way to express the split in the first place:
`VexArchInfo` carries one endness for both instruction fetch and data access.

### Fix

Read the flag alongside the ABI bits and build the architecture with
little-endian instruction endness; a BE8 object carrying neither ABI bit
returns `ArchARM` directly rather than falling through to `arch_from_id`. Data
accesses are then tagged little-endian too, which is wrong, and separating the
two needs a libVEX change.

That is the design the parking note rejects. Ghidra already ships
`ARM:LEBE:32:v7LEInstruction` and `ARM:LEBE:32:v8LEInstruction`, declared
`endian="big" instructionEndian="little"`, and its ARM opinion constrains on
the BE8 flag directly, so the split can be had today through the p-code path
without an archinfo change at all. Before this becomes reviewable, the layer
question has to be settled that way, and it has to account for cle 610, a
third-party attempt at ARM BE8 in this same file that has been open far longer.

### Testing

`tests/test_arch_detect.py` covers both fixtures; on master the new case fails
with `assert <Endness.BE> == <Endness.LE>` for `arch.instruction_endness`. The
suite figures and the 48-object recovery measurement in the validation record
were taken with the closed archinfo branch on the path, so they describe a
dependency that no longer exists; they are kept as the size of the problem, not
as a claim about this branch. No output comparison is posted while this is
parked.

Validation: https://github.com/angr/cle/pull/793#issuecomment-5432381033

sync: angr/binaries#202

session: sharpen
