### PR TITLE
Mach-O: say what was rejected instead of raising an empty error

### DIFF
--- a/cle/backends/macho/binding.py
+++ b/cle/backends/macho/binding.py
@@ -113,10 +113,10 @@ class BindingState:
 
     def check_address_bounds(self):
         if self.address >= self.seg_end_address:
-            log.error(
-                "index %d: address >= seg_end_address (%#x >= %#x)", self.index, self.address, self.seg_end_address
+            raise CLEInvalidBinaryError(
+                f"Binding opcode at index {self.index} walked the address to {self.address:#x}, "
+                f"past the end of the segment being bound ({self.seg_end_address:#x})"
             )
-            raise CLEInvalidBinaryError()
 
 
 class BindingHelper:
@@ -251,10 +251,18 @@ class BindingHelper:
                     address += self.binary.arch.bytes
 
             elif opcode == RebaseOpcode.DO_REBASE_ULEB_TIMES:
+                if segment is None or address is None or reloc_type is None:
+                    raise CLEInvalidBinaryError(
+                        "REBASE_OPCODE_DO_REBASE_ULEB_TIMES before a segment, address and rebase type were set"
+                    )
                 count, index = self.read_uleb(blob, index)
+                segment_end = segment.vaddr + segment.memsize
                 for _ in range(count):
-                    if address >= segment.vaddr + segment.memsize:
-                        raise CLEInvalidBinaryError()
+                    if address >= segment_end:
+                        raise CLEInvalidBinaryError(
+                            f"REBASE_OPCODE_DO_REBASE_ULEB_TIMES: rebase address {address:#x} is past the end "
+                            f"of segment {segment.segname} ({segment_end:#x})"
+                        )
                     self.rebase_at(address, reloc_type)
                     address += self.binary.arch.bytes
 
@@ -264,11 +272,20 @@ class BindingHelper:
                 address += uleb + self.binary.arch.bytes
 
             elif opcode == RebaseOpcode.DO_REBASE_ULEB_TIMES_SKIPPING_ULEB:
+                if segment is None or address is None or reloc_type is None:
+                    raise CLEInvalidBinaryError(
+                        "REBASE_OPCODE_DO_REBASE_ULEB_TIMES_SKIPPING_ULEB before a segment, address and rebase "
+                        "type were set"
+                    )
                 count, index = self.read_uleb(blob, index)
                 skip, index = self.read_uleb(blob, index)
+                segment_end = segment.vaddr + segment.memsize
                 for _ in range(count):
-                    if address >= segment.vaddr + segment.memsize:
-                        raise CLEInvalidBinaryError()
+                    if address >= segment_end:
+                        raise CLEInvalidBinaryError(
+                            f"REBASE_OPCODE_DO_REBASE_ULEB_TIMES_SKIPPING_ULEB: rebase address {address:#x} is "
+                            f"past the end of segment {segment.segname} ({segment_end:#x})"
+                        )
                     self.rebase_at(address, reloc_type)
                     address += skip + self.binary.arch.bytes
 
@@ -440,10 +457,10 @@ def n_opcode_do_bind_add_addr_uleb(s: BindingState, b: MachO, _i: int, blob: byt
     uleb = read_uleb(blob, s.index)
     log.debug("DO_BIND_ADD_ADDR_ULEB @ %#x: %d", s.index, uleb[0])
     if s.address >= s.seg_end_address:
-        log.error(
-            "DO_BIND_ADD_ADDR_ULEB @ %#x: address >= seg_end_address (%#x>=%#x)", s.index, s.address, s.seg_end_address
+        raise CLEInvalidBinaryError(
+            f"BIND_OPCODE_DO_BIND_ADD_ADDR_ULEB at index {s.index:#x}: bind address {s.address:#x} is past the "
+            f"end of the segment being bound ({s.seg_end_address:#x})"
         )
-        raise CLEInvalidBinaryError()
     s.index += uleb[1]
     s.bind_handler(s, b)
     # this is done AFTER binding in preparation for the NEXT step
@@ -454,13 +471,10 @@ def n_opcode_do_bind_add_addr_uleb(s: BindingState, b: MachO, _i: int, blob: byt
 def n_opcode_do_bind_add_addr_imm_scaled(s: BindingState, b: MachO, i: int, _blob: bytes) -> BindingState:
     log.debug("DO_BIND_ADD_ADDR_IMM_SCALED @ %#x: %d", s.index, i)
     if s.address >= s.seg_end_address:
-        log.error(
-            "DO_BIND_ADD_ADDR_IMM_SCALED @ %#x: address >= seg_end_address (%#x>=%#x)",
-            s.index,
-            s.address,
-            s.seg_end_address,
+        raise CLEInvalidBinaryError(
+            f"BIND_OPCODE_DO_BIND_ADD_ADDR_IMM_SCALED at index {s.index:#x}: bind address {s.address:#x} is past "
+            f"the end of the segment being bound ({s.seg_end_address:#x})"
         )
-        raise CLEInvalidBinaryError()
     s.bind_handler(s, b)
     # this is done AFTER binding in preparation for the NEXT step
     s.add_address_ov(s.address, (i * s.sizeof_intptr_t) + s.sizeof_intptr_t)
@@ -475,13 +489,11 @@ def n_opcode_do_bind_uleb_times_skipping_uleb(s: BindingState, b: MachO, _i: int
     log.debug("DO_BIND_ULEB_TIMES_SKIPPING_ULEB @ %#x: %d,%d", s.index - skip[1] - count[1], count[0], skip[0])
     for _ in range(0, count[0]):
         if s.address >= s.seg_end_address:
-            log.error(
-                "DO_BIND_ADD_ADDR_IMM_SCALED @ %#x: address >= seg_end_address (%#x >= %#x)",
-                s.index - skip[1] - count[1],
-                s.address,
-                s.seg_end_address,
+            raise CLEInvalidBinaryError(
+                "BIND_OPCODE_DO_BIND_ULEB_TIMES_SKIPPING_ULEB at index "
+                f"{s.index - skip[1] - count[1]:#x}: bind address {s.address:#x} is past the end of the "
+                f"segment being bound ({s.seg_end_address:#x})"
             )
-            raise CLEInvalidBinaryError()
         s.bind_handler(s, b)
         s.add_address_ov(s.address, skip[0] + s.sizeof_intptr_t)
     return s
@@ -578,8 +590,10 @@ def default_binding_handler(state: BindingState, binary: MachO):
     # locate the symbol:
     matches = binary.symbols.get_by_name_and_ordinal(state.sym_name, state.lib_ord)
     if len(matches) > 1:
-        log.error("Cannot bind: More than one match for (%r,%d)", state.sym_name, state.lib_ord)
-        raise CLEInvalidBinaryError()
+        raise CLEInvalidBinaryError(
+            f"Cannot bind {state.sym_name!r}: {len(matches)} symbols match name and library ordinal "
+            f"{state.lib_ord}, expected exactly one"
+        )
     if len(matches) < 1:
         log.info("No match for (%r,%d), generating BindingSymbol ...", state.sym_name, state.lib_ord)
         matches = [BindingSymbol(binary, state.sym_name, state.lib_ord)]
@@ -618,5 +632,7 @@ def default_binding_handler(state: BindingState, binary: MachO):
         )
         symbol.bind_xrefs.append(location_32)
     else:
-        log.error("Unknown BIND_TYPE: %d", state.binding_type)
-        raise CLEInvalidBinaryError()
+        raise CLEInvalidBinaryError(
+            f"Unknown BIND_TYPE {state.binding_type} while binding {state.sym_name!r}, expected 1 (POINTER), "
+            "2 (TEXT_ABSOLUTE32) or 3 (TEXT_PCREL32)"
+        )

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -477,7 +477,11 @@ class MachO(Backend):
                 return ">"
             else:
                 log.debug("Not a mach-o file")
-                raise CLECompatibilityError()
+                raise CLECompatibilityError(
+                    f"Not a Mach-O file: magic is {magic:#010x} on a little-endian host, expected one of "
+                    f"{MachO.MH_MAGIC:#010x}, {MachO.MH_CIGAM:#010x}, "
+                    f"{MachO.MH_MAGIC_64:#010x}, {MachO.MH_CIGAM_64:#010x}"
+                )
         else:
             if magic in [MachO.MH_MAGIC_64, MachO.MH_MAGIC]:
                 log.debug("Detected big-endian")
@@ -487,7 +491,11 @@ class MachO(Backend):
                 return "<"
             else:
                 log.debug("Not a mach-o file")
-                raise CLECompatibilityError()
+                raise CLECompatibilityError(
+                    f"Not a Mach-O file: magic is {magic:#010x} on a big-endian host, expected one of "
+                    f"{MachO.MH_MAGIC:#010x}, {MachO.MH_CIGAM:#010x}, "
+                    f"{MachO.MH_MAGIC_64:#010x}, {MachO.MH_CIGAM_64:#010x}"
+                )
 
     def do_binding(self):
         # Perform binding
@@ -767,8 +775,10 @@ class MachO(Backend):
                 break
 
         if address is None:
-            log.error("Could not determine base-address for function starts")
-            raise CLEInvalidBinaryError()
+            raise CLEInvalidBinaryError(
+                "Could not determine the base address for LC_FUNCTION_STARTS: none of the "
+                f"{len(self.segments)} segments is mapped at file offset 0 with a non-zero file size"
+            )
         log.debug("Located base-address: %#x", address)
 
         while i < end:
@@ -786,16 +796,20 @@ class MachO(Backend):
 
     def _load_lc_main(self, f, offset):
         if self.entryoff is not None or self.unixthread_pc is not None:
-            log.error("More than one entry point for main detected, abort.")
-            raise CLEInvalidBinaryError()
+            raise CLEInvalidBinaryError(
+                "More than one entry point: LC_MAIN found, but an entry point was already set "
+                f"(entryoff={self.entryoff}, unixthread_pc={self.unixthread_pc})"
+            )
 
         _, _, self.entryoff, _ = self._unpack("2I2Q", f, offset, 24)
         log.debug("LC_MAIN: entryoff=%#x", self.entryoff)
 
     def _load_lc_unixthread(self, f, offset):
         if self.entryoff is not None or self.unixthread_pc is not None:
-            log.error("More than one entry point for main detected, abort.")
-            raise CLEInvalidBinaryError()
+            raise CLEInvalidBinaryError(
+                "More than one entry point: LC_UNIXTHREAD found, but an entry point was already set "
+                f"(entryoff={self.entryoff}, unixthread_pc={self.unixthread_pc})"
+            )
 
         # parse basic structure
         # _, cmdsize, flavor, long_count

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -6,6 +6,8 @@ import os
 import struct
 from io import BytesIO
 
+import pytest
+
 import cle
 from cle import MachO
 from cle.backends.macho.macho_enums import LoadCommands, SectionAttributes, SectionType
@@ -391,6 +393,24 @@ def test_filesize_larger_than_vmsize():
     macho: MachO = ld.main_object
     assert dict(macho.memory.backers())[0x3000] == patched[:0x1000]
     assert macho.max_addr == 0x100003FFF
+
+
+def test_non_macho_magic_is_reported():
+    """
+    A file that is not Mach-O at all, pushed through the Mach-O backend, must say so. The backend used to
+    reject it with a CLECompatibilityError carrying no message, which left nothing in a log to tell that
+    rejection apart from every other reason the backend can refuse a file.
+    """
+    elffile = os.path.join(TEST_BASE, "tests", "x86_64", "fauxware")
+    with pytest.raises(cle.CLECompatibilityError) as excinfo:
+        cle.Loader(elffile, auto_load_libs=False, main_opts={"backend": "mach-o"})
+
+    # The magic that was found, and the four the backend accepts, so the message alone identifies the file
+    # and the check that rejected it.
+    message = str(excinfo.value)
+    assert "0x464c457f" in message
+    for magic in (MachO.MH_MAGIC, MachO.MH_CIGAM, MachO.MH_MAGIC_64, MachO.MH_CIGAM_64):
+        assert f"{magic:#010x}" in message
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

Thirteen raise sites in the Mach-O backend raised `CLECompatibilityError` or
`CLEInvalidBinaryError` with no message. A caller that catches one, and any log
that records one, gets an empty string, so every rejection is indistinguishable
from every other and from the several unrelated conditions that raise the same
type. The contrast is visible in the backend itself: the messaged rejection two
functions away (`Unsupported Mach-O file type: 8. Please open an issue if you
need support for this`) is classifiable on sight, and its neighbours are not.

**Most of this diff moves a diagnosis that already existed rather than inventing
one.** Nine of the thirteen sites had a `log.error` immediately above the raise
already holding the exact numbers — the index, the address, the segment end, the
bind type. That text was computed and then dropped into a logger, where it is
lost as soon as logging is not configured at that level, and it was never
attached to the exception. Those hunks read as `log.error(...)` + bare raise
becoming one `raise ...(f"...")`. The remaining four had no diagnosis at all and
gained one.

Sites, all in `cle/backends/macho/`:

| file | site |
| --- | --- |
| `macho.py` | `_detect_byteorder`, little-endian host — magic is not one of the four |
| `macho.py` | `_detect_byteorder`, big-endian host — same, host endianness named so the two are distinguishable |
| `macho.py` | `_load_lc_function_starts` — no segment at file offset 0 to take a base address from |
| `macho.py` | `_load_lc_main` — second entry point |
| `macho.py` | `_load_lc_unixthread` — second entry point |
| `binding.py` | `BindingState.check_address_bounds` |
| `binding.py` | `REBASE_OPCODE_DO_REBASE_ULEB_TIMES` past segment end |
| `binding.py` | `REBASE_OPCODE_DO_REBASE_ULEB_TIMES_SKIPPING_ULEB` past segment end |
| `binding.py` | `BIND_OPCODE_DO_BIND_ADD_ADDR_ULEB` past segment end |
| `binding.py` | `BIND_OPCODE_DO_BIND_ADD_ADDR_IMM_SCALED` past segment end |
| `binding.py` | `BIND_OPCODE_DO_BIND_ULEB_TIMES_SKIPPING_ULEB` past segment end |
| `binding.py` | `default_binding_handler` — more than one symbol matches |
| `binding.py` | `default_binding_handler` — unknown `BIND_TYPE` |

## Two rebase opcodes also gained a state check

The two rebase messages name the segment that was overrun, and `segment`,
`address` and `reloc_type` are all `None` until a `SET_*` opcode assigns them, so
reading them for a message is only well typed once that is established. Both
branches now reject a rebase opcode arriving before its state is set. That case
is a malformed blob, and it previously died on an `AttributeError` a few lines
later, so the change turns an incidental crash into the same kind of stated
rejection as the rest of this diff. Valid blobs are unaffected. The segment end
is also hoisted out of a loop it does not vary in.

## One site is deliberately left alone

`_load_lc_unixthread`'s unknown-thread-flavor raise keeps its empty message.
#727 **deletes** that branch rather than messaging it, making an unrecognized
flavor non-fatal, so a message there would conflict with that PR and be removed
by it. It is the one obviously-missing site and this is why.

## This does not fix any known load failure

Stated plainly so the diff is not oversold: no binary that fails to load today
loads after this change. The two populations that do fail belong to other PRs —
the x86-64 `LC_UNIXTHREAD` binaries to #727, and the `MH_BUNDLE` ones to #728.
This change only makes a rejection say what it rejected.

## Tests

Only one of the thirteen paths is reachable from a fixture that already exists in
`angr/binaries`. `test_non_macho_magic_is_reported` covers it by loading
`binaries/tests/x86_64/fauxware` — an ELF — with
`main_opts={"backend": "mach-o"}`, and asserting the message names both the magic
found and the four the backend accepts. Verified to fail on the unfixed revision,
where the message is `''`, and to pass here.

**No tests were added for the other twelve.** They need malformed Mach-O inputs
that do not exist in `angr/binaries`, and building one in the test file with
`struct.pack` is exactly what this project's test-inputs rule forbids. An honest
gap seemed better than twelve synthetic headers that no toolchain emits.

## Validation

**This was a scoped gate, not the complete one.** It ran in a feature instance
that adopts `cle` only, so eight suites were skipped — `archinfo`, `pypcode`,
`pyvex`, `pysoot`, `claripy`, `angr`, `angr-rust` and `angr-management`. Nothing
exercised this `cle` through `angr`. For a cle-only change that is the
appropriate coverage, but it is a limit and not an implication to be read off a
list of skip lines.

What did run, at `3e36a7f` on `origin/master` `d2ecea0`:

- `cle` Python tests: **240 passed, 9 skipped** (249 collected; the 9 are the
  pre-existing `TODO` markers in `tests/test_macho_bindinghelper.py`)
- all configured pre-commit hooks, over all files
- the angr-agentic workspace checks, the test-inputs check, the per-feature
  instance suite and the vibr pipeline tests
- focused re-run: `tests/test_macho*.py` plus `tests/test_cart.py` — 46 passed,
  9 skipped
- the merge-base lint and typecheck comparison the hosted jobs apply, via
  `run-ci-diff-checks.py`. Lint unchanged at `10.00` on all three files.
  Typecheck badness, all three improving against the base:
  `binding.py` `0.5306 -> 0.3292`, `macho.py` `0.1713 -> 0.1695`,
  `test_macho.py` `0.0490 -> 0.0467`. The base scores this reproduces match the
  ones the hosted job printed to sixteen digits, which is what makes it a
  reproduction rather than a second opinion.

Confirmed the run imported the branch rather than an editable install of master
(`cle/__init__.py` resolving inside the instance worktree), and that
`test_non_macho_magic_is_reported` is collected and passes there rather than
inferring it from a green total.

session: crazybins
