### PR TITLE
PE: State little-endian for the PowerPC and MIPS machine types

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -61,6 +61,31 @@ def image_os(optional_header: Any) -> str:
     return "uefi" if optional_header.Subsystem in EFI_SUBSYSTEMS else "windows"
 
 
+LITTLE_ENDIAN_MACHINE_TYPES = frozenset(
+    (
+        "IMAGE_FILE_MACHINE_POWERPC",
+        "IMAGE_FILE_MACHINE_POWERPCFP",
+        "IMAGE_FILE_MACHINE_WCEMIPSV2",
+        "IMAGE_FILE_MACHINE_MIPS16",
+        "IMAGE_FILE_MACHINE_MIPSFPU",
+        "IMAGE_FILE_MACHINE_MIPSFPU16",
+    )
+)
+
+
+def arch_from_machine_type(ident: str) -> archinfo.Arch:
+    """
+    Resolve the architecture named by a PE file header's machine type.
+
+    A machine type names an architecture but not a byte order. The only big-endian machine type in the PE/COFF
+    specification is IMAGE_FILE_MACHINE_R3000BE (0x160), which pefile does not name, so cle states little-endian
+    for the machine types whose archinfo class would otherwise default to big-endian.
+    """
+
+    endness = archinfo.Endness.LE if ident in LITTLE_ENDIAN_MACHINE_TYPES else archinfo.Endness.ANY
+    return archinfo.arch_from_id(ident, endness=endness)
+
+
 class PE(Backend):
     """
     Representation of a PE (i.e. Windows) binary.
@@ -125,7 +150,7 @@ class PE(Backend):
 
         if self._arch is None:
             machine_type = self._pe.FILE_HEADER.Machine
-            self.set_arch(archinfo.arch_from_id(pefile.MACHINE_TYPE.get(machine_type, hex(machine_type))))
+            self.set_arch(arch_from_machine_type(pefile.MACHINE_TYPE.get(machine_type, hex(machine_type))))
 
         self.mapped_base = self.linked_base = self._pe.OPTIONAL_HEADER.ImageBase
 
@@ -230,7 +255,7 @@ class PE(Backend):
 
         assert pe.FILE_HEADER is not None
 
-        arch = archinfo.arch_from_id(pefile.MACHINE_TYPE[pe.FILE_HEADER.Machine])  # pylint:disable=no-member
+        arch = arch_from_machine_type(pefile.MACHINE_TYPE[pe.FILE_HEADER.Machine])  # pylint:disable=no-member
         return arch == obj.arch
 
     #

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -7,9 +7,11 @@ import sys
 import tempfile
 import unittest
 
+import archinfo
 import pefile
 
 import cle
+from cle.backends.pe.pe import arch_from_machine_type
 from cle.backends.pe.symbolserver import PDBInfo
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
@@ -324,6 +326,35 @@ class TestPEBackend(unittest.TestCase):
         assert isinstance(ld.main_object, cle.PE)
         assert ld.main_object.arch.name == "RISCV64"
         assert ld.main_object.os == "uefi"
+
+
+class TestPEMachineTypes(unittest.TestCase):
+    """
+    Test the architecture a PE file header's machine type resolves to.
+    """
+
+    # IMAGE_FILE_MACHINE_POWERPC and IMAGE_FILE_MACHINE_POWERPCFP
+    powerpc_machine_types = (0x1F0, 0x1F1)
+
+    def test_powerpc_is_32_bit_little_endian(self):
+        for machine_type in self.powerpc_machine_types:
+            arch = arch_from_machine_type(pefile.MACHINE_TYPE[machine_type])
+
+            assert arch.name == "PPC32"
+            assert arch.bits == 32
+            assert arch.memory_endness == archinfo.Endness.LE
+
+    # IMAGE_FILE_MACHINE_WCEMIPSV2, IMAGE_FILE_MACHINE_MIPS16, IMAGE_FILE_MACHINE_MIPSFPU and
+    # IMAGE_FILE_MACHINE_MIPSFPU16
+    mips_machine_types = (0x169, 0x266, 0x366, 0x466)
+
+    def test_mips_is_32_bit_little_endian(self):
+        for machine_type in self.mips_machine_types:
+            arch = arch_from_machine_type(pefile.MACHINE_TYPE[machine_type])
+
+            assert arch.name == "MIPS32"
+            assert arch.bits == 32
+            assert arch.memory_endness == archinfo.Endness.LE
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

cle attaches the wrong byte order to a PowerPC or MIPS PE. `cle/backends/pe/pe.py` turns `FILE_HEADER.Machine` into an architecture at two sites -- the `self._arch is None` branch of `PE.__init__` and `PE.check_compatibility` -- and both call `archinfo.arch_from_id` with no `endness` argument. Against archinfo master `384c676`, six machine types come back big-endian:

```
$ python -P -c 'import archinfo, pefile
for m in (0x1f0, 0x1f1, 0x169, 0x266, 0x366, 0x466):
    arch = archinfo.arch_from_id(pefile.MACHINE_TYPE[m])
    print(hex(m), pefile.MACHINE_TYPE[m], arch.name, arch.memory_endness)'
0x1f0 IMAGE_FILE_MACHINE_POWERPC PPC32 Iend_BE
0x1f1 IMAGE_FILE_MACHINE_POWERPCFP PPC32 Iend_BE
0x169 IMAGE_FILE_MACHINE_WCEMIPSV2 MIPS32 Iend_BE
0x266 IMAGE_FILE_MACHINE_MIPS16 MIPS32 Iend_BE
0x366 IMAGE_FILE_MACHINE_MIPSFPU MIPS32 Iend_BE
0x466 IMAGE_FILE_MACHINE_MIPSFPU16 MIPS32 Iend_BE
```

The [PE/COFF specification](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#machine-types) calls 0x1f0 "Power PC little endian" and 0x169 "MIPS little-endian WCE v2". Its one big-endian machine type is `IMAGE_FILE_MACHINE_R3000BE` (0x160), which `pefile` does not name, so no machine type cle can resolve is big-endian.

`pefile` parses the headers little-endian whatever the machine type, so the parse itself survives. What does not is everything that reads a word through the object's `Arch`: `Clemory.unpack_word`, the TLS and `gopclntab` readers, and the lifting and CFG built on top.

### Root cause

The registrations these machine types fall through to are `register_arch([r".*p\w*pc.*"], 32, Endness.ANY, ArchPPC32)` and `register_arch([r".*mips.*"], 32, "any", ArchMIPS32)`, and for an entry whose endness is `ANY` a call that names none is answered with `cls(cls.default_endness)`. Both classes default to big-endian. The identifier string carries no byte order, so the endness of a PE is decided by an architecture's default rather than by the container format that knows the answer. `ArchPPC32`'s default became big-endian in angr/archinfo#380 on 2026-09-01.

### Fix

Both sites go through one module-level helper in `cle/backends/pe/pe.py` that passes `Endness.LE` for those six machine types and `Endness.ANY` -- `arch_from_id`'s own default -- for everything else. Each site keeps the lookup it had: `PE.__init__` still falls back to `hex(machine_type)` for a machine `pefile` does not name, and `check_compatibility` still indexes the table directly. The ELF and Mach-O backends already state what they read: `elf.py` passes `"le" if reader.little_endian else "be"`, and `macho.py` passes the byte order of the header it parsed.

Of the 35 machine types `pefile` names, plus three numbers it does not, 32 resolve to exactly the same architecture as on master; the six that move all go from big-endian to little-endian. The full before and after tables are in the output comment. archinfo's defaults are left alone on purpose: angr/archinfo#380 set the PowerPC one deliberately and said this repair belongs in cle.

0x162 `IMAGE_FILE_MACHINE_R3000`, 0x166 `IMAGE_FILE_MACHINE_R4000` and 0x168 `IMAGE_FILE_MACHINE_R10000` are not touched. They raise `ArchNotFound` before and after, because no archinfo identifier matches those names, which is a mapping gap rather than a byte order one.

### Testing

`TestPEMachineTypes` in `tests/test_pe.py` asserts that the two PowerPC machine types resolve to a 32-bit little-endian `PPC32` and the four MIPS ones to a 32-bit little-endian `MIPS32`. Take the `endness` argument back out of the helper and both fail -- `AssertionError: assert <Endness.BE: 'Iend_BE'> == <Endness.LE: 'Iend_LE'>`. They assert the machine type mapping instead of loading a PE because `angr/binaries` has neither kind: of the 1,845 files tracked at `003e82a2`, 106 carry a valid `PE\0\0` signature, and their machine types are 0x8664, 0x14c, 0xaa64, 0x1c4 and 0x5064.

#757 rewrites the same two call sites for an unrelated reason, so the two conflict; whichever merges second needs a rebase.

Validation: https://github.com/angr/cle/pull/805#issuecomment-5496268858

session: sharpen