### PR TITLE
ELF: keep the section header table when one section's sh_link is dangling

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -68,6 +68,41 @@ additional_e_machine_mappings: dict[int, str] = {
 }
 
 
+class _LenientELFFile(elffile.ELFFile):
+    """
+    An ELFFile that does not discard the whole section header table because one section is malformed.
+
+    pyelftools validates ``sh_link`` when it builds a section: a hash table or a version table whose link does not
+    point at a symbol table, or a symbol table whose link does not point at a string table, raises ``ELFError``.
+    Real linker output hits this. u-boot's linker scripts discard ``.dynstr``, and on some architectures
+    ``.dynsym`` too, while keeping ``.hash``; the linker then writes ``sh_link = 0`` into what is left and any walk
+    of the section table dies on the first such section.
+
+    Sections pyelftools refuses to specialise are handed back as plain sections instead. The header and the data are
+    still there; only the interpretation is missing, which is the right answer for a section whose link is broken.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Set before the base constructor: it builds sections itself.
+        self._malformed_sections: set[str] = set()
+        super().__init__(*args, **kwargs)
+
+    def _make_section(self, section_header):
+        try:
+            return super()._make_section(section_header)
+        except (ELFError, AssertionError):
+            # pyelftools reports a bad link either by raising ELFError or, when the linked section has the right
+            # sh_type but we have already downgraded it, by tripping an internal assertion. Both mean the same
+            # thing here: this section cannot be interpreted.
+            # If the name cannot be read either then the section header string table is broken too, and the table
+            # really is unusable. Let that propagate to the caller, which knows how to fall back.
+            name = self._get_section_name(section_header)
+            if name not in self._malformed_sections:
+                self._malformed_sections.add(name)
+                log.warning("Section %s is malformed; loading it without interpreting its contents.", name)
+            return sections.Section(section_header, name, self)
+
+
 class ELF(MetaELF):
     """
     The main loader class for statically loading ELF executables. Uses the pyreadelf library where useful.
@@ -100,7 +135,7 @@ class ELF(MetaELF):
         )
         patch_undo = []
         try:
-            self._reader = elffile.ELFFile(self._binary_stream)
+            self._reader = _LenientELFFile(self._binary_stream)
             list(self._reader.iter_sections())
         except Exception as e:  # pylint: disable=broad-except
             self._binary_stream.seek(4)
@@ -121,7 +156,7 @@ class ELF(MetaELF):
             log.error("PyReadELF couldn't load this file. Trying again without section headers...")
 
             try:
-                self._reader = elffile.ELFFile(self._binary_stream)
+                self._reader = _LenientELFFile(self._binary_stream)
             except Exception as e1:  # pylint: disable=broad-except
                 raise CLECompatibilityError from e1
 
@@ -1293,9 +1328,13 @@ class ELF(MetaELF):
                     return
 
         symtab = self._reader.get_section(section.header["sh_link"]) if "sh_link" in section.header else dynsym
-        if isinstance(symtab, sections.NullSection):
-            # Oh my god Atmel please stop
+        if symtab is not None and not isinstance(symtab, sections.SymbolTableSection):
+            # Oh my god Atmel please stop.
+            # sh_link can point at nothing (index 0) or at a section that is not a symbol table at all -- u-boot's
+            # .rel.dyn links to a .dynsym whose string table the linker script discarded. Use .symtab instead.
             symtab = self._reader.get_section_by_name(".symtab")
+            if not isinstance(symtab, sections.SymbolTableSection):
+                symtab = None
         if symtab is None and section.header.get("sh_type") != "SHT_RELR":
             # A stripped object can still carry a relocation section whose linked symbol table was stripped away.
             # Without the table there is nothing that can be registered.
@@ -1570,7 +1609,9 @@ class ELF(MetaELF):
     def __process_debug_file(self, filename):
         with open(filename, "rb") as fp:
             try:
-                elf = elffile.ELFFile(fp)
+                # Lenient for the same reason the main reader is: iter_sections() below is outside this guard, and
+                # one section with a dangling sh_link would take the whole debug file down with it.
+                elf = _LenientELFFile(fp)
             except ELFError:
                 log.warning("pyelftools failed to load debug file %s", filename, exc_info=True)
                 return

--- a/tests/test_elf_resiliency.py
+++ b/tests/test_elf_resiliency.py
@@ -1,0 +1,32 @@
+# pylint:disable=no-self-use,missing-class-docstring
+from __future__ import annotations
+
+import os
+from unittest import TestCase, main
+
+import cle
+
+TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries", "tests"))
+
+
+class TestElfResiliency(TestCase):
+    def test_malformed_section_keeps_the_rest_of_the_table(self):
+        """
+        A section whose sh_link points at nothing must not cost us the rest of the section header table.
+
+        u-boot's linker scripts discard .dynstr while keeping .hash and .dynsym, so the linker writes sh_link = 0
+        into both and pyelftools refuses to build them. CLE used to answer that by discarding the whole section
+        header table and rereading the file from the program headers, which threw away .symtab as well and left
+        the binary with no symbols at all. The fixture has the same section table, built by clang and GNU ld.
+        """
+        binary_path = os.path.join(TESTS_BASE, "i386", "hash_without_dynstr")
+        obj = cle.Loader(binary_path, auto_load_libs=False).main_object
+
+        assert ".symtab" in {section.name for section in obj.sections}
+        # These functions are only reachable through a table of pointers, so their symbols are all we have.
+        names = {symbol.name for symbol in obj.symbols if symbol.is_function}
+        assert {"table_helper", "table_entry_one", "table_entry_two"} <= names
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

One section CLE has no use for takes the whole section header table down with
it, silently. On `binaries/tests/i386/hash_without_dynstr`, and on the u-boot
2026.07 qemu images for x86, arm and arm64,
`cle.Loader(path).main_object.sections` is `[]` and `.symbols` is `[]`
although `.symtab` is right there -- 11631 entries on a 2026.07 `qemu-arm64`
build, 3796 of them `STT_FUNC`. The `.debug_*` sections and every
section-derived memory region go with them. The only trace is one line:

```
ERROR:cle.backends.elf.elf:PyReadELF couldn't load this file. Trying again without section headers...
```

Downstream, CFGFast misses 365 functions across six u-boot objects on five
architectures -- `bootmeth_read_all` at `0x9bc8`, `bootdev_get_bootflow`,
`efi_var_collect_mem`, `enable_interrupts`. u-boot reaches most of them only
through a linker list, so with no symbol and no call there is nothing left to
find them by. 299 of the 365 have a basic block starting at exactly the declared
address, so the code was decoded and no function was ever made there.

### Root cause

`ELF.__init__` probes the table with `list(self._reader.iter_sections())` and,
on any exception, zeroes `e_shoff`, `e_shentsize`, `e_shnum` and `e_shstrndx`
and rereads the file from the program headers alone. pyelftools validates
`sh_link` when it builds a section, and u-boot keeps `.hash` while its linker
script discards `.dynstr` and `.dynsym`, so the linker writes `sh_link = 0` and
the walk dies on `ELFError: Section points at section 0 of type SHT_NULL,
expected SHT_SYMTAB/SHT_DYNSYM`. The fallback is right for a section table that
cannot be read at all; it is much too broad for one section that cannot be
interpreted.

### Fix

A section pyelftools refuses to specialise is handed back as a plain section
instead, so the header and the data survive and only the interpretation is
missing -- which is the correct answer for a section whose link is broken. The
program-headers-only fallback stays for a genuinely unusable table:
`binaries/tests/i386/oxfoo1m3` still takes it, unchanged. A relocation section
whose `sh_link` is then not a symbol table falls back to `.symtab`, extending
the `NullSection` case already there, and the debug-file reader is made lenient
for the same reason.

359 of the 365 functions come back: 134 on the x86 image, 119 on arm64, 106 on
arm. Four of the rest are ppce500 addresses where angr decodes no block at all,
which is a different question.

Restoring the table also makes CLE apply these images' relocation sections for
the first time, and it gets that wrong in two ways that rewrite `.text`. #801
fixes one and #773 the other, and this pull request needs both: on the x86 image
`.text` comes back with 60045 of its 558238 bytes differing from the file on
this change alone, 20632 with #801 as well, 39413 with #773 as well, and 0 only
with both. They merge cleanly in every pairing, so merging in number order --
#773, #801, #802 -- is enough.

### Testing

`tests/test_elf_resiliency.py` loads `binaries/tests/i386/hash_without_dynstr`,
a freestanding clang and GNU ld build carrying the same section table, and
asserts that `.symtab` is present and that the three functions reachable only
through a pointer table have symbols. Both assertions fail on master. Loading
all 826 ELF files in angr/binaries and hashing each loaded image gives identical
results before and after this change.

Validation: https://github.com/angr/cle/pull/802#issuecomment-5462484867

sync: angr/binaries#219

session: sharpen
