### PR TITLE
Do not treat input-file strings (NT_FILE filenames, path-like DT_NEEDED) as host paths

### DIFF
--- a/cle/backends/elf/elfcore.py
+++ b/cle/backends/elf/elfcore.py
@@ -56,6 +56,12 @@ class ELFCore(ELF):
         self._page_size = 0x1000  # a default page size, will be changed later by parsing notes
         self._main_object = None
 
+        # SECURITY: NT_FILE filenames are attacker-controllable strings embedded in the
+        # input file. Only honor them when the analyst has explicitly authorized a mapping.
+        self._honor_file_notes = (
+            executable is not None or remote_file_mapping is not None or remote_file_mapper is not None
+        )
+
         if remote_file_mapping is not None:
             self._remote_file_mapper = lambda x: remote_file_mapping.get(x, x)
         else:
@@ -412,6 +418,14 @@ class ELFCore(ELF):
         self.loader.page_size = self._page_size
         self.loader._perform_relocations = False
 
+        if not self._honor_file_notes:
+            log.warning(
+                "Ignoring NT_FILE mappings in core dump: filenames embedded in the input file are not trusted "
+                "as host paths. Pass executable=, remote_file_mapping= or remote_file_mapper= to enable "
+                "loading children from core notes."
+            )
+            return
+
         # hack: we are using a loader internal method in a non-kosher way which will cause our children to be
         # marked as the main binary if we are also the main binary
         # work around this by setting ourself here:
@@ -433,7 +447,9 @@ class ELFCore(ELF):
             try:
                 with open(filename, "rb") as fp:
                     obj = self.loader._load_object_isolated(fp)
-            except (FileNotFoundError, PermissionError, CLECompatibilityError) as ex:
+            except (OSError, CLEError, CLECompatibilityError) as ex:
+                # OSError covers FileNotFoundError / PermissionError / IsADirectoryError;
+                # CLEError covers backend refusals raised during partial loading
                 if isinstance(ex, FileNotFoundError):
                     log.warning(
                         "Dependency %s does not exist on the current system; this core may be incomplete.", filename

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -846,9 +846,7 @@ class Loader:
             # absolute spec makes os.path.join() discard the search directories entirely,
             # and '..' components escape them. Both open attacker-chosen host files.
             if os.path.isabs(spec) or "/" in spec or "\\" in spec:
-                log.warning(
-                    "Refusing to resolve path-like dependency name %r from the input binary", spec
-                )
+                log.warning("Refusing to resolve path-like dependency name %r from the input binary", spec)
                 cached_failures.add(spec)
                 continue
             if spec in cached_failures:

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -841,6 +841,16 @@ class Loader:
 
         while self._auto_load_libs and dependencies:
             spec = dependencies.pop(0)
+            # SECURITY: dependency names originate from the input binary (e.g. DT_NEEDED
+            # strings) and must be treated as bare library names, never as paths: an
+            # absolute spec makes os.path.join() discard the search directories entirely,
+            # and '..' components escape them. Both open attacker-chosen host files.
+            if os.path.isabs(spec) or "/" in spec or "\\" in spec:
+                log.warning(
+                    "Refusing to resolve path-like dependency name %r from the input binary", spec
+                )
+                cached_failures.add(spec)
+                continue
             if spec in cached_failures:
                 log.debug("Skipping implicit dependency %s - cached failure", spec)
                 continue


### PR DESCRIPTION
## What

Two small hardening changes so that strings originating **inside the analyzed input file** are never used as host filesystem paths:

1. **ELFCore / NT_FILE** — filenames from the NT_FILE note are now only honored when the analyst has explicitly opted in via `executable=`, `remote_file_mapping=`, or `remote_file_mapper=`. Without an explicit mapping, child loading from core notes is skipped with a warning. This is a security-relevant behavior change: previously any core dump could cause cle to `open()` arbitrary host paths named in the note (also serving as a file-existence oracle via distinct warnings), with no flag involved. The existing opt-in APIs cover the legitimate same-host/remote-core workflows.
2. **Loader / dependency resolution** — specs popped from the dependency queue (which originate from DT_NEEDED and equivalent fields of the input binary) are rejected if they are absolute or contain path separators. Library names are bare names by definition; previously an absolute spec would make `os.path.join()` silently discard every search directory, and `..` components escaped them. Main-binary paths and explicit preload specs are unaffected.

Additionally, `__reload_children`'s except-clause was widened (`OSError`, `CLEError`) so that naming a directory or a `:`-prefixed text file (claimed by the Hex backend) no longer raises out of `ELFCore.__init__` and kills the whole load.

## Why

angr's SECURITY.md promises that analyzing an untrusted binary never manipulates the host; unauthorized host file reads are explicitly in scope. Both changes close gaps in that promise.

## Testing

Verified against current release behavior and re-tested after the patch (7/7):

- crafted cores naming `/etc/passwd`, a directory, and a loadable host ELF → no host opens, no crash, no child ingestion
- crafted ELF with absolute and `../` DT_NEEDED entries under `auto_load_libs=True` → refused
- regressions: main binary by absolute path still loads; bare-name dependency (`libc.so.6`-style) still resolves from search dirs; explicit opt-in (`remote_file_mapping=`) still loads children

Full details, PoCs, and a suggested advisory writeup are being sent to the maintainers privately per SECURITY.md — happy to coordinate before this merges publicly.
