### PR TITLE
Rebase the PowerPC64 ELFv1 initial TOC value

### DIFF
--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -440,7 +440,9 @@ class MetaELF(Backend):
         Get initial rtoc value for PowerPC64 architecture.
         """
         if self.is_ppc64_abiv1:
-            return self._ppc64_abiv1_initial_rtoc
+            if self._ppc64_abiv1_initial_rtoc is None:
+                return None
+            return AT.from_lva(self._ppc64_abiv1_initial_rtoc, self).to_mva()
         elif self.is_ppc64_abiv2:
             return self._ppc64_abiv2_get_initial_rtoc()
         else:

--- a/tests/test_ppc64_initial_rtoc.py
+++ b/tests/test_ppc64_initial_rtoc.py
@@ -41,6 +41,21 @@ def test_ppc64el_abiv1():
     assert ld.main_object.ppc64_initial_rtoc == 0x10018E80
 
 
+def test_ppc64_abiv1_rebased():
+    # ABIv1 takes the entry point and the TOC out of the same entry descriptor, and both words are
+    # link-time addresses. libc.so.6 is a shared object, so the loader always rebases it.
+    lib = os.path.join(test_location, "ppc64", "libc.so.6")
+    ld = cle.Loader(lib, auto_load_libs=False, main_opts={"base_addr": 0x10100000})
+    main = ld.main_object
+    assert isinstance(main, cle.ELF)
+    assert main.is_ppc64_abiv1
+    assert main.mapped_base == 0x10100000
+    assert main.entry == 0x10147B60
+    assert main.ppc64_initial_rtoc == 0x102CC6F0
+    # the same address, taken from the mapped .got rather than from the descriptor
+    assert main.ppc64_initial_rtoc == main.sections_map[".got"].vaddr + 0x8000
+
+
 def load_relocatable(name):
     ld = cle.Loader(os.path.join(test_location, "ppc64", name), auto_load_libs=False)
     main = ld.main_object
@@ -70,5 +85,6 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     test_ppc64el_abiv1()
     test_ppc64el_abiv2()
+    test_ppc64_abiv1_rebased()
     test_ppc64_abiv1_relocatable_mapping_nothing()
     test_ppc64_abiv1_relocatable_mapping_code()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`MetaELF.ppc64_initial_rtoc` returns a link-time address for PowerPC64 ELFv1 objects, so
an object the loader moves reports a TOC pointer that is not where its TOC is.
`tests/ppc64/libc.so.6` from angr/binaries loads at `0x400000` under
`angr.Project(path, auto_load_libs=False)` and reports this:

```
main_object.entry               0x447b60
main_object.ppc64_initial_rtoc  0x1cc6f0
entry_state().regs.r2           0x1cc6f0
```

The entry point comes out of the same function descriptor as the TOC and is rebased; the
TOC is not. angr's `set_entry_register_values` stores the attribute straight into `r2`, so
a plain `Project` on that file starts with `r2` one base too low, and every TOC-relative
load from it addresses memory outside the image. Any ELFv1 object the loader moves is
wrong by the distance it moved. ELFv2 is unaffected.

### Root cause

`_ppc64_abiv1_entry_fix` unpacks both words out of the ELFv1 entry descriptor and stores
them as they appear in the file:

```python
self._entry = self.memory.unpack_word(AT.from_lva(ep_offset, self).to_rva())
self._ppc64_abiv1_initial_rtoc = self.memory.unpack_word(AT.from_lva(ep_offset + 8, self).to_rva())
```

`Backend.entry` translates the first on the way out, with
`return AT.from_lva(self._entry, self).to_mva()`. `ppc64_initial_rtoc` returned the second
unchanged. The ELFv2 branch beside it computes from `sections_map[".got"].vaddr`, which
`Region._rebase` has already moved, so one property returned a mapped address under one
ABI and a linked address under the other. The two branches have meant different things
since the ELFv2 one arrived in #218.

### Fix

Translate the ELFv1 value in the property, the way `Backend.entry` translates the entry
point, and leave `None` alone for a relocatable object that has no descriptor to read. It
belongs in the property rather than in `_ppc64_abiv1_entry_fix`, because that runs from
`ELF.__init__` before the loader has picked a base. `ppc64_initial_rtoc` is now a mapped
address for every object:

```
main_object.ppc64_initial_rtoc  0x5cc6f0
entry_state().regs.r2           0x5cc6f0
```

`0x5cc6f0` is also that object's mapped `.got` plus `0x8000`, and the word cle itself
leaves at the descriptor once it has resolved the `R_PPC64_RELATIVE` covering it.

### Testing

`tests/test_ppc64_initial_rtoc.py::test_ppc64_abiv1_rebased` loads `tests/ppc64/libc.so.6`
at `0x10100000` and asserts the TOC comes back as `0x102cc6f0`, cross-checked against the
mapped `.got`; on master it comes back as `0x1cc6f0` and the test fails. The four existing
tests in that file are untouched and pass on both revisions. Loading all seventeen
tracked files under `tests/ppc64/` on both revisions, each alone and again with its
libraries, moves nothing but this attribute — across 61 object loads per revision the
memory backers and the symbol tables hash identically, and the 31 rows that differ are
`libc.so.6` and `ld64.so.1` at the four bases they get mapped to.

Validation: https://github.com/angr/cle/pull/814#issuecomment-5534823052

session: sharpen