### PR TITLE
Fix Mach-O section metadata and function discovery

### DIFF
--- a/cle/backends/backend.py
+++ b/cle/backends/backend.py
@@ -34,6 +34,7 @@ class FunctionHintSource:
     EH_FRAME = 0
     EXTERNAL_EH_FRAME = 1
     EXPORT_TABLE = 2
+    MACHO_FUNCTION_STARTS = 3
 
 
 class FunctionHint:

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -14,7 +14,7 @@ from os import SEEK_CUR, SEEK_SET
 import archinfo
 from sortedcontainers import SortedKeyList
 
-from cle.backends.backend import AT, Backend, register_backend
+from cle.backends.backend import AT, Backend, FunctionHint, FunctionHintSource, register_backend
 from cle.backends.gopclntab import register_gopclntab_symbols
 from cle.backends.macho.binding import BindingHelper, MachOPointerRelocation, MachOSymbolRelocation, read_uleb
 from cle.backends.regions import Regions
@@ -24,7 +24,7 @@ from cle.errors import CLECompatibilityError, CLEInvalidBinaryError, CLEOperatio
 from .encrypted_sentinel_backer import CryptSentinel
 from .macho_enums import LoadCommands as LC
 from .macho_enums import MachoFiletype, MH_flags
-from .section import MachOSection
+from .section import TYPE_MASK, ZEROFILL_SECTION_TYPES, MachOSection
 from .segment import MachOSegment
 from .structs import (
     DYLD_CHAINED_PTR_START_NONE,
@@ -801,6 +801,7 @@ class MachO(Backend):
             address += uleb[0]
 
             self.lc_function_starts.append(address)
+            self.function_hints.append(FunctionHint(address, 0, FunctionHintSource.MACHO_FUNCTION_STARTS))
             log.debug("Function start @ %#x (%#x)", uleb[0], address)
             i += uleb[1]
         log.debug("Done parsing function starts")
@@ -1035,12 +1036,13 @@ class MachO(Backend):
             # Clean segname and sectname
             section_sectname = section_sectname.replace(b"\0", b"")
             section_segname = section_segname.replace(b"\0", b"")
+            section_filesize = 0 if (section_flags & TYPE_MASK) in ZEROFILL_SECTION_TYPES else section_vsize
 
             # Create section
             sec = MachOSection(
                 section_foff,
                 section_vaddr,
-                section_vsize,
+                section_filesize,
                 section_vsize,
                 section_segname,
                 section_sectname,

--- a/cle/backends/macho/macho.py
+++ b/cle/backends/macho/macho.py
@@ -1036,7 +1036,7 @@ class MachO(Backend):
             # Clean segname and sectname
             section_sectname = section_sectname.replace(b"\0", b"")
             section_segname = section_segname.replace(b"\0", b"")
-            section_filesize = 0 if (section_flags & TYPE_MASK) in ZEROFILL_SECTION_TYPES else section_vsize
+            section_filesize = 0 if section_flags & TYPE_MASK in ZEROFILL_SECTION_TYPES else section_vsize
 
             # Create section
             sec = MachOSection(

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -267,6 +267,9 @@ def test_function_start_hints():
     rebased = cle.Loader(
         machofile, auto_load_libs=False, main_opts={"base_addr": macho.linked_base + 0x200000}
     ).main_object
+    assert isinstance(rebased, cle.MachO)
+    assert rebased.image_base_delta is not None
+    assert rebased.lc_function_starts is not None
     rebased_hints = [hint for hint in rebased.function_hints if hint.source == FunctionHintSource.MACHO_FUNCTION_STARTS]
     assert [hint.addr for hint in rebased_hints] == [
         addr + rebased.image_base_delta for addr in rebased.lc_function_starts

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -10,6 +10,7 @@ import pytest
 
 import cle
 from cle import MachO
+from cle.backends.backend import FunctionHintSource
 from cle.backends.macho.macho_enums import LoadCommands, MachoFiletype, SectionAttributes, SectionType
 from cle.backends.macho.section import MachOSection
 
@@ -240,10 +241,36 @@ def test_zerofill_sections():
     assert isinstance(bss, MachOSection)
     assert bss.type == SectionType.S_ZEROFILL
     assert bss.only_contains_uninitialized_data
+    assert bss.filesize == 0
+    assert bss.memsize > 0
+    assert not bss.contains_offset(bss.offset)
 
-    assert not macho.sections_map["__TEXT,__text"].only_contains_uninitialized_data
-    assert not macho.sections_map["__DATA,__data"].only_contains_uninitialized_data
+    text = macho.sections_map["__TEXT,__text"]
+    data = macho.sections_map["__DATA,__data"]
+    assert not text.only_contains_uninitialized_data
+    assert not data.only_contains_uninitialized_data
+    assert text.filesize == text.memsize
+    assert data.filesize == data.memsize
     assert {s.name for s in macho.sections if s.only_contains_uninitialized_data} == {"__bss"}
+
+
+def test_function_start_hints():
+    machofile = os.path.join(TEST_BASE, "tests", "aarch64", "dyld_ios15.macho")
+    ld = cle.Loader(machofile, auto_load_libs=False)
+    macho = ld.main_object
+    assert isinstance(macho, cle.MachO)
+
+    hints = [hint for hint in macho.function_hints if hint.source == FunctionHintSource.MACHO_FUNCTION_STARTS]
+    assert [hint.addr for hint in hints] == macho.lc_function_starts
+    assert all(hint.size == 0 for hint in hints)
+
+    rebased = cle.Loader(
+        machofile, auto_load_libs=False, main_opts={"base_addr": macho.linked_base + 0x200000}
+    ).main_object
+    rebased_hints = [hint for hint in rebased.function_hints if hint.source == FunctionHintSource.MACHO_FUNCTION_STARTS]
+    assert [hint.addr for hint in rebased_hints] == [
+        addr + rebased.image_base_delta for addr in rebased.lc_function_starts
+    ]
 
 
 def test_instruction_sections():


### PR DESCRIPTION
## Summary

- represent Mach-O zero-fill sections with `filesize == 0` while preserving their virtual size
- publish decoded `LC_FUNCTION_STARTS` entries through CLE's standard `function_hints` interface
- cover file-offset containment, ordinary section sizing, hint ordering, zero-sized hint metadata, and rebasing

## Rationale

Mach-O section `size` is a virtual size. `S_ZEROFILL`, `S_GB_ZEROFILL`, and
`S_THREAD_LOCAL_ZEROFILL` occupy memory but have no file-backed bytes. Passing
their virtual size as CLE's file size makes them claim unrelated file offsets,
often including offset zero.

CLE already decodes `LC_FUNCTION_STARTS`, but previously retained those
addresses only in the Mach-O-specific `lc_function_starts` list. Publishing
them as source-labeled `FunctionHint` entries lets existing CFG consumers use
the linker-provided starts without Mach-O-specific integration.

## Validation

- `pytest -q tests/test_macho.py -k 'not relocatable_object'` (`14 passed, 1 deselected`)
- verified all 11,199 decoded starts from a stripped AArch64 Mach-O are exposed as ordered function hints
- verified hints rebase by `image_base_delta`

The deselected test was added to CLE master by #787, but its
`relocatable_object.macho` fixtures are not yet present in the current
`angr/binaries` master.
