### PR TITLE
PE: Report a no-DEP image's sections as executable when none says it is

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -175,6 +175,7 @@ class PE(Backend):
         self._register_tls()
         # parse sections
         self._register_sections()
+        self._mark_sections_executable_without_dep()
 
         self.linking = "dynamic" if self.deps else "static"
         self.jmprel = self._get_jmprel()
@@ -1116,6 +1117,31 @@ class PE(Backend):
             section = PESection(pe_section, remap_offset=self.linked_base, name=name)
             self.sections.append(section)
             self.sections_map[section.name] = section
+
+    def _mark_sections_executable_without_dep(self):
+        """
+        Report an image's sections as executable when it marks none of them executable.
+
+        Windows enforces IMAGE_SCN_MEM_EXECUTE only through DEP, which an image opts into with
+        IMAGE_DLLCHARACTERISTICS_NX_COMPAT. Without that bit every readable page is executable, so a
+        packer can clear the flag on every section and the image still runs. One that then enters
+        inside such a section is not describing where its code is.
+        """
+        if self.supports_nx or any(section.is_executable for section in self.sections):
+            return
+        if self.find_section_containing(self._entry) is None:
+            return
+
+        log.warning(
+            "%s marks no section executable but enters at %#x. Reporting the sections that hold "
+            "content as executable, which is how the image runs without DEP.",
+            self.binary_basename,
+            self._entry,
+        )
+        for section in self.sections:
+            assert isinstance(section, PESection)
+            if not section.only_contains_uninitialized_data:
+                section.executable_without_dep = True
 
     def _find_pdb_path(self):
         """

--- a/cle/backends/pe/regions.py
+++ b/cle/backends/pe/regions.py
@@ -6,6 +6,10 @@ from cle.backends.region import Section
 class PESection(Section):
     """
     Represents a section for the PE format.
+
+    :ivar executable_without_dep: Set by the backend on an image whose cleared execute flags the
+                                  Windows loader would not have enforced. Read it through
+                                  ``is_executable``.
     """
 
     def __init__(self, pe_section, remap_offset=0, name: str | None = None):
@@ -18,6 +22,7 @@ class PESection(Section):
 
         self.characteristics = pe_section.Characteristics
         self.filesize = pe_section.SizeOfRawData
+        self.executable_without_dep = False
 
     #
     # Public properties
@@ -33,7 +38,7 @@ class PESection(Section):
 
     @property
     def is_executable(self):
-        return self.characteristics & 0x20000000 != 0
+        return self.characteristics & 0x20000000 != 0 or self.executable_without_dep
 
     @property
     def only_contains_uninitialized_data(self):

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -315,6 +315,22 @@ class TestPEBackend(unittest.TestCase):
         assert data[:4] == b"\x8bD$\x04"
         assert data[-4:] == b"3\xdb;\xc3"
 
+    def test_image_that_opts_into_dep_keeps_its_section_permissions(self):
+        # A PE that marks no section executable still runs when it does not opt into DEP, so cle reports
+        # the sections that hold content as executable there. This one is a resource-only DLL: it opts
+        # into DEP and enters nowhere, so its section table is believed and nothing becomes executable.
+        dll = os.path.join(
+            TEST_BASE, "tests", "x86_64", "windows", "65e25ea21a2f873affee8034e2c3381df48ff4129d447fa288fbd92307647582"
+        )
+        ld = cle.Loader(dll, auto_load_libs=False)
+        obj = ld.main_object
+        assert isinstance(obj, cle.PE)
+
+        assert obj.supports_nx
+        assert obj.find_section_containing(obj.entry) is None
+        assert [sec.name for sec in obj.sections] == [".rdata", ".rsrc"]
+        assert not any(sec.is_executable for sec in obj.sections)
+
     def test_uefi_image_is_not_windows(self):
         # A UEFI module is a PE, but it runs under the UEFI boot environment rather than Windows, and it says so in
         # the optional header. Windows has never run on RISC-V, so nothing else could have told them apart.


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A PE that sets `IMAGE_SCN_MEM_EXECUTE` on no section at all loads cleanly and then
gets an entirely empty CFG out of angr's `CFGFast`: zero functions, zero blocks,
zero edges, no exception and no failed decode.

The images hold real code and they run. Windows enforces that flag only through DEP,
which an image opts into by setting `IMAGE_DLLCHARACTERISTICS_NX_COMPAT`; a process
without that bit and without hardware DEP executes any readable page. So a packer can
clear the execute bit on every section, and the section table stops saying anything
about where the code is.

This is the largest single reason a well-formed Windows image comes back with nothing. A
sweep ran `CFGFast` over 9,256 objects from a private malware corpus. 6,627 of them are
well-formed PE images the corpus expects to load, and 513 of those produced no functions:
435 loaded and returned an empty CFG, the rest errored or ran over budget. **408 of the
435 mark no section executable** -- 408 of the 513. `NX_COMPAT` is clear on all 408, and 406 also enter at an address inside one
of those non-executable sections, so all three of this change's conditions hold on 406.
The 408 was counted twice by different code -- a standalone parser reading the section
table out of the file, and cle evaluating `any(s.is_executable for s in sections)` -- and
the two agree exactly.

### Root cause

`PESection.is_executable` returns the raw bit:

```python
@property
def is_executable(self):
    return self.characteristics & 0x20000000 != 0
```

With no section answering `True`, `CFGBase._executable_memory_regions` appends nothing
in its `elif isinstance(b, (Coff, PE))` branch, so `CFGFast` has no region to scan.
Handing it `regions=` by hand does not help either: `CFGFast._generate_cfgnode` reads
`section.is_executable` again and refuses any address in a non-executable section
before it decodes. Four more readers of the same predicate sit in `cfg_fast.py`, and
`cle/backends/gopclntab.py` has two of its own.

### Fix

Answer the question correctly in the one place all of them ask it. When a PE marks no
section executable, does not opt into DEP, and enters inside one of its sections, its
section table cannot be describing where its code is -- the image would fault on its
first instruction -- so report the sections that hold content as executable, and log a
warning saying so. `characteristics` keeps the value the file holds; the new
`executable_without_dep` flag is what `is_executable` ORs in.

That keeps the answer in the loader. Open issue
https://github.com/angr/angr/issues/4665, "Move executable page detection from CFGBase to
CLE", argues for more of this question living here; this change moves no region
derivation, only the answer cle gives it. angr needs no change.

All three conditions have to hold together, which is what keeps the rule off every
well-formed image: over the 106 PE files `angr/binaries` tracks at `3de2c41a`, 105 mark a
section executable and so return at the first test, and the one that does not is a
resource-only DLL meeting neither of the others.

Two of the 408 are not covered, both declined by the third condition. One enters in the
header page before its first section. The other enters one byte past its `.text` section's
`VirtualSize` but inside its `SizeOfRawData`: `PESection`'s memsize is `Misc_VirtualSize`
alone where Windows maps by the larger of the two, a separate gap that belongs in its own
change.

#### Why this and not angr's fallback

`CFGBase._executable_memory_regions` still has a fallback that scans the whole binary
when no region is found, and it is dead for PE. That is deliberate: angr `3dd6ce7406b9`
("CFG: Do not fallback to the full binary if no executable regions exist.", angr#6268)
introduced `has_executable`, gated the fallback on it, deleted the `AngrCFGError` that
used to be raised, and added `tests/analyses/cfg/test_cfg_no_executable_regions.py`.

Reviving it would revert that decision, and it does not work anyway: over 25 corpus
objects this change recovers, it finds 4 to 12 functions each, **none inside a section**,
and the entry is refused on all 25 because the second gate reads `section.is_executable`
again.

### Testing

**No public reproducer exists.** Nothing in `angr/binaries` has code and no executable
section. The single tracked PE with no executable section,
`tests/x86_64/windows/65e25ea2...`, is a resource-only DLL: `.rdata` and `.rsrc`,
`NX_COMPAT` set, entry RVA 0. Zero functions is the right answer for it, and angr's own
`test_cfg_no_executable_regions` pins it there. The images that show the defect are
non-redistributable malware samples, so the evidence is the measurement rather than a file
you can load.

The regression is therefore a negative one:
`tests/test_pe.py::test_image_that_opts_into_dep_keeps_its_section_permissions` loads that
same tracked DLL and asserts both guards hold and that nothing becomes executable. Because
the fixture has *both* `NX_COMPAT` and no entry point, it fails only when both guards are
removed, not when either one is. Nothing is built, assembled or patched at run time; the test reuses a file the
repository already tracks.

On 40 objects drawn with a fixed seed from the 406, `CFGFast` goes from **0 of 40
recovering any function to 40 of 40, finding 102,613**, with no errors or timeouts. On 166
controls -- 60 images from the same corpus that already recover functions, and every PE
`angr/binaries` tracks -- **not one section changes permission** and the flag is set on
none of them. The newer measurement comment on this pull request has the
per-object table, the controls and the two uncovered objects in full.

Validation: https://github.com/angr/cle/pull/812#issuecomment-5533342624

session: sharpen
