### PR TITLE
Fix Clemory.split_backer destroying a nested clemory

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -263,7 +263,10 @@ class Clemory(ClemoryBase):
             return
         if addr <= start_addr:
             return
-        if isinstance(backer, ClemoryBase):
+        # backers() recurses into nested clemories and yields the child's own backers, while remove_backer() below
+        # removes from self._backers, where the child itself sits.
+        idx = bisect.bisect_left(self._backers, start_addr, key=lambda x: x[0])
+        if idx >= len(self._backers) or self._backers[idx][1] is not backer:
             raise ValueError("Cannot split a backer which is itself a clemory")
         if addr >= start_addr + len(backer):
             return

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import os
 import sys
 import timeit
 import unittest
 
 import cffi
+import pytest
 
 import cle
 
@@ -85,6 +87,38 @@ def performance_clemory_contains():
         number=20000000,
     )
     print(t)
+
+
+def test_split_backer_refuses_to_split_through_a_nested_clemory():
+    child = cle.Clemory(None)  # type: ignore[arg-type]
+    child.add_backer(0, b"A" * 0x200)
+    child.add_backer(0x200, b"B" * 0x200)
+
+    clemory = cle.Clemory(None, root=True)  # type: ignore[arg-type]
+    clemory.add_backer(0, b"C" * 0x400)
+    clemory.add_backer(0x400, child)
+
+    before = [(start, bytes(backer)) for start, backer in clemory.backers()]
+
+    with pytest.raises(ValueError, match="itself a clemory"):
+        clemory.split_backer(0x401)
+
+    assert [(start, bytes(backer)) for start, backer in clemory.backers()] == before
+    assert clemory.load(0x600, 0x10) == b"B" * 0x10
+
+
+def test_split_backer_refuses_to_split_through_a_loaded_object():
+    filename = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../binaries/tests/x86_64/fauxware")
+    ld = cle.Loader(filename, auto_load_libs=False)
+    assert any(isinstance(backer, cle.Clemory) for _, backer in ld.memory._backers)
+
+    addr = ld.main_object.entry
+    before = [(start, bytes(backer)) for start, backer in ld.memory.backers()]
+
+    with pytest.raises(ValueError, match="itself a clemory"):
+        ld.memory.split_backer(addr + 1)
+
+    assert [(start, bytes(backer)) for start, backer in ld.memory.backers()] == before
 
 
 def test_clemory_contains():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Clemory.split_backer(addr)` removes the wrong thing when `addr` falls inside a
nested clemory, and `Loader.memory` is exactly that shape -- `Loader._map_object`
adds a loaded object's memory to it as a nested clemory.

On master the damage is hidden behind angr/cle#718 -- `remove_backer` never finds
its target, so the call raises `ValueError: Can't find backer to remove` and
nothing moves. With #718 applied it succeeds and silently drops memory. On
`binaries/tests/x86_64/fauxware`:

```
backers before: [('0x400000', 2676), ('0x600e28', 568), ('0x700000', 49)]
ld.memory.add_backer(ld.main_object.entry + 1, b"\x90" * 4, overwrite=True)
backers after : [('0x400000', 1409), ('0x400581', 4), ('0x400585', 1263), ('0x700000', 49)]
```

The 568-byte backer at `0x600e28` is gone -- 3293 backer bytes before, 2725
after -- and it is nowhere near the four bytes the caller asked to overwrite.

### Root cause

`split_backer` finds its target with `backers()` and removes it with
`remove_backer()`, and those two do not look at the same collection. `backers()`
recurses into a nested clemory and yields the child's own bytearrays at absolute
addresses, while `_backers`, which `remove_backer` pops from, holds the child
clemory itself. So the split reads a start that names a backer *inside* the
child, removes the whole child, and puts back two slices of that one inner
backer.

The guard that was meant to cover this cannot fire:

```python
if isinstance(backer, ClemoryBase):
    raise ValueError("Cannot split a backer which is itself a clemory")
```

`backers()` recurses past nested clemories rather than yielding them, so `backer`
is never a clemory.

### Fix

Raise unless the backer `backers()` found is one of this clemory's own, which is
the precondition for `remove_backer(start_addr)` to remove the thing being split.
The guard stays where it is and the rest of the function is unchanged.

Raising rather than recursing into the child is deliberate. `split_backer`'s only
caller in the tree is `add_backer(overwrite=True)`, which afterwards calls
`remove_backer` on the outer clemory, and that can only remove from `_backers`. A
recursive split would therefore leave the outer holding both the child and the
new backer over the same addresses.

### Testing

`tests/test_clemory.py` gains two tests, one on a nested clemory built in the
test and one on `Loader.memory` from `binaries/tests/x86_64/fauxware`. Both fail
on the merge base.

Nothing in cle, angr or angr-management reaches this on a load. Loading the 745
ELF files under `binaries/tests` calls `split_backer` 5,722 times and no call
gets as far as the removal, so the new guard never fires and no loaded object
changes. It is reachable through the public API, which is what the fauxware
example above uses.

Validation: https://github.com/angr/cle/pull/809#issuecomment-5529343715

session: sharpen
