### PR TITLE
ELF: Resolve MIPS n32 and O64 from e_flags

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -58,6 +58,12 @@ _NON_ALLOCATED_SECTION_NAMES = {  # Sections that do not occupy memory at runtim
 }
 
 
+# MIPS e_flags bits that name the ABI. binutils include/elf/mips.h.
+EF_MIPS_ABI2 = 0x20  # n32
+EF_MIPS_ABI = 0x0000F000
+E_MIPS_ABI_O64 = 0x00002000
+
+
 # map 'e_machine' ELF header values (represented as `short int`s) to human-readable format (string)
 # There are mappings missing currently in `elftools`, so we provide them ourselves
 additional_e_machine_mappings: dict[int, str] = {
@@ -351,6 +357,16 @@ class ELF(MetaELF):
                 return archinfo.ArchARMEL("Iend_LE" if reader.little_endian else "Iend_BE")
             elif reader.header.e_flags & 0x400:
                 return archinfo.ArchARMHF("Iend_LE" if reader.little_endian else "Iend_BE")
+
+        if arch_str == "EM_MIPS" and reader.elfclass == 32:
+            # The n32 and O64 ABIs put a 64-bit MIPS instruction stream in an ELFCLASS32
+            # container, and say so in e_flags. Resolved by the class alone they become
+            # 32-bit MIPS and the instruction stream does not decode. The class is still
+            # right about everything else in the file -- Elf32_Rel, Elf32_Sym, 4-byte GOT
+            # slots -- so the word size must stay 32; only the instruction set is 64-bit.
+            e_flags = reader.header.e_flags
+            if e_flags & EF_MIPS_ABI2 or (e_flags & EF_MIPS_ABI) == E_MIPS_ABI_O64:
+                return archinfo.ArchMIPSN32(archinfo.Endness.LE if reader.little_endian else archinfo.Endness.BE)
 
         try:
             return archinfo.arch_from_id(arch_str, "le" if reader.little_endian else "be", reader.elfclass)

--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -161,7 +161,7 @@ class MetaELF(Backend):
         )
 
         # ATTEMPT 1: some arches will just leave the plt stub addr in the import symbol
-        if self.arch.name in ("ARM", "ARMEL", "ARMHF", "ARMCortexM", "AARCH64", "MIPS32", "MIPS64"):
+        if self.arch.name in ("ARM", "ARMEL", "ARMHF", "ARMCortexM", "AARCH64", "MIPS32", "MIPS64", "MIPSN32"):
             for name, reloc in func_jmprel.items():
                 if not plt_secs or any(plt_sec.contains_addr(reloc.symbol.linked_addr) for plt_sec in plt_secs):
                     self._add_plt_stub(name, reloc.symbol.linked_addr, sanity_check=bool(plt_secs))

--- a/cle/backends/elf/relocation/__init__.py
+++ b/cle/backends/elf/relocation/__init__.py
@@ -22,6 +22,7 @@ ALL_RELOCATIONS = {
     "X86": relocation_table_i386,
     "MIPS32": relocation_table_mips,
     "MIPS64": relocation_table_mips,
+    "MIPSN32": relocation_table_mips,
     "PPC32": relocation_table_ppc,
     "PPC64": relocation_table_ppc64,
     "S390X": relocation_table_s390x,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,11 @@ cle = ["py.typed"]
 py_limited_api = "cp312"
 
 [tool.uv.sources]
-archinfo = { git = "https://github.com/angr/archinfo.git", branch = "feature/mips-n32-arch" }
+archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
 bitarray = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
 cffi = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
 pycryptodome = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
-pyvex = { git = "https://github.com/angr/pyvex.git", branch = "feature/mips-n32-lifter" }
+pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
 
 [[tool.uv.index]]
 name = "pyodide"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,11 +78,11 @@ cle = ["py.typed"]
 py_limited_api = "cp312"
 
 [tool.uv.sources]
-archinfo = { git = "https://github.com/angr/archinfo.git", branch = "master" }
+archinfo = { git = "https://github.com/angr/archinfo.git", branch = "feature/mips-n32-arch" }
 bitarray = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
 cffi = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
 pycryptodome = { index = "pyodide", marker = "sys_platform == 'emscripten'" }
-pyvex = { git = "https://github.com/angr/pyvex.git", branch = "master" }
+pyvex = { git = "https://github.com/angr/pyvex.git", branch = "feature/mips-n32-lifter" }
 
 [[tool.uv.index]]
 name = "pyodide"

--- a/tests/test_mips_n32.py
+++ b/tests/test_mips_n32.py
@@ -1,0 +1,78 @@
+# pylint:disable=no-self-use
+from __future__ import annotations
+
+import os
+import unittest
+
+import archinfo
+
+import cle
+from cle.backends.elf.relocation.generic import MipsGlobalReloc, MipsLocalReloc
+
+test_location = str(os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../binaries/tests"))
+
+
+class TestMipsN32(unittest.TestCase):
+    """
+    The n32 and O64 ABIs put a 64-bit MIPS instruction stream in an ELFCLASS32 container. Taking
+    the instruction set from the container gives 32-bit MIPS and nothing decodes; taking the word
+    size from the instruction set instead gives 8-byte reads and writes into the file's 4-byte
+    relocation slots and GOT entries.
+    """
+
+    def _load(self, name):
+        return cle.Loader(os.path.join(test_location, "mipsn32", name), auto_load_libs=False)
+
+    def test_n32_big_endian(self):
+        arch = self._load("n32_be_static").main_object.arch
+        assert isinstance(arch, archinfo.ArchMIPSN32)
+        assert arch.memory_endness == archinfo.Endness.BE
+        assert arch.bits == 32
+        assert arch.vex_arch == "VexArchMIPS64"
+
+    def test_n32_little_endian(self):
+        arch = self._load("n32_el_dynamic").main_object.arch
+        assert isinstance(arch, archinfo.ArchMIPSN32)
+        assert arch.memory_endness == archinfo.Endness.LE
+
+    def test_n32_relocatable_object(self):
+        arch = self._load("n32_el.o").main_object.arch
+        assert isinstance(arch, archinfo.ArchMIPSN32)
+
+    def test_o64(self):
+        for name in ("o64_el_static", "o64_el.o"):
+            arch = self._load(name).main_object.arch
+            assert isinstance(arch, archinfo.ArchMIPSN32), name
+
+    def test_o32_is_still_mips32(self):
+        # The detection keys on the ABI bits, so a plain o32 object must be unaffected even when
+        # it was built for a 64-bit MIPS processor.
+        for name in ("mips/fauxware", "mipsel/fauxware"):
+            ld = cle.Loader(os.path.join(test_location, name), auto_load_libs=False)
+            assert type(ld.main_object.arch) is archinfo.ArchMIPS32, name
+
+    def test_n64_is_still_mips64(self):
+        ld = cle.Loader(os.path.join(test_location, "mips64/test_arrays"), auto_load_libs=False)
+        assert type(ld.main_object.arch) is archinfo.ArchMIPS64
+
+    def test_got_and_relocation_slots_stay_four_bytes(self):
+        obj = self._load("n32_el_dynamic").main_object
+        assert obj.arch.bytes == 4
+
+        # Every relocation must apply without raising. Resolving n32 to a 64-bit architecture
+        # reads an 8-byte implicit addend out of a 4-byte REL slot and writes 8 bytes back over
+        # the neighbouring word, which shows up here as a KeyError off the end of the GOT.
+        for reloc in obj.relocs:
+            reloc.relocate()
+
+        # The MIPS GOT is strided by the word size. At 8 bytes the entries would land on every
+        # other slot and run off the end of the section.
+        got = sorted(r.dest_addr for r in obj.relocs if isinstance(r, MipsGlobalReloc | MipsLocalReloc))
+        assert got, "expected a classic MIPS GOT"
+        assert min(b - a for a, b in zip(got, got[1:])) == 4
+        got_section = obj.sections_map[".got"]
+        assert got[-1] + 4 <= got_section.vaddr + got_section.memsize
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ELF.extract_arch` resolves MIPS by container class, so an n32 or O64 object —
64-bit MIPS instructions in an ELFCLASS32 container — loads as 32-bit MIPS and
the instruction stream stops decoding at the first 64-bit opcode. On
`tests/mipsn32/n32_el_dynamic`, `main` at `0x4006c0`:

```
arch: <Arch MIPS32 (LE)>
  0x004006c0  e0ffbd27     addiu $sp, $sp, -0x20
```

and that is the whole of it: the next word, `0x0800bcff`, is `sd $gp, 8($sp)`,
which a 32-bit MIPS decoder has no encoding for. Every function that spills
`$gp` this way ends after one instruction.

### Root cause

The ABI is stated in `e_flags`, and nothing reads it: `EF_MIPS_ABI2` marks n32,
and the ABI nibble marks O64. Both leave `e_ident[EI_CLASS]` at `ELFCLASS32`,
which is correct — the pointer width really is 32 — so resolving the
architecture from the class alone cannot distinguish them from o32.

### Fix

Read the ABI from `e_flags` and resolve to `ArchMIPSN32`. The pointer width
stays 32-bit: these objects' relocations, symbol tables and GOT slots are
Elf32-sized, so resolving to `ArchMIPS64` would decode correctly and then fail
to load.

~~`[tool.uv.sources]` temporarily pins `archinfo` and `pyvex`; both must return
to `master` before this merges.~~

**Updated 2026-08-29.** Both merged today, archinfo 375 at 14:15Z and pyvex 576
at 14:19Z, and GitHub deleted the branches on merge, so `uv sync` here stopped at
`failed to fetch branch feature/mips-n32-lifter`. The checks above were green from
08:44Z to 11:20Z, before the deletion, so they were stale rather than passing.
`d5f9497` points both pins back at `master`; the content does not change with the
switch, since archinfo master is byte-identical to the tree at that pull request's
head and pyvex master differs from its one only in a license identifier string.
This also unblocked angr 6982, whose `uv sync` follows this file through the git
dependency on this branch and was still fetching the deleted branch after its own
pins were fixed.

### Testing

`tests/test_mips_n32.py` covers both ABIs on the fixtures in binaries 206. On
all five — the dynamic n32 executable, the big-endian n32 static, the O64
static and the two relocatable objects — resolution goes from `MIPS32` to
`MIPSN32`, and `main` disassembles past the `sd` instead of stopping at it.

~~These four must land together: with the loader and the architecture definition
ahead of the lifter, `MIPSN32` reaches a lifter with no entry for it and
recovery on these objects drops to zero blocks. Merge order: archinfo 375, then
pyvex 576, then cle 795, then angr 6982.~~

With archinfo and pyvex merged, the partial state that warning was about can no
longer happen. What is left of the order is cle 795, then angr 6982.

Validation: https://github.com/angr/cle/pull/795#issuecomment-5434299122

sync: angr/binaries#206
session: sharpen