### PR TITLE
Lowercase the AR, COFF and Universal2 backend names

### DIFF
--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -552,4 +552,4 @@ class Coff(Backend):
         raise NotImplementedError("Unsupported symbol")
 
 
-register_backend("COFF", Coff)
+register_backend("coff", Coff)

--- a/cle/backends/static_archive.py
+++ b/cle/backends/static_archive.py
@@ -47,4 +47,4 @@ class StaticArchive(Backend):
             self.loader._main_object = None
 
 
-register_backend("AR", StaticArchive)
+register_backend("ar", StaticArchive)

--- a/cle/backends/universal2.py
+++ b/cle/backends/universal2.py
@@ -183,4 +183,4 @@ class Universal2(Backend):
         return list(self.child_objects)
 
 
-register_backend("Universal2", Universal2)
+register_backend("universal2", Universal2)

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -1335,8 +1335,8 @@ class Loader:
     def _backend_resolver(backend: str | type[Backend], default: T | None = None) -> type[Backend] | T | None:
         if isinstance(backend, type) and issubclass(backend, Backend):
             return backend
-        elif backend in ALL_BACKENDS:
-            return ALL_BACKENDS[backend]
+        elif isinstance(backend, str) and backend.lower() in ALL_BACKENDS:
+            return ALL_BACKENDS[backend.lower()]
         elif backend is None:
             return default
         else:

--- a/tests/test_backend_names.py
+++ b/tests/test_backend_names.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import cle
+from cle.backends import ALL_BACKENDS
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
+
+# A GCC-ARM static archive of 43 ELF objects. Its R_ARM_THM_CALL relocations only reach between members
+# when the members are packed more tightly than the default granularity.
+ARCHIVE = os.path.join(
+    TEST_BASE,
+    "tests_src",
+    "i2c_master_read-nucleol152re",
+    "mbed",
+    "TARGET_NUCLEO_L152RE",
+    "TOOLCHAIN_GCC_ARM",
+    "libmbed.a",
+)
+OBJECT_FILE = os.path.join(TEST_BASE, "tests", "x86_64", "fauxware.obj")
+FATBIN = os.path.join(TEST_BASE, "tests", "multi_arch", "fauxware_macho_multiarch")
+
+TARGETS = {
+    cle.StaticArchive: (ARCHIVE, {"rebase_granularity": 0x1000}),
+    cle.Coff: (OBJECT_FILE, {}),
+    cle.Universal2: (FATBIN, {}),
+}
+
+
+def load_as(backend_cls, name):
+    path, loader_opts = TARGETS[backend_cls]
+    return cle.Loader(path, main_opts={"backend": name}, auto_load_libs=False, **loader_opts)
+
+
+def test_every_registered_backend_name_is_lowercase():
+    assert [name for name in ALL_BACKENDS if name != name.lower()] == []
+
+
+@pytest.mark.parametrize(
+    ("backend_cls", "name"),
+    [(cle.StaticArchive, "ar"), (cle.Coff, "coff"), (cle.Universal2, "universal2")],
+)
+def test_a_backend_is_selectable_by_its_lowercase_name(backend_cls, name):
+    assert type(load_as(backend_cls, name).main_object) is backend_cls
+
+
+@pytest.mark.parametrize(
+    ("backend_cls", "name"),
+    [(cle.StaticArchive, "AR"), (cle.Coff, "COFF"), (cle.Universal2, "Universal2")],
+)
+def test_the_spellings_recorded_in_existing_databases_still_resolve(backend_cls, name):
+    """
+    angr's .adb serializer stores the registered name and passes it back as main_opts["backend"] when the
+    database is reopened, so databases written before these names were lowercased still carry these.
+    """
+    assert type(load_as(backend_cls, name).main_object) is backend_cls
+
+
+def test_an_unregistered_backend_name_is_still_rejected():
+    with pytest.raises(cle.CLEError, match="Invalid backend: nope"):
+        cle.Loader(OBJECT_FILE, main_opts={"backend": "nope"}, auto_load_libs=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Selecting the static-archive backend by name fails, on the lowercase spelling
that every other backend in the registry teaches:

```
>>> ld = cle.Loader("binaries/tests_src/i2c_master_read-nucleol152re/mbed/TARGET_NUCLEO_L152RE/TOOLCHAIN_GCC_ARM/libmbed.a",
...                 main_opts={"backend": "ar"})
cle.errors.CLEError: Invalid backend: ar
>>> "ar" in cle.ALL_BACKENDS
False
```

`{"backend": "coff"}` on `binaries/tests/x86_64/fauxware.obj` and
`{"backend": "universal2"}` on `binaries/tests/multi_arch/fauxware_macho_multiarch`
fail the same way, while `{"backend": "elf"}` works. The spellings that do work
for these three are `AR`, `COFF` and `Universal2`, which appear nowhere outside
their own registration lines: not in cle's README, not in cle's docs, and not in
angr's table of backend names. So the only way to find them is to read the source
of each backend, and a caller who generalises from `elf`, `pe`, `mach-o` or
`blob` gets a `CLEError` instead of a loader.

### Root cause

`Loader._backend_resolver` looks a name up exactly:

```python
        elif backend in ALL_BACKENDS:
            return ALL_BACKENDS[backend]
```

and the names it looks up are inconsistent. Nineteen of the twenty-two entries in
`ALL_BACKENDS` are lowercase; `register_backend("AR", StaticArchive)`,
`register_backend("COFF", Coff)` and `register_backend("Universal2", Universal2)`
are not. Each was spelled that way in the commit that added the backend, by three
different authors, and no commit message discusses the choice.

### Fix

Rename those three registrations to match their siblings, so the convention the
registry already follows holds for every entry, and resolve a backend name
without regard to case.

The second half is what keeps the rename safe rather than being a convenience.
angr's `.adb` serializer writes cle's registered name into the database
(`LoaderSerializer.backend2name`) and hands it straight back to `cle.Loader` as
`main_opts["backend"]` when the database is reopened, so every database saved
from an AR, COFF or Universal2 object has the capitalized spelling on disk. With
the rename alone, reopening one of those raises `AngrDBError` from
`CLEError: Invalid backend: COFF`; with case-insensitive resolution it loads.

Registering the lowercase names as extra aliases would do the same job and cost
more: `ALL_BACKENDS` is iterated for format autodetection and is the list
angr-management fills its backend dropdown from, so each alias would add a
duplicate probe and a duplicate menu entry, and it would make
`backend2name`, a dict inversion, pick its winner by insertion order.

### Testing

`tests/test_backend_names.py` loads a real static archive, a real COFF object and
a real universal binary by their lowercase names, checks that the capitalized
spellings an existing `.adb` holds still resolve, checks that an unregistered name
is still rejected, and asserts that every registered name is lowercase, which is
the property the resolver now depends on. Its three lowercase cases and the
lowercase assertion fail at the merge base with `CLEError: Invalid backend: ar`,
`: coff` and `: universal2`. The archive is
`binaries/tests_src/i2c_master_read-nucleol152re/mbed/TARGET_NUCLEO_L152RE/TOOLCHAIN_GCC_ARM/libmbed.a`,
the only committed `!<arch>` fixture that loads today.

Validation: https://github.com/angr/cle/pull/799#issuecomment-5460290062

session: sharpen