### PR TITLE
Read the Go pclntab on Mach-O and PE, not only ELF

### DIFF
--- a/cle/backends/backend.py
+++ b/cle/backends/backend.py
@@ -19,7 +19,7 @@ from .relocation import Relocation
 from .symbol import Symbol
 
 if TYPE_CHECKING:
-    from cle.backends import Section, Segment
+    from cle.backends import GoPclntab, Section, Segment
     from cle.loader import Loader
     from cle.structs import MemRegion
 
@@ -127,6 +127,7 @@ class Backend:
     :ivar bool execstack:   Whether this executable has an executable stack
     :ivar str provides:     The name of the shared library dependancy that this object resolves
     :ivar list symbols:     A list of symbols provided by this object, sorted by address
+    :ivar gopclntab:        The Go runtime's function table, if this object has one, else None
     :ivar has_memory:       Whether this backend is backed by a Clemory or not. As it stands now, a backend should still
                             define `min_addr` and `max_addr` even if `has_memory` is False.
     """
@@ -253,6 +254,9 @@ class Backend:
 
         # line number mapping
         self.addr_to_line = {}
+
+        # the Go runtime's function table
+        self.gopclntab: GoPclntab | None = None
 
         # Custom options
         self._custom_entry_point = entry_point

--- a/cle/backends/gopclntab.py
+++ b/cle/backends/gopclntab.py
@@ -42,9 +42,6 @@ PCLNTAB_SECTION_NAMES = frozenset({".gopclntab", "__gopclntab", ".go.pclntab", "
 # Sections a pclntab may be embedded in, searched by magic as a fallback.
 _EMBEDDING_SECTION_NAMES = frozenset({".rdata", ".rodata", "__rodata", "__const", "__DATA_CONST"})
 
-# Sections whose presence means "this was built by the Go toolchain".
-_GO_MARKER_SECTION_NAMES = frozenset({".gosymtab", ".typelink", ".itablink", ".noptrdata", ".noptrbss"})
-
 _VALID_PTR_SIZES = (4, 8)
 _VALID_MIN_LC = (1, 2, 4)
 _MAX_NAME_LEN = 4096
@@ -226,10 +223,6 @@ def _text_start_fallback(execs) -> int | None:
     return min(sec.vaddr for sec in execs)
 
 
-def _looks_like_go(backend: Backend) -> bool:
-    return any(sec.name in _GO_MARKER_SECTION_NAMES or sec.name.startswith(".go.") for sec in backend.sections)
-
-
 def _find_pclntab_data(backend: Backend, endness: str):
     """
     Yield candidate ``bytes`` objects, each starting at a possible pclntab header.
@@ -243,9 +236,9 @@ def _find_pclntab_data(backend: Backend, endness: str):
         elif section.name in _EMBEDDING_SECTION_NAMES and not section.is_executable:
             embedding.append(section)
 
-    # PE and Mach-O bury the table in a generic read-only section; find it by magic. Only worth
-    # doing when something else already says this is a Go binary.
-    if not embedding or not _looks_like_go(backend):
+    # PE and Mach-O bury the table in a generic read-only section, so find it by magic and let
+    # GoPclntab.parse decide whether what follows is really a table.
+    if not embedding:
         return
     magics = [struct.pack(endness + "I", magic) for magic in GO_PCLNTAB_MAGICS]
     for section in embedding:

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -15,8 +15,10 @@ import archinfo
 from sortedcontainers import SortedKeyList
 
 from cle.backends.backend import AT, Backend, register_backend
+from cle.backends.gopclntab import register_gopclntab_symbols
 from cle.backends.macho.binding import BindingHelper, MachOPointerRelocation, MachOSymbolRelocation, read_uleb
 from cle.backends.regions import Regions
+from cle.backends.symbol import Symbol
 from cle.errors import CLECompatibilityError, CLEInvalidBinaryError, CLEOperationError
 
 from .encrypted_sentinel_backer import CryptSentinel
@@ -55,14 +57,15 @@ class SymbolList(SortedKeyList):
         super().__init__(**kwargs)
         self._symbol_cache = defaultdict(list)
 
-    def add(self, value: AbstractMachOSymbol):
+    def add(self, value: Symbol):
         super().add(value)
-        self._symbol_cache[
-            (
-                value.name,
-                value.library_ordinal,
-            )
-        ].append(value)
+        if isinstance(value, AbstractMachOSymbol):
+            self._symbol_cache[
+                (
+                    value.name,
+                    value.library_ordinal,
+                )
+            ].append(value)
 
     def get_by_name_and_ordinal(self, name: str, ordinal: int, include_stab=False) -> list[AbstractMachOSymbol]:
         if include_stab:
@@ -250,6 +253,9 @@ class MachO(Backend):
                 self.do_binding()
 
         self._load_stubs()
+
+        # Go binaries keep a full function table even when stripped
+        self.gopclntab = register_gopclntab_symbols(self)
 
     @property
     def stubs(self):
@@ -1236,7 +1242,11 @@ class MachO(Backend):
         sym.symbol_stubs
         """
         for sym in self.symbols:
-            if address == sym.relative_addr or address in sym.bind_xrefs or address in sym.symbol_stubs:
+            if address == sym.relative_addr:
+                return sym
+            if not isinstance(sym, AbstractMachOSymbol):
+                continue
+            if address in sym.bind_xrefs or address in sym.symbol_stubs:
                 return sym
         return None
 
@@ -1253,7 +1263,7 @@ class MachO(Backend):
         """
         result = []
         for sym in self.symbols:
-            if sym.is_stab and not include_stab:
+            if not include_stab and isinstance(sym, AbstractMachOSymbol) and sym.is_stab:
                 continue
 
             if fuzzy:

--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -19,6 +19,7 @@ except ImportError:
 from cle.address_translator import AT
 from cle.backends.backend import Backend, FunctionHint, FunctionHintSource, register_backend
 from cle.backends.coff import IMAGE_SYM_CLASS
+from cle.backends.gopclntab import register_gopclntab_symbols
 from cle.backends.symbol import SymbolType
 from cle.structs import DataDirectory, MemRegion, MemRegionSort, PointerArray, StringBlob, StructArray
 from cle.utils import extract_null_terminated_bytestr
@@ -190,6 +191,9 @@ class PE(Backend):
             pdb_path = debug_symbols or self._find_pdb_path()
             if pdb_path:
                 self.load_symbols_from_pdb(pdb_path)
+
+        # Go binaries keep a full function table even when stripped
+        self.gopclntab = register_gopclntab_symbols(self)
 
         self.is_dotnet = (
             self._pe.OPTIONAL_HEADER.DATA_DIRECTORY[

--- a/tests/test_gopclntab.py
+++ b/tests/test_gopclntab.py
@@ -17,6 +17,17 @@ TEST_LOCATION = os.path.join(
 # A stripped Go binary whose pclntab magic and textStart field have been clobbered.
 DAMAGED_BINARY = os.path.join(TEST_LOCATION, "x86_64", "starling")
 
+# Cross-compiled from tests_src/language_detector/langdetect_go.go. A PE has no section for the
+# pclntab: it is embedded in .rdata and has to be found by its magic. A Mach-O does have one,
+# __gopclntab, which PCLNTAB_SECTION_NAMES already knows.
+GO_PE_BINARY = os.path.join(TEST_LOCATION, "x86_64", "windows", "langdetect_go.exe")
+GO_MACHO_BINARY = os.path.join(TEST_LOCATION, "aarch64", "langdetect_go.macho")
+
+# A Go PE from the wild, stripped: its COFF symbol table names not one Go function.
+STRIPPED_GO_PE_BINARY = os.path.join(
+    TEST_LOCATION, "x86_64", "windows", "131252a8059fdbb12d77cd4711e597c45bb48e6d4bc3ddc808697a5e0488ff2c"
+)
+
 
 def _symtab_functions(path):
     """
@@ -107,11 +118,96 @@ class TestGoPclntab(unittest.TestCase):
         assert ld.find_symbol("runtime.GOMAXPROCS") is not None
         assert obj.get_symbol("runtime.Caller").rebased_addr in by_addr
 
-    def test_non_go_binary(self):
-        path = os.path.join(TEST_LOCATION, "x86_64", "fauxware")
-        ld = cle.Loader(path, auto_load_libs=False)
-        assert ld.main_object.gopclntab is None
-        assert not [s for s in ld.main_object.symbols if isinstance(s, cle.GoSymbol)]
+    def test_pe_binary(self):
+        obj = cle.Loader(GO_PE_BINARY, auto_load_libs=False).main_object
+        tab = obj.gopclntab
+
+        assert tab is not None
+        assert ".gopclntab" not in obj.sections_map
+        assert tab.go_version == (1, 20)
+        assert tab.ptr_size == 8
+        assert tab.min_lc == 1
+        assert tab.text_start == 0x140001000
+        assert len(tab.functions) == 1898
+        assert all(f.size > 0 for f in tab.functions)
+        assert [f.addr for f in tab.functions] == sorted(f.addr for f in tab.functions)
+
+    def test_pe_binary_supplies_the_function_symbols(self):
+        obj = cle.Loader(GO_PE_BINARY, auto_load_libs=False).main_object
+        tab = obj.gopclntab
+        assert tab is not None
+        go_symbols = [s for s in obj.symbols if isinstance(s, cle.GoSymbol)]
+
+        # 23 of the pclntab's entries are assembly routines the COFF symbol table already covers
+        assert len(go_symbols) == 1875
+        assert all(s.type == cle.SymbolType.TYPE_FUNCTION for s in go_symbols)
+        assert sum(1 for s in obj.symbols if s.is_function) == 1945
+
+        by_addr = {}
+        for symbol in obj.symbols:
+            by_addr.setdefault(symbol.rebased_addr, set()).add(symbol.name)
+        assert all(func.name in by_addr[func.addr] for func in tab.functions)
+
+        assert (sym := obj.get_symbol("runtime.main")) is not None and sym.rebased_addr == 0x140047E20
+        assert (sym := obj.get_symbol("main.main")) is not None and sym.rebased_addr == 0x1400A73C0
+
+    def test_stripped_pe_binary(self):
+        obj = cle.Loader(STRIPPED_GO_PE_BINARY, auto_load_libs=False).main_object
+        tab = obj.gopclntab
+
+        assert tab is not None
+        assert tab.text_start == 0x401000
+        assert len(tab.functions) == 1821
+        # nothing in this object's symbol table lands on a Go function, so every entry is added
+        assert len([s for s in obj.symbols if isinstance(s, cle.GoSymbol)]) == 1821
+        assert sum(1 for s in obj.symbols if s.is_function) == 1861
+        assert (sym := obj.get_symbol("main.main")) is not None and sym.rebased_addr == 0x4B75C0
+
+    def test_macho_binary(self):
+        obj = cle.Loader(GO_MACHO_BINARY, auto_load_libs=False).main_object
+        tab = obj.gopclntab
+
+        assert tab is not None
+        assert "__TEXT,__gopclntab" in obj.sections_map
+        assert tab.go_version == (1, 20)
+        assert tab.ptr_size == 8
+        assert tab.min_lc == 4
+        assert tab.text_start == 0x100001000
+        assert len(tab.functions) == 1888
+        assert [f.addr for f in tab.functions] == sorted(f.addr for f in tab.functions)
+
+    def test_macho_binary_supplies_the_function_symbols(self):
+        obj = cle.Loader(GO_MACHO_BINARY, auto_load_libs=False).main_object
+        assert isinstance(obj, cle.MachO)
+        tab = obj.gopclntab
+        assert tab is not None
+        go_symbols = [s for s in obj.symbols if isinstance(s, cle.GoSymbol)]
+
+        # cle reports no Mach-O symbol as a function, so nothing here covers a pclntab address and
+        # every entry is added, next to the underscore-prefixed name the symbol table already has
+        assert len(go_symbols) == 1888
+        assert all(s.type == cle.SymbolType.TYPE_FUNCTION for s in go_symbols)
+
+        by_addr = {}
+        for symbol in obj.symbols:
+            by_addr.setdefault(symbol.rebased_addr, set()).add(symbol.name)
+        assert all(func.name in by_addr[func.addr] for func in tab.functions)
+
+        assert obj.get_symbol("runtime.main")[0].rebased_addr == 0x10003FF30
+        assert obj.get_symbol("main.main")[0].rebased_addr == 0x10009D340
+
+    def test_non_go_binaries(self):
+        # One per format, each with a read-only section the magic scan now reaches, so that a
+        # miss here means the scan ran and found nothing rather than that it never ran.
+        for path, section in (
+            (os.path.join(TEST_LOCATION, "x86_64", "fauxware"), ".rodata"),
+            (os.path.join(TEST_LOCATION, "x86_64", "windows", "fauxware.exe"), ".rdata"),
+            (os.path.join(TEST_LOCATION, "aarch64", "dyld_ios15.macho"), "__DATA_CONST,__const"),
+        ):
+            obj = cle.Loader(path, auto_load_libs=False).main_object
+            assert section in obj.sections_map
+            assert obj.gopclntab is None
+            assert not [s for s in obj.symbols if isinstance(s, cle.GoSymbol)]
 
     def test_rejects_garbage(self):
         assert GoPclntab.parse(b"") is None


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

cle reads a Go binary's `pclntab` only when the binary is an ELF. On Mach-O and
PE it reads nothing, so a Go binary arrives with whatever handful of names its
symbol table happens to carry. `tests/x86_64/windows/langdetect_go.exe` is the
repository's own cross-compiled Go program, and its pclntab names 1,898
functions:

```pycon
>>> obj = cle.Loader("tests/x86_64/windows/langdetect_go.exe", auto_load_libs=False).main_object
>>> len(obj.symbols)
85
>>> obj.get_symbol("main.main"), obj.get_symbol("runtime.gopanic")
(None, None)
```

`tests/aarch64/langdetect_go.macho` behaves the same way, and it has a section
called `__gopclntab`.

Two things downstream lose by this. `CFGFast` on the stripped Go PE
`tests/x86_64/windows/131252a8059fdbb12d77cd4711e597c45bb48e6d4bc3ddc808697a5e0488ff2c`
finds 1,783 of that binary's 1,821 Go functions and can name six of them. And
`Project.is_go_binary` is `"go" in self.languages() and self.language_is_certain`,
and `language_is_certain` accepts only `None` or `"high"`. With no `runtime.*`
symbol and no section name `LanguageDetector` recognises, a Go Mach-O or PE is
detected as Go at `low` confidence, so the Go calling convention never engages
on either format.

### Root cause

`cle/backends/gopclntab.py` was written for all three formats.
`PCLNTAB_SECTION_NAMES` lists `__gopclntab` and `__go_pclntab` beside the ELF
spellings, and `_EMBEDDING_SECTION_NAMES` lists `.rdata`, `.rodata`, `__rodata`,
`__const` and `__DATA_CONST` for the formats that bury the table in a generic
read-only section. But `register_gopclntab_symbols` has exactly one caller,
`cle/backends/elf/elf.py:252` at `2f7657fd`.

Mach-O and PE do not fail for the same reason, which is why fixing one would not
have fixed the other.

Mach-O has the `__gopclntab` section, so `load_gopclntab` finds and parses the
table without complaint. Nothing calls it.

PE carries no Go-named section, so the table has to be found by its magic inside
`.rdata`. That scan sat behind a gate:

```python
def _looks_like_go(backend: Backend) -> bool:
    return any(sec.name in _GO_MARKER_SECTION_NAMES or sec.name.startswith(".go.") for sec in backend.sections)
```

`_GO_MARKER_SECTION_NAMES` is `{".gosymtab", ".typelink", ".itablink",
".noptrdata", ".noptrbss"}`, and no Go PE has any of them. Thirteen Go PEs in
`angr/binaries` at `a2eb7cf` load, between them showing six different
section-name sets; all thirteen carry `.text`, `.rdata`, `.data`, `.idata`,
`.reloc` and `.symtab`, twelve add `.zdebug_*` and two add `.pdata` and
`.xdata`, and not one carries any of those five names or a name starting
`.go.`. So the gate is False for every Go PE and the scan never runs.

### Fix

Call `register_gopclntab_symbols` from the Mach-O and PE backends, where the ELF
backend already calls it, and declare `gopclntab` on `Backend` so every object
answers the question rather than only some. `elf.py` is left alone.

Delete the gate rather than repair it, and let `GoPclntab.parse` decide. That is
what validates a candidate anyway: it checks the header padding, the pointer
size, the minimum instruction length, the five sub-table offsets, that the
function entries increase monotonically, and that every name is terminated
inside the table. A repaired gate is possible — of the 106 PE paths in
`angr/binaries` at `a2eb7cf` (105 distinct blobs; the one duplicated pair is not
Go), the thirteen with a `.symtab` section are exactly the thirteen Go ones —
but that is a Go linker detail rather than a documented marker. What it saves is
a `bytes.find` for two four-byte magics over an object's non-executable
read-only sections, and across that whole corpus those sections declare 36.2 MB
on the 862 objects the gate was keeping the scan away from.

Calling this from the Mach-O backend turned up three places where that backend
narrows `Backend.symbols` to `AbstractMachOSymbol` without saying so.
`SymbolList.add` indexes every symbol by `library_ordinal`, `get_symbol` reads
`is_stab`, and `get_symbol_by_address_fuzzy` reads `bind_xrefs` and
`symbol_stubs`. Those attributes are declared on `AbstractMachOSymbol` and on
nothing else, so any plain `Symbol` added by shared loader code raised
`AttributeError`. The three sites are guarded instead of teaching a
format-neutral symbol about Mach-O; they are the only reads of a Mach-O-only
symbol attribute over `self.symbols` anywhere in cle.

Not done here: at `2f7657fd` no Mach-O symbol is reported as a function, so the
address-based deduplication in `register_gopclntab_symbols` suppresses nothing
on that format and every pclntab entry is added beside the underscore-prefixed
name the Mach-O symbol table already carries. The pull request #796 changes
that. With both applied the dedupe, which compares addresses only, covers all
1,888 pclntab addresses on the Mach-O fixture and keeps `_main.main` over
`main.main`, so it will need to compare names as well as addresses.

### Testing

Five new tests in `tests/test_gopclntab.py` assert the recovered table and
symbols on a Go PE, a stripped Go PE and a Go Mach-O, and the existing non-Go
test is widened to three binaries, one per format, each with a read-only section
the scan now reaches. Reverting the four changed production files to `2f7657fd`
fails exactly those six and leaves the other seven passing.

The Mach-O fixture is new. It arrives in angr/binaries#224, which this
needs.

Validation: https://github.com/angr/cle/pull/808#issuecomment-5526280652

session: sharpen
