### PR TITLE
Remove the dead symbolic-ASLR loader API

### DIFF
--- a/cle/backends/backend.py
+++ b/cle/backends/backend.py
@@ -219,7 +219,6 @@ class Backend:
         self._md5: bytes | None = None
         self._sha256: bytes | None = None
 
-        self.mapped_base_symbolic = 0
         # These are set by cle, and should not be overriden manually
         self.mapped_base = self.linked_base = 0  # not to be set manually - used by CLE
 

--- a/cle/loader.py
+++ b/cle/loader.py
@@ -735,28 +735,6 @@ class Loader:
             log.warning("Dynamic load failed: %r", e)
             return None
 
-    def get_loader_symbolic_constraints(self):
-        """
-        Do not use this method.
-        """
-        if not self.aslr:
-            return []
-
-        try:
-            import claripy  # pylint:disable=import-outside-toplevel
-        except ImportError:
-            claripy = None
-
-        if not claripy:
-            log.error("Please install claripy to get symbolic constraints")
-            return []
-        outputlist = []
-        for obj in self.all_objects:
-            # TODO Fix Symbolic for tls whatever
-            if obj.aslr and isinstance(obj.mapped_base_symbolic, claripy.ast.BV):
-                outputlist.append(obj.mapped_base_symbolic == obj.mapped_base)
-        return outputlist
-
     # Private stuff
 
     @staticmethod


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Loader.get_loader_symbolic_constraints` holds cle's last `import claripy`. The
clarirs migration in angr (https://github.com/angr/angr/pull/6550, merged
2026-09-03) folded claripy into angr — it is built into `angr.rustylib.claripy`
and exposed as `angr.claripy` — and dropped the standalone `claripy` package
from angr's dependencies, so installing angr no longer installs it. Loading
`binaries/tests/x86_64/fauxware` with `aslr=True` in such an environment and
calling the method:

```
ERROR | cle.loader | Please install claripy to get symbolic constraints
Loader.aslr          : True
symbolic constraints : []
mapped_base_symbolic : 0
```

The error asks the user to install a package angr no longer uses.

### Root cause

The method returned `[]` before the migration too. The value it tests,
`Backend.mapped_base_symbolic`, is assigned in exactly one place —
`self.mapped_base_symbolic = 0` in `Backend.__init__` — so
`isinstance(obj.mapped_base_symbolic, claripy.ast.BV)` was never true and the
loop never appended a constraint. Nothing in cle, angr or angr-management calls
the method or writes the attribute, and the docstring is "Do not use this
method."

### Fix

Delete the method and the attribute that only fed it. cle is a dependency of
angr, so it cannot follow the migration's `from angr import claripy` rule;
dropping the dead code is how cle reaches zero `claripy` references, which
`git grep -n claripy` now confirms with exit 1. The `aslr` flags stay: `aslr` is
a documented `Loader` keyword, so removing it would break callers that pass it,
while removing the method breaks nobody. Nothing reads either flag after this
change; retiring them is a separate API change.

### Testing

No regression test: the change removes dead code and adds no behaviour to
assert. The load above is the check — it prints that error and `[]` on master and
raises `AttributeError` on this head, and both captures are in the output
comment. The cle suite is unchanged at 257 passed and 9 skipped, with the same 3
pre-existing failures master has.

Validation: https://github.com/angr/cle/pull/811#issuecomment-5532503753

session: sharpen