### PR TITLE
COFF: bound a section's raw data by the size of the file

### DIFF
--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -430,6 +430,18 @@ RELOC_CLASSES: dict[IntEnum, dict[IntEnum, type[Relocation]]] = {
     },
 }
 
+
+def _raw_data_in_file(pointer_to_raw_data: int, size_of_raw_data: int, file_size: int) -> int:
+    """
+    How many of a section's declared raw data bytes the file holds. A section that states
+    PointerToRawData 0 has no raw data in the file and gives its size in memory instead, which the
+    file does not bound.
+    """
+    if not pointer_to_raw_data:
+        return size_of_raw_data
+    return max(0, min(size_of_raw_data, file_size - pointer_to_raw_data))
+
+
 COFF_MACHINE_TO_ARCH_NAME = {
     IMAGE_FILE_MACHINE.I386: "x86",
     IMAGE_FILE_MACHINE.AMD64: "AMD64",
@@ -465,13 +477,33 @@ class Coff(Backend):
         for section_idx, section in enumerate(self._coff.sections):
             section_name = self._coff.get_section_name(section_idx)
             vaddr = section.PointerToRawData
-            vsize = section.SizeOfRawData
-            self.segments.append(Segment(section.PointerToRawData, vaddr, section.SizeOfRawData, vsize))
+            vsize = _raw_data_in_file(section.PointerToRawData, section.SizeOfRawData, len(self._data))
+            if vsize == 0 and section.SizeOfRawData:
+                log.warning(
+                    "Section %s states %#x bytes of raw data at %#x, which a %#x byte file does not reach. "
+                    "Skipping this section.",
+                    section_name,
+                    section.SizeOfRawData,
+                    section.PointerToRawData,
+                    len(self._data),
+                )
+                continue
+            if vsize != section.SizeOfRawData:
+                log.warning(
+                    "Section %s states %#x bytes of raw data at %#x, which a %#x byte file does not hold. "
+                    "Mapping the %#x bytes it does.",
+                    section_name,
+                    section.SizeOfRawData,
+                    section.PointerToRawData,
+                    len(self._data),
+                    vsize,
+                )
+            self.segments.append(Segment(section.PointerToRawData, vaddr, vsize, vsize))
             self.sections.append(
                 CoffSection(
                     section_name,
                     section.PointerToRawData,
-                    section.SizeOfRawData,
+                    vsize,
                     vaddr,
                     vsize,
                     section,

--- a/tests/test_coff.py
+++ b/tests/test_coff.py
@@ -6,6 +6,7 @@ import struct
 import unittest
 
 import cle
+from cle.backends.coff import _raw_data_in_file
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
 
@@ -73,6 +74,32 @@ class TestCoff(unittest.TestCase):
         ld = cle.Loader(exe, auto_load_libs=False)
         field_addr = section_vaddr(ld.main_object, ".text") + field_offset
         assert ld.memory.load(field_addr, 4) == struct.pack("<i", expected)
+
+    def test_a_sections_raw_data_is_bounded_by_the_file(self):
+        file_size = 0x100
+
+        # Raw data the file holds is mapped whole.
+        assert _raw_data_in_file(0x3C, 0x10, file_size) == 0x10
+        # Raw data the file cuts short is mapped as far as the file goes.
+        assert _raw_data_in_file(0x3C, 0x4000000, file_size) == file_size - 0x3C
+        # Raw data that starts past the end of the file: none of it is there, and Coff skips the section.
+        assert _raw_data_in_file(0x1000, 0x10, file_size) == 0
+        # PointerToRawData 0 says the section has no raw data and SizeOfRawData is its size in memory,
+        # which the file does not bound.
+        assert _raw_data_in_file(0, 0x1300, file_size) == 0x1300
+
+    def test_a_well_formed_objects_sections_map_the_bytes_they_declare(self):
+        exe = os.path.join(TEST_BASE, "tests", "x86", "fauxware.obj")
+        with open(exe, "rb") as f:
+            raw = f.read()
+
+        ld = cle.Loader(exe, auto_load_libs=False, perform_relocations=False)
+        sections = ld.main_object.sections
+        assert sections
+        for section in sections:
+            assert section.memsize == section.filesize
+            mapped = ld.memory.load(section.vaddr, section.memsize)
+            assert mapped == raw[section.offset : section.offset + section.filesize]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A COFF section header says where a section's raw data starts and how much of it
there is, and cle checks neither field against the file.

Take `tests/x86/coff_reloc_dir32.obj`, 108 bytes with one section, and set that
section's `SizeOfRawData` to `0x4000000`. On master `2f7657fd` cle believes it:

```
seg vaddr=0x40003c filesize=0x4000000 memsize=0x4000000
main_object.max_addr = 0x440003b
```

A 108-byte file gets a segment and a section claiming 64 MiB of memory that
nothing backs, and `max_addr` lands 64 MiB past the end of the image. Set
`PointerToRawData` to `0x4000000` instead and the section is placed 64 MiB out
whole. `SizeOfRawData` is 32 bits wide, so a header can claim close to 4 GiB
this way.

None of that allocates on master. The COFF image is the file itself, so the
header buys a wrong extent rather than memory: the first `0x30` bytes are real
and read fine, and everything the section claims past them is unbacked, so
`ld.memory.load(0x40006c, 4)` raises `KeyError`.

It stops being only an extent once the backend materialises what the header
states, which is what #804 does. #804 is unmerged, so this is not something cle
does today. On its head, with the section additionally marked
`IMAGE_SCN_ALIGN_512BYTES` so that its file offset `0x3c` fails its own stated
alignment and the realignment branch runs, that same 108-byte object produces a
67,109,376 byte image and takes the process from 70 MB to 262 MB RSS over three
runs. Bounding the field is cheaper before that lands than after.

### Root cause

`Coff.__init__` copies both fields straight out of the section table:

```python
vaddr = section.PointerToRawData
vsize = section.SizeOfRawData
self.segments.append(Segment(section.PointerToRawData, vaddr, section.SizeOfRawData, vsize))
```

Nothing between the header and the `Segment` compares `PointerToRawData +
SizeOfRawData` against `len(self._data)`. The PE backend does compare them, in
`_get_memory_mapped_image` in `cle/backends/pe/pe.py`: it cuts a section the file
ends inside, and skips one that starts past the end. The COFF path never got
that check.

### Fix

Map what the file holds, and skip a section the file does not reach at all --
the same two outcomes PE has. The two objects above:

```
seg vaddr=0x40003c filesize=0x30 memsize=0x30
main_object.max_addr = 0x40006b

(no segments, no sections)
main_object.max_addr = 0x400000
```

`tests/x86/fauxware.obj` is untouched either way: image 16,676 bytes,
`max_addr` `0x4031c0`.

Both `filesize` and `memsize` are clamped. A COFF section header does carry a
`VirtualSize`, but it is zero in every section of all five COFF objects
`angr/binaries` tracks that this backend can load, so `SizeOfRawData` is the
only size on offer and an unclamped `memsize` is memory with nothing behind it.
The header's own value is still readable as `section._coff_sec.SizeOfRawData`.

Deliberately not done: `PointerToRawData` 0 says the section has no raw data in
the file at all and gives its size in memory instead, which the file does not
bound. That case is left alone, so a section stating it keeps whatever
`SizeOfRawData` its header asks for. Whether anything is allocated for one is
#764's: it gives space of its own only to a section also marked
`IMAGE_SCN_CNT_UNINITIALIZED_DATA`, and caps that space at `MAX_IMAGE_SIZE`.

Also left alone: a section stating `SizeOfRawData` 0 at a `PointerToRawData`
past the end of the file is still kept, at an address the image does not cover,
exactly as on master.

The bound is a three-argument function rather than an inline expression so that
the test below can reach it.

#### Merge order

Seven open pull requests touch `cle/backends/coff.py`: #724, #761, #764, #775,
#799, #804 and #807. Against this branch #724, #764 and #804 conflict in
`coff.py`, and #724, #761, #764, #775 and #804 conflict in `tests/test_coff.py`;
#799 and #807 are clean. Whichever lands second resolves them, and the
resolution in `coff.py` is to keep the bounded size. On #804 that is one line:

```python
vsize = _raw_data_in_file(raw_ptr, section.SizeOfRawData, len(self._data))
```

Applied that way, #804's 67,109,376 byte image becomes 560 bytes and RSS does
not move. That line alone is not the whole resolution: without the skip beside
it, a section the file does not reach still gets a zero-length segment at an
address outside the image, and `max_addr` lands below that segment's own
`vaddr`. Carry both.

#775 caps `max_addr` at the image's own length, so on a tree carrying it the
`max_addr` line above already reads `0x40006b`; the `filesize` and `memsize`
lines hold either way.

### Testing

`tests/test_coff.py` asserts the bound at its four boundaries -- raw data inside
the file, cut short by it, starting past its end, and the `PointerToRawData` 0
carve-out. That is the test that fails on master, where the function does not
exist. A second asserts that a well-formed object still maps every byte its
sections declare, checked against the file's own bytes; it passes on master too,
and guards against the bound cutting into a real object.

No fixture reaches the bound through `cle.Loader` and none can be built from
real toolchain output, because a well-formed object never overruns. Truncating a
real one does not reach the section loop either: raw data ends at or before the
symbol table in all five COFF objects `angr/binaries` tracks that this backend
can load, so a file cut short enough to overrun a section has also lost its
string table, which `CoffParser._parse` reads first. `tests/x86/fauxware.obj`
cut to `0x2000` bytes raises `struct.error` there.

Validation: https://github.com/angr/cle/pull/806#issuecomment-5497368361

session: sharpen
