### PR TITLE
COFF: bound the offsets and counts a COFF object declares

### DIFF
--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -11,6 +11,7 @@ from enum import IntEnum, IntFlag
 
 import archinfo
 
+from cle.errors import CLEInvalidBinaryError
 from cle.utils import extract_null_terminated_bytestr
 
 from .backend import Backend, register_backend
@@ -173,6 +174,14 @@ class CoffParser:
         self.data: bytes = data
         self._parse()
 
+    def _require_in_file(self, offset: int, size: int, what: str) -> None:
+        # A table with no entries is never read, so nothing dereferences its pointer.
+        if size and offset + size > len(self.data):
+            raise CLEInvalidBinaryError(
+                f"The {what} needs {size:#x} bytes at {offset:#x}, "
+                f"which a {len(self.data):#x} byte file does not hold"
+            )
+
     def _parse(self) -> None:
         self.header = CoffFileHeader.from_buffer_copy(self.data)
         if self.header.Machine not in {
@@ -181,8 +190,20 @@ class CoffParser:
         }:
             raise NotImplementedError("Unsupported machine type")
 
-        strings_offset = (
-            self.header.PointerToSymbolTable + ctypes.sizeof(CoffSymbolTableEntry) * self.header.NumberOfSymbols
+        self._require_in_file(
+            ctypes.sizeof(self.header),
+            ctypes.sizeof(CoffSectionTableEntry) * self.header.NumberOfSections,
+            f"section table of {self.header.NumberOfSections} entries",
+        )
+
+        symbols_size = ctypes.sizeof(CoffSymbolTableEntry) * self.header.NumberOfSymbols
+        strings_offset = self.header.PointerToSymbolTable + symbols_size
+        # The string table begins on the byte after the last symbol and opens with its own size,
+        # so bounding that size field bounds every symbol table read as well.
+        self._require_in_file(
+            self.header.PointerToSymbolTable,
+            symbols_size + 4,
+            f"symbol table of {self.header.NumberOfSymbols} entries and the string table size after it",
         )
         strings_size = struct.unpack("<I", self.data[strings_offset : strings_offset + 4])[0]
         self.strings: bytes = self.data[strings_offset : strings_offset + strings_size]
@@ -224,6 +245,11 @@ class CoffParser:
             # Relocations
             relocs = []
             offset = section.PointerToRelocations
+            self._require_in_file(
+                offset,
+                ctypes.sizeof(CoffRelocationTableEntry) * section.NumberOfRelocations,
+                f"relocation table of section {i} with {section.NumberOfRelocations} entries",
+            )
             for i in range(section.NumberOfRelocations):
                 reloc = CoffRelocationTableEntry.from_buffer_copy(self.data, offset)
                 relocs.append(reloc)

--- a/cle/backends/coff.py
+++ b/cle/backends/coff.py
@@ -413,7 +413,7 @@ class CoffRelocationSECREL(CoffRelocation):
         return offset_to_symbol
 
 
-RELOC_CLASSES: dict[IntEnum, dict[IntEnum, type[Relocation]]] = {
+RELOC_CLASSES: dict[IntEnum, dict[IntEnum, type[CoffRelocation]]] = {
     IMAGE_FILE_MACHINE.I386: {
         IMAGE_REL_I386.REL32: CoffRelocationREL32,
         IMAGE_REL_I386.DIR32: CoffRelocationDIR32,
@@ -514,6 +514,21 @@ class Coff(Backend):
                 }:
                     reloc_class = RELOC_CLASSES[self._coff.header.Machine].get(reloc.Type, None)
                     if reloc_class is not None:
+                        patch_size = struct.calcsize(reloc_class.PACK_FORMAT)
+                        section_size = self._coff.sections[section_idx].SizeOfRawData
+                        image_size = len(self._image_vmem)
+                        if reloc.VirtualAddress + patch_size > section_size or patch_offset + patch_size > image_size:
+                            log.warning(
+                                "Section %s has a relocation of type %#x at %#x patching %#x bytes, which is out of "
+                                "bounds for its SizeOfRawData %#x or for the image size %#x. Skipping this relocation.",
+                                self._coff.get_section_name(section_idx),
+                                reloc.Type,
+                                reloc.VirtualAddress,
+                                patch_size,
+                                section_size,
+                                image_size,
+                            )
+                            continue
                         cle_symbol = self.get_symbol(sym_name, produce_extern_symbols=True)
                         self.relocs.append(reloc_class(self, cle_symbol, patch_offset))
                         continue

--- a/tests/test_coff.py
+++ b/tests/test_coff.py
@@ -59,6 +59,25 @@ class TestCoff(unittest.TestCase):
         field_addr = section_vaddr(ld.main_object, ".text")
         assert ld.memory.load(field_addr, 4) == struct.pack("<I", (target_symbol.rebased_addr + addend) % 2**32)
 
+    def test_a_relocation_past_the_end_of_its_section_is_skipped(self):
+        # The object's one relocation sits at offset 0x10 of a .text section holding 0x10 bytes, so
+        # its four-byte field falls on the start of .data, which is filled with 0xaa.
+        exe = os.path.join(TEST_BASE, "tests", "x86", "coff_reloc_outside_section.obj")
+        ld = cle.Loader(exe, auto_load_libs=False, perform_relocations=True)
+        assert ld.memory.load(section_vaddr(ld.main_object, ".data"), 0x10) == b"\xaa" * 0x10
+        assert ld.main_object.relocs == []
+
+    def test_a_relocation_past_the_end_of_the_file_is_skipped(self):
+        # The object's one relocation sits at offset 0x4000000 of .text, which the whole file does
+        # not reach.
+        exe = os.path.join(TEST_BASE, "tests", "x86", "coff_reloc_outside_file.obj")
+        with open(exe, "rb") as f:
+            raw = f.read()
+
+        ld = cle.Loader(exe, auto_load_libs=False, perform_relocations=True)
+        assert ld.main_object.relocs == []
+        assert ld.main_object.memory.load(0, len(raw)) == raw
+
     def test_rel32_relocation_encodes_a_negative_displacement(self):
         # The object holds a backwards call: _callee at offset 0, and a displacement field at
         # offset 5 storing the addend -4. Both live in .text, so the result does not depend on

--- a/tests/test_coff.py
+++ b/tests/test_coff.py
@@ -37,6 +37,35 @@ class TestCoff(unittest.TestCase):
         assert "rejected" in symbol_names
         assert "authenticate" in symbol_names
 
+    def test_a_section_table_longer_than_the_file_is_rejected(self):
+        # The first 512 bytes of x86/fauxware.obj. Its header declares 29 sections, whose table
+        # needs 0x49c bytes counted from the start of the file.
+        exe = os.path.join(TEST_BASE, "tests", "x86", "coff_truncated_section_table.obj")
+        with self.assertRaisesRegex(cle.CLEInvalidBinaryError, "section table"):
+            cle.Loader(exe, auto_load_libs=False)
+
+    def test_a_symbol_table_past_the_end_of_the_file_is_rejected(self):
+        # The first 2048 bytes of x86/fauxware.obj, which is long enough to hold the whole
+        # section table and not the 152 symbols at 0x31c1 or the string table after them.
+        exe = os.path.join(TEST_BASE, "tests", "x86", "coff_truncated_symbol_table.obj")
+        with self.assertRaisesRegex(cle.CLEInvalidBinaryError, "symbol table"):
+            cle.Loader(exe, auto_load_libs=False)
+
+    def test_a_relocation_table_past_the_end_of_the_file_is_rejected(self):
+        # An otherwise well-formed 108-byte object whose .text points its relocation table at
+        # 0x4000000, so everything else the parser reads is in range.
+        exe = os.path.join(TEST_BASE, "tests", "x86", "coff_reloc_table_past_file.obj")
+        with self.assertRaisesRegex(cle.CLEInvalidBinaryError, "relocation table"):
+            cle.Loader(exe, auto_load_libs=False)
+
+    def test_the_whole_object_still_loads(self):
+        # The bounds above are on what the header declares, so an object that declares only what
+        # it holds is unaffected.
+        exe = os.path.join(TEST_BASE, "tests", "x86", "fauxware.obj")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        assert len(ld.main_object.sections) == 29
+        assert len(ld.main_object.relocs) == 225
+
     def test_long_section_names_come_from_the_string_table(self):
         exe = os.path.join(TEST_BASE, "tests", "x86", "coff_long_section_names.obj")
         ld = cle.Loader(exe, auto_load_libs=False)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

The COFF backend reads and writes at addresses it computes from fields in the object's own
header, and checks none of them against the file. Three failures follow.

A relocation whose field lies past the end of its own section is applied anyway. On
`tests/x86/coff_reloc_outside_section.obj`, a relocation belonging to a `.text` of `0x10` bytes
has its four-byte field at offset `0x10`, which is the first byte of `.data`. The load returns
normally, `.data` comes back rewritten with `aa aa aa` become `16 ab ea`, and nothing is
reported.

A relocation whose field lies past the end of the file crashes. On
`tests/x86/coff_reloc_outside_file.obj` the field is at `0x4000000` in a 108-byte object, and
`cle.Loader(path, auto_load_libs=False, perform_relocations=True)` raises:

```
  File "cle/backends/coff.py", line 338, in value
    org_bytes = self.owner.memory.load(self.relative_addr, 4)
  File "cle/memory.py", line 422, in load
    raise KeyError(addr)
KeyError: 67108924
```

And `CoffParser._parse` reads the section table, the symbol and string table, and each
section's relocation table at offsets and counts the file supplies, bounding none of them.
Each of those three reads can leave `cle.Loader` as `struct.error` or as `ValueError` from
`ctypes`, neither of which is a `CLEError`, so nothing catching `CLEError` catches them.
Loading all 16677 truncations of the tracked `tests/x86/fauxware.obj`, 15457 fail that way.

### Root cause

The backend maps the whole file as one backer at address 0, so every offset inside the file
resolves and nothing outside it does. `_add_relocs` adds a relocation's `VirtualAddress` to its
section's `PointerToRawData` and registers the result unchecked, so an offset the section does
not contain still lands somewhere live: another section's raw data, the relocation table, the
symbol table. `_parse` has the same shape one layer earlier, taking `NumberOfSections`,
`PointerToSymbolTable`, `NumberOfSymbols` and `PointerToRelocations` as read.

### Fix

Two bounds.

A relocation is registered only if its field lies wholly inside its own section's raw data and
wholly inside the file; otherwise it is skipped with a `log.warning`, which is what the PE
backend does with a section whose raw data the file does not hold. The width comes from
`struct.calcsize` on the relocation class's `PACK_FORMAT`, so a four-byte field starting on the
last byte of a section is out of bounds.

Two details in that bound serve the other open COFF branches and change nothing here: the
section is read by index out of `self._coff.sections` rather than off the loop variable, and
the file-size half is bounded by `self._image_vmem` rather than by `self._data`. Both are the
same object here. Without them, #764 and #804, which conflict with this nowhere, stop four of
the COFF objects `angr/binaries` tracks from loading.

The parser refuses a header table the file does not hold, raising `CLEInvalidBinaryError` that
names the field, the bytes it wanted and the size of the file. A table with no entries is
exempt, because nothing dereferences its pointer. Nothing else changes about which objects
load: across a sweep of the five fields patched into `tests/x86/coff_reloc_dir32.obj`, master
and this branch accept the same objects and reject the same ones, and what changes is only the
exception. One bound covers two reads, because the string table begins on the byte after the
last symbol, so a file holding the four-byte string table size holds every symbol — across
those 16677 truncations, not one reaches the symbol table read.

A malformed table is fatal rather than skippable because the parser has no partial product:
`_add_relocs` indexes `self._coff.symbols` by an index from the file, so a short symbol list
becomes an `IndexError` elsewhere. `pe.py` takes the other option for its analogue, warning and
returning no symbols when a PE symbol table ends past the file. A COFF object has no second
source.

Deliberately not done: bounding a section's own raw data by the file size, which is #806; and
the fixed-size header read on the first line of `_parse`, which still raises `ValueError` for
18 of the 20 truncations shorter than twenty bytes, the other two never reaching this backend.
That read takes no field from the file, and whether such a file should reach the parser is
`Coff.is_compatible`'s question.

### Testing

Five regressions in `tests/test_coff.py`, all loading committed objects. The out-of-section one
asserts `.data` still reads `aa` sixteen times, which is what a fix that stopped the crash but
kept the silent write would fail; the three parser ones assert `CLEInvalidBinaryError` and the
field it names, so each pins a different bound. All five fail on master, on the byte
comparison, on the `KeyError` above, and three times on `struct.error` or `ValueError`.

A sixth test checks that an unmodified `tests/x86/fauxware.obj` still yields 29 sections and
225 relocations, and the cle suite goes from 261 to 267 passed with 9 skipped. Of the 16677
truncations, the same 1200 lengths load before and after. Of the ten COFF objects in
`angr/binaries` at the fixture head, the five well-formed ones keep their relocation counts exactly, 225 and 126
among them, and the two carrying a loose relocation drop from one registered relocation to
none. With `perform_relocations=True`, the default, master loads six of the ten and this branch
loads seven.

The fixtures live in the `angr/binaries` pull request below, which must merge first.

Validation: https://github.com/angr/cle/pull/807#issuecomment-5505417016

sync: angr/binaries#223

session: sharpen