### PR TITLE
PE: read the loading environment from the optional header

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -6,6 +6,7 @@ import os
 import re
 import struct
 from collections.abc import Callable
+from typing import Any
 
 import archinfo
 import pefile
@@ -31,7 +32,32 @@ from .symbolserver import PDBInfo, SymbolResolver
 SECTION_NAME_STRING_TABLE_OFFSET_RE = re.compile(r"\/(\d+)")
 VALID_SYMBOL_NAME_RE = re.compile(r"[A-Za-z0-9_@$?]+")
 
+# The optional header subsystems that mark an image as a UEFI module rather than a Windows one.
+EFI_SUBSYSTEMS = frozenset(
+    pefile.SUBSYSTEM_TYPE[name]
+    for name in (
+        "IMAGE_SUBSYSTEM_EFI_APPLICATION",
+        "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+        "IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER",
+        "IMAGE_SUBSYSTEM_EFI_ROM",
+    )
+)
+
 log = logging.getLogger(name=__name__)
+
+
+def image_os(optional_header: Any) -> str:
+    """
+    Name the environment that loads an image with this optional header.
+
+    A PE whose subsystem is one of the EFI ones is a UEFI module: the firmware loads it, Windows does not, and on a
+    target such as RISC-V no Windows exists to load it. Everything else is a Windows image.
+
+    pefile builds an optional header out of the field names it read, so it is typed as a bare structure and the
+    subsystem has to be reached dynamically.
+    """
+
+    return "uefi" if optional_header.Subsystem in EFI_SUBSYSTEMS else "windows"
 
 
 class PE(Backend):
@@ -78,7 +104,6 @@ class PE(Backend):
         self._search_microsoft_symserver = search_microsoft_symserver
 
         self.segments = self.sections  # in a PE, sections and segments have the same meaning
-        self.os = "windows"
         self._raw_data = self._binary_stream.read()
         if self.binary is None:
             self._pe = pefile.PE(data=self._raw_data, fast_load=True)
@@ -94,6 +119,8 @@ class PE(Backend):
 
         assert self._pe.FILE_HEADER is not None
         assert self._pe.OPTIONAL_HEADER is not None
+
+        self.os = image_os(self._pe.OPTIONAL_HEADER)
 
         if self._arch is None:
             machine_type = self._pe.FILE_HEADER.Machine

--- a/cle/backends/te.py
+++ b/cle/backends/te.py
@@ -104,6 +104,9 @@ class TE(Backend):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        # A Terse Executable only exists inside UEFI firmware; there is no other environment that loads one.
+        self.os = "uefi"
+
         self._binary_stream.seek(0)
         self.header = HeaderType(*HEADER.unpack(self._binary_stream.read(HEADER.size)))
         self.section_headers = [

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -315,6 +315,16 @@ class TestPEBackend(unittest.TestCase):
         assert data[:4] == b"\x8bD$\x04"
         assert data[-4:] == b"3\xdb;\xc3"
 
+    def test_uefi_image_is_not_windows(self):
+        # A UEFI module is a PE, but it runs under the UEFI boot environment rather than Windows, and it says so in
+        # the optional header. Windows has never run on RISC-V, so nothing else could have told them apart.
+        efi = os.path.join(TEST_BASE, "tests", "riscv64", "uefi", "HighMemDxe.efi")
+        ld = cle.Loader(efi, auto_load_libs=False)
+
+        assert isinstance(ld.main_object, cle.PE)
+        assert ld.main_object.arch.name == "RISCV64"
+        assert ld.main_object.os == "uefi"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_te.py
+++ b/tests/test_te.py
@@ -88,6 +88,12 @@ def test_partially_backed_section():
     assert obj.loader.memory.load(data.vaddr, data.memsize) == b"\xaa" * 0x10 + b"\0" * 8
 
 
+def test_os_is_uefi():
+    # A TE image only ever runs under UEFI, so it must not be handed to the Windows environment the way a PE is.
+    assert load_te("i386").os == "uefi"
+    assert load_te("aarch64").os == "uefi"
+
+
 def test_aarch64_machine():
     obj = load_te("aarch64")
 
@@ -100,4 +106,5 @@ if __name__ == "__main__":
     test_section_permissions()
     test_section_file_offsets()
     test_partially_backed_section()
+    test_os_is_uefi()
     test_aarch64_machine()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`PE.os` is the string `"windows"` for every PE, whatever the image says about
itself. That is wrong for UEFI modules, and downstream it is fatal: angr routes
on `os`, so `HighMemDxe.efi` -- a RISC-V UEFI boot service driver -- reaches
`SimWindows`, which asks for a Win32 syscall calling convention on an
architecture that has never run Windows:

```
$ python -c "import angr; angr.Project('HighMemDxe.efi', auto_load_libs=False)"
  File "angr/simos/windows.py", line 58, in __init__
    ...SYSCALL_CC[self.arch.name]["Win32"](self.arch)
KeyError: 'Win32'
```

The project never gets built, so nothing about the image can be analysed. A
corpus census over a sample of 11,989 objects put this at 2 objects overall and
2 of the 32 sampled from a Debian edk2 collection of 2,219.

### Root cause

`cle/backends/pe/pe.py` assigned `self.os = "windows"` before it had even parsed
the headers. The optional header records which environment loads the image --
subsystems 10 through 13 are the EFI ones, and the Microsoft loader will not
load any of them -- and nothing read that field.

The same is true a second time for `cle/backends/te.py`: a Terse Executable is a
UEFI construct and exists nowhere else, and it set no `os` at all.

### Fix

Read the subsystem. `PE.os` is `"uefi"` when the optional header declares one of
`EFI_APPLICATION`, `EFI_BOOT_SERVICE_DRIVER`, `EFI_RUNTIME_DRIVER` or `EFI_ROM`,
and `"windows"` otherwise; `TE.os` is `"uefi"` unconditionally. This is not a new
branch for an awkward case -- it replaces a constant with the field that was
always there to answer the question.

Nothing else in cle reads `os` for a PE, and the assignment moved to just after
the optional header is parsed, which is the first point at which it can be
answered.

### Testing

`tests/test_pe.py::test_uefi_image_is_not_windows` loads the RISC-V driver added
in angr/binaries#218 and asserts `os == "uefi"` with the arch still RISCV64;
`test_exe` above it already asserts `os == "windows"` for a Windows
PE, so both directions are covered. `tests/test_te.py::test_os_is_uefi` covers
the two Terse Executables. On master the first fails with
`assert 'windows' == 'uefi'`.

`python -m pytest tests`: 244 passed, 9 skipped.

The consumer is the angr change linked in a comment below, which registers the
UEFI environment `os == "uefi"` now selects.

sync: angr/binaries#218

session: sharpen
