### PR TITLE
ELF: do not relocate an image the linker has already finished with

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1480,11 +1480,21 @@ class ELF(MetaELF):
         for sec_readelf, section in sec_list:
             if isinstance(sec_readelf, sections.SymbolTableSection):
                 self.__register_section_symbols(sec_readelf)
-            if isinstance(sec_readelf, RelocationSection | RelrRelocationSection) and not (
-                "DT_REL" in self._dynamic
-                or "DT_RELA" in self._dynamic
-                or "DT_JMPREL" in self._dynamic
-                or "DT_RELR" in self._dynamic
+            if (
+                isinstance(sec_readelf, RelocationSection | RelrRelocationSection)
+                # A linked image only carries relocations that are still outstanding in sections it maps. One that
+                # is not SHF_ALLOC is link-time output kept for the record -- u-boot's .rel.text, and anything built
+                # with --emit-relocs -- and the linker has already applied every entry in it. A REL entry reads its
+                # addend out of memory, so applying it a second time computes S + (S + A) and rewrites the code. In
+                # a relocatable object nothing is applied yet and no relocation section is allocated, so they all
+                # have to run.
+                and (self.is_relocatable or sec_readelf.header["sh_flags"] & 2)  # alloc flag
+                and not (
+                    "DT_REL" in self._dynamic
+                    or "DT_RELA" in self._dynamic
+                    or "DT_JMPREL" in self._dynamic
+                    or "DT_RELR" in self._dynamic
+                )
             ):
                 self.__register_relocs(sec_readelf, dynsym=None)
 

--- a/tests/test_linked_image_relocations.py
+++ b/tests/test_linked_image_relocations.py
@@ -1,0 +1,34 @@
+# pylint:disable=no-self-use,missing-class-docstring
+from __future__ import annotations
+
+import os
+from unittest import TestCase, main
+
+import cle
+
+TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries", "tests"))
+
+
+class TestLinkedImageRelocations(TestCase):
+    """
+    An image the linker has already finished with, keeping the link-time .rel.text and .rel.data that
+    --emit-relocs left behind, the way u-boot's build does.
+    """
+
+    def setUp(self):
+        self.path = os.path.join(TESTS_BASE, "i386", "linked_with_emit_relocs")
+        self.loader = cle.Loader(self.path, auto_load_libs=False)
+        self.obj = self.loader.main_object
+
+    def test_link_time_relocations_are_not_applied_again(self):
+        # The linker has applied every entry in .rel.text already. A REL entry reads its addend out of memory, so
+        # applying it a second time computes S + (S + A) and rewrites the code.
+        text = self.obj.sections_map[".text"]
+        with open(self.path, "rb") as fp:
+            fp.seek(text.offset)
+            on_disk = fp.read(text.memsize)
+        assert self.loader.memory.load(text.vaddr, text.memsize) == on_disk
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

CLE applies relocations the linker has already applied, so every analysis
downstream reads bytes that are not in the binary. On
`binaries/tests/i386/linked_with_emit_relocs` cle registers 8 relocations where
2 are still outstanding, and 5 of the 128 bytes of `.text` come back from
`cle.Loader` different from the file:

```
relocations registered: 8
.text bytes differing: 5 of 128
```

Nothing raises.

The same fault on real firmware: on u-boot 2026.07's big-endian MIPS image cle
applies 29228 entries and 65495 of the 413956 bytes of `.text` differ from the
file; on the little-endian one, 10200 entries and 23807 of 214932 bytes.

### Root cause

`__register_sections` applies every relocation section when the object carries
no dynamic relocation tags:

```python
if isinstance(sec_readelf, RelocationSection | RelrRelocationSection) and not (
    "DT_REL" in self._dynamic
    or "DT_RELA" in self._dynamic
    or "DT_JMPREL" in self._dynamic
    or "DT_RELR" in self._dynamic
):
```

That is right for a relocatable object, where nothing has been applied yet and
no relocation section is allocated. A linked image built with `--emit-relocs`,
which is how u-boot keeps its `.rel.text`, has had every one of those entries
applied by the linker already, and a REL entry takes its addend from memory, so
applying it again computes `S + (S + A)`.

### Fix

Run a relocation section only when it is `SHF_ALLOC`, or when the object is
relocatable and therefore has no allocated relocation section at all. On the
fixture that leaves the 2 outstanding entries and `.text` byte-identical to the
file; on both u-boot MIPS images it takes the applied relocations to 0 and
`.text` to byte-identical.

Deliberately not done here: `GenericRelativeReloc.value` adds `mapped_base`
where a relative relocation wants the distance the object moved. That is a
separate defect, and #773 fixes it with the identical one-line change this pull
request used to carry as well. Dropping it here is what lets the two apply
together.

### Testing

`tests/test_linked_image_relocations.py` loads the fixture above -- a
freestanding clang and GNU ld build, linked at `0x1000`, with `--emit-relocs` --
and asserts that the loaded `.text` matches the file. It fails on master.

Validation: https://github.com/angr/cle/pull/801#issuecomment-5462483608

sync: angr/binaries#219

session: sharpen
