### PR TITLE
MachO: Report a symbol in an instruction-bearing section as a function

### DIFF
--- a/cle/backends/gopclntab.py
+++ b/cle/backends/gopclntab.py
@@ -289,12 +289,21 @@ def register_gopclntab_symbols(backend: Backend) -> GoPclntab | None:
     if tab is None:
         return None
 
-    covered = {sym.relative_addr for sym in backend.symbols if sym.size and sym.is_function}
+    # A symbol covers a pclntab entry only if it carries the entry's name as well as its
+    # address. The Go linker gives an assembly function an extra ".abi0" suffix in the symbol
+    # table only, and Mach-O prefixes every symbol with an underscore -- _main.main is not the
+    # name Go tooling asks for, so it does not cover main.main.
+    covered: dict[int, set[str]] = {}
+    for sym in backend.symbols:
+        if sym.size and sym.is_function:
+            covered.setdefault(sym.relative_addr, set()).add(sym.name)
+
     by_name = getattr(backend, "_symbols_by_name", None)
     added = 0
     for func in tab.functions:
         relative_addr = AT.from_lva(func.addr, backend).to_rva()
-        if relative_addr in covered:
+        names = covered.get(relative_addr)
+        if names and (not func.name or names & {func.name, f"{func.name}.abi0"}):
             continue
         symbol = GoSymbol(backend, func.name, relative_addr, func.size)
         backend.symbols.add(symbol)

--- a/cle/backends/macho/symbol.py
+++ b/cle/backends/macho/symbol.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from archinfo.arch_arm import is_arm_arch
+
 from cle import AT
 from cle.backends.backend import Backend
 from cle.backends.symbol import Symbol, SymbolType
@@ -23,6 +25,7 @@ SYMBOL_TYPE_PBUD = 0xC
 SYMBOL_TYPE_INDIR = 0xA
 N_STAB = 0xE0  # actually a mask
 N_EXT = 0x01  # external symbol bit
+N_ARM_THUMB_DEF = 0x0008  # n_desc bit: this definition is Thumb code
 
 LIBRARY_ORDINAL_SELF = 0x0
 LIBRARY_ORDINAL_OLD_MAX = 0xFE
@@ -120,6 +123,17 @@ class SymbolTableSymbol(AbstractMachOSymbol):
         else:
             # The n_value is probably an address, but we need to convert it to a relative address
             addr = AT.from_lva(n_value, owner).to_rva()
+
+        # ARM states in n_desc that a definition is Thumb and leaves n_value even; ELF states the same thing in
+        # bit 0 of st_value, and that is where the rest of the stack reads it. Normalise to the ELF convention.
+        if (
+            (n_type & N_STAB) == 0
+            and (n_type & 0x0E) == SYMBOL_TYPE_SECT
+            and n_desc & N_ARM_THUMB_DEF
+            and is_arm_arch(owner.arch)
+            and owner.arch.bits == 32
+        ):
+            addr |= 1
 
         # now we may call super
         # however we cannot access any properties yet that would touch superclass-initialized attributes

--- a/cle/backends/macho/symbol.py
+++ b/cle/backends/macho/symbol.py
@@ -11,6 +11,7 @@ from cle.backends.symbol import Symbol, SymbolType
 
 if TYPE_CHECKING:
     from . import MachO
+    from .section import MachOSection
 
 log = logging.getLogger(name=__name__)
 
@@ -186,10 +187,37 @@ class SymbolTableSymbol(AbstractMachOSymbol):
         return self.is_weak_referenced
 
     @property
+    def section(self) -> MachOSection | None:
+        """
+        The section this symbol is defined in, or None if it does not define anything in this object.
+        """
+        if self.sym_type != SYMBOL_TYPE_SECT:
+            return None
+        if not 0 < self.n_sect < len(self.owner.sections_by_ordinal):
+            log.warning("Symbol %s names section ordinal %d, which the object does not have", self, self.n_sect)
+            return None
+        return self.owner.sections_by_ordinal[self.n_sect]
+
+    @property
     def is_function(self):
-        # Incompatibility to CLE
-        log.debug("It is not possible to decide wether a symbol is a function or not for MachOSymbols")
-        return False
+        """
+        Whether this symbol names code.
+
+        An ``nlist`` has no equivalent of ELF's ``STT_FUNC``: ``n_type`` says where a symbol is defined, never
+        what it defines. What the file does state is which of its sections hold machine instructions, so a
+        symbol defined in one of those sections names code and one defined anywhere else does not.
+
+        Only an ``N_SECT`` symbol defines anything here at all. An undefined, common, prebound or indirect
+        symbol names something another object defines, an ``N_ABS`` symbol names a constant, and a debug entry
+        keeps its own type in ``n_type`` -- :attr:`sym_type` returns that type unmasked, so no ``N_STAB`` entry
+        reaches the section test.
+
+        The address has to lie in the section as well. ``__mh_execute_header`` is an ``N_SECT`` symbol on the
+        first section of ``__TEXT``, but it addresses the Mach-O header in front of that section rather than
+        anything in it.
+        """
+        section = self.section
+        return section is not None and section.is_executable and section.contains_addr(self.rebased_addr)
 
     # real symbols have properties, mach-o symbols have plenty of them:
     @property

--- a/tests/test_gopclntab.py
+++ b/tests/test_gopclntab.py
@@ -76,7 +76,8 @@ class TestGoPclntab(unittest.TestCase):
         assert exact + abi0 == len(tab.functions)
 
     def test_clean_binary_does_not_duplicate_symbols(self):
-        # The symbol table already covers every Go function here, so nothing should be added.
+        # The symbol table already names every Go function here at its own address -- 115 of them
+        # under the ".abi0" spelling checked above -- so nothing should be added.
         path = os.path.join(TEST_LOCATION, "x86_64", "langdetect_go")
         ld = cle.Loader(path, auto_load_libs=False)
         assert not [s for s in ld.main_object.symbols if isinstance(s, cle.GoSymbol)]
@@ -183,10 +184,17 @@ class TestGoPclntab(unittest.TestCase):
         assert tab is not None
         go_symbols = [s for s in obj.symbols if isinstance(s, cle.GoSymbol)]
 
-        # cle reports no Mach-O symbol as a function, so nothing here covers a pclntab address and
-        # every entry is added, next to the underscore-prefixed name the symbol table already has
+        # Every one of these addresses already carries a function symbol, but under Mach-O's
+        # leading underscore, which is not the name Go tooling asks for. The dedupe compares
+        # names as well as addresses, so each entry is added next to the prefixed one.
         assert len(go_symbols) == 1888
         assert all(s.type == cle.SymbolType.TYPE_FUNCTION for s in go_symbols)
+
+        symtab = {}
+        for symbol in obj.symbols:
+            if not isinstance(symbol, cle.GoSymbol) and symbol.is_function:
+                symtab.setdefault(symbol.rebased_addr, set()).add(symbol.name)
+        assert all(symtab[func.addr] & {"_" + func.name, "_" + func.name + ".abi0"} for func in tab.functions)
 
         by_addr = {}
         for symbol in obj.symbols:

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -13,6 +13,7 @@ from cle import MachO
 from cle.backends.backend import FunctionHintSource
 from cle.backends.macho.macho_enums import LoadCommands, MachoFiletype, SectionAttributes, SectionType
 from cle.backends.macho.section import MachOSection
+from cle.backends.macho.symbol import SYMBOL_TYPE_SECT, SymbolTableSymbol
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
@@ -302,6 +303,41 @@ def test_instruction_sections():
     }
     assert macho.sections_map["__TEXT,__text"].attributes & SectionAttributes.S_ATTR_PURE_INSTRUCTIONS
     assert macho.sections_map["__TEXT,__cstring"].attributes == 0
+
+
+def test_symbol_is_function():
+    machofile = os.path.join(TEST_BASE, "tests", "x86_64", "fauxware.macho")
+    ld = cle.Loader(machofile, auto_load_libs=False)
+    macho = ld.main_object
+    assert isinstance(macho, cle.MachO)
+
+    symbols = {sym.name: sym for sym in macho.symbols if isinstance(sym, SymbolTableSymbol)}
+
+    # The four symbols defined in a section that holds instructions, and nothing else.
+    assert {name for name, sym in symbols.items() if sym.is_function} == {
+        "_authenticate",
+        "_accepted",
+        "_rejected",
+        "_main",
+    }
+
+    # _sneaky is an N_SECT symbol too, but its section holds data.
+    assert symbols["_sneaky"].section is not None
+    assert symbols["_sneaky"].section.full_name == "__DATA,__data"
+    assert not symbols["_sneaky"].is_function
+
+    # __mh_execute_header names the first section of __TEXT and addresses the Mach-O header in front of it.
+    header = symbols["__mh_execute_header"]
+    assert header.sym_type == SYMBOL_TYPE_SECT
+    assert header.section is not None
+    assert header.section.full_name == "__TEXT,__text"
+    assert not header.section.contains_addr(header.rebased_addr)
+    assert not header.is_function
+
+    # An undefined symbol defines nothing here, so it names no code here either.
+    assert symbols["_printf"].is_import
+    assert symbols["_printf"].section is None
+    assert not symbols["_printf"].is_function
 
 
 def test_find_symbol():

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -340,6 +340,30 @@ def test_symbol_is_function():
     assert not symbols["_printf"].is_function
 
 
+def test_arm_thumb_definition_carries_the_flag_in_its_address():
+    machofile = os.path.join(TEST_BASE, "tests", "armhf", "FileProtection-05.armv7.macho")
+    ld = cle.Loader(machofile, auto_load_libs=False)
+    macho = ld.main_object
+    assert isinstance(macho, cle.MachO)
+    assert macho.arch.name == "ARMEL"
+
+    symbols = {sym.name: sym for sym in macho.symbols if isinstance(sym, SymbolTableSymbol)}
+
+    # n_value is 0x83a8 and n_desc says Thumb. ELF would have stated both in st_value.
+    main = symbols["_main"]
+    assert main.is_function
+    assert main.is_thumb_definition
+    assert main.rebased_addr == 0x83A9
+
+    # The one ARM-mode definition in this image keeps the address the file gives it.
+    helpers = symbols[" stub helpers"]
+    assert helpers.is_function
+    assert not helpers.is_thumb_definition
+    assert helpers.rebased_addr == 0xA2F0
+
+    assert sum(1 for sym in symbols.values() if sym.is_function) == 74
+
+
 def test_find_symbol():
     machofile = os.path.join(TEST_BASE, "tests", "x86_64", "fauxware.macho")
     ld = cle.Loader(machofile, auto_load_libs=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`SymbolTableSymbol.is_function` returns `False` unconditionally, so
`binary.symbols` never names a function on a Mach-O object. On
`tests/x86_64/fauxware.macho`:

```
symbols reported as functions: 0 of 14
  _authenticate          0x0100000cc0  section __text    is_function=False
  _main                  0x0100000de0  section __text    is_function=False
```

In angr that silently empties the CFG's symbol-derived starting points, its
function-boundary fixup, and two protections against dropping recovered
functions.

### Root cause

An `nlist` has no equivalent of ELF's `STT_FUNC`, so there was nothing obvious
to test; and until #762 `MachOSection.is_executable` reported `__TEXT`'s
wholesale r-x, so the obvious repair would have called every string literal a
function.

### Fix

Now that a section states whether it holds instructions, a symbol is a function
when it is `N_SECT`, its section holds instructions, and its address lies
inside that section. The containment test is load-bearing:
`__mh_execute_header` names `__TEXT,__text` but addresses the Mach-O header, so
without it every linked image seeds the CFG at its own header. On
`fauxware.macho` that gives 4 of 14 — `_authenticate`, `_accepted`, `_rejected`
and `_main` — while `_sneaky`, which lives in `__data`, stays out.

A second commit normalises ARM's Thumb flag, which Mach-O keeps in `n_desc`, to
the low address bit the rest of the codebase reads it from. On
`tests/armhf/FileProtection-05.armv7.macho`, `_main` moves from `0x83a8` to
`0x83a9` while the one ARM-mode definition, ` stub helpers` at `0xa2f0`, keeps
its address.

A third commit repairs what the first one breaks in the Go pclntab loader.
`register_gopclntab_symbols` skipped a pclntab entry whenever any sized function
symbol sat at its address, which was only safe while no Mach-O symbol was ever a
function. With the first commit applied, the Mach-O symbol table covers all 1,888
addresses of `aarch64/langdetect_go.macho` — but under the platform's leading
underscore, `_main.main` rather than `main.main` — so every un-prefixed Go name
disappeared, and angr's language detector matches Go on exactly those names. The
dedupe now compares the entry's name as well as its address, accepting the
`.abi0` suffix the Go linker gives an assembly function in the symbol table only.
Seven objects move, out of every object in `angr/binaries` that has a Go pclntab
(27 of the 894 ELF, PE and Mach-O files under `tests/`). `langdetect_go.macho`
goes 0 → 1,888, back to what cle master produces. The other six each gain two
or three symbols, and that is intended: they are Go type-equality thunks whose
name the pclntab abbreviates and the symbol table spells out —
`type:.eq.[...]runtime.Frame` against `type:.eq.[2]runtime.Frame` — so the two
names really are different, nothing covers the entry, and the entry is added.
The other twenty objects are unchanged, `starling` at 6,079 among them. The
full table is in the validation record.

### Testing

`tests/test_macho.py::test_symbol_is_function` and
`test_arm_thumb_definition_carries_the_flag_in_its_address` cover the first two
commits, on existing fixtures. Both fail on master, where the function count is 0
on each image; on this head it is 4 of 14 on `fauxware.macho` and 74 of 548 on
the armv7 image.

`tests/test_gopclntab.py::TestGoPclntab::test_macho_binary_supplies_the_function_symbols`,
which cle master gained in #808, covers the third. Master's own copy of it passes
on master and fails on the first two commits of this branch with
`assert 0 == 1888`; this branch's copy passes here. The two are not the same
test: this branch adds a block asserting that each of those 1,888 addresses
already carries a function symbol under the `_`-prefixed or `.abi0` spelling,
which is what the address-only dedupe was matching on. That block raises
`KeyError` on master, where no Mach-O symbol is a function and the map it
indexes is empty, so running this branch's file against master shows an error
rather than a pass.

Validation: https://github.com/angr/cle/pull/796#issuecomment-5436541248

session: sharpen
