### PR TITLE
ELF: do not fail the load over a dynamic segment with no string table

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1065,26 +1065,35 @@ class ELF(MetaELF):
                 False,
             )
 
+        # Take the string table first. pyelftools resolves a tag's string as it hands the tag back, so a
+        # dynamic segment with no string table fails on every tag rather than on the four that carry one.
+        try:
+            strtab = seg_readelf._get_stringtable()  # pylint: disable=protected-access
+        except (AssertionError, ELFError):
+            # pyelftools 0.33 asserts; older versions return None, which the check below already handles.
+            strtab = None
+
         runpath, rpath = "", ""
-        for tag in seg_readelf.iter_tags():
+        for entry in seg_readelf._iter_tags():  # pylint: disable=protected-access
             # Create a dictionary, self._dynamic, mapping DT_* strings to their values
-            tagstr = self.arch.translate_dynamic_tag(tag.entry.d_tag)
-            self._dynamic[tagstr] = tag.entry.d_val
+            tagstr = self.arch.translate_dynamic_tag(entry.d_tag)
+            self._dynamic[tagstr] = entry.d_val
             # For tags that may appear more than once, handle them here
+            if strtab is None:
+                continue
             if tagstr == "DT_NEEDED":
-                self.deps.append(maybedecode(tag.needed))
+                self.deps.append(maybedecode(strtab.get_string(entry.d_val)))
             elif tagstr == "DT_SONAME":
-                self.provides = maybedecode(tag.soname)
+                self.provides = maybedecode(strtab.get_string(entry.d_val))
             elif tagstr == "DT_RUNPATH":
-                runpath = maybedecode(tag.runpath)
+                runpath = maybedecode(strtab.get_string(entry.d_val))
             elif tagstr == "DT_RPATH":
-                rpath = maybedecode(tag.rpath)
+                rpath = maybedecode(strtab.get_string(entry.d_val))
 
         self.extra_load_path = self.__parse_rpath(runpath, rpath)
 
-        strtab = seg_readelf._get_stringtable()
         if strtab is None:
-            log.warning("Unexpected return value from pyelftools: stringtable object is None.")
+            log.warning("%s has a dynamic segment but no dynamic string table.", self.binary)
             return
         self.__neuter_streams(strtab)
 

--- a/cle/backends/elf/metaelf.py
+++ b/cle/backends/elf/metaelf.py
@@ -38,7 +38,13 @@ def _get_relro(elf):
     # checksec.sh v1.5 (https://www.trapkit.de/tools/checksec/):
     #   - Partial RELRO has a 'GNU_RELRO' segment
     #   - Full RELRO also has a 'BIND_NOW' flag in the dynamic section
-    if not any(seg.header.p_type == "PT_GNU_RELRO" for seg in elf.iter_segments()):
+
+    # Ask the program headers directly: iter_segments() builds a DynamicSegment for PT_DYNAMIC, and building
+    # one walks the whole section table, so a section CLE has no use for here can fail the load.
+    if not any(
+        elf._get_segment_header(i)["p_type"] == "PT_GNU_RELRO"  # pylint: disable=protected-access
+        for i in range(elf.num_segments())
+    ):
         return Relro.NONE
     dyn_sec = elf.get_section_by_name(".dynamic")
     if dyn_sec is None or not isinstance(dyn_sec, DynamicSection):


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

CLE cannot load u-boot's x86-64 image at all. `cle.Loader(path, auto_load_libs=False)`
raises:

```
elftools.common.exceptions.ELFError: SHT_SYMTAB section points at section 0 of type SHT_NULL, expected SHT_STRTAB
  cle/backends/elf/metaelf.py:41 in _get_relro
  elftools/elf/elffile.py:191 in _get_linked_strtab_section
```

The object is u-boot v2026.07 for `qemu-x86_64_defconfig`, gcc 13.3.0, `-Os -gdwarf-4`
(sha256
`8224b8886308b6b00282815df304b0f75831de3516df77406a05b85c40838a43`). It is 24 MB and carries
a good `.symtab`: 13,273 entries, 4,372 of them `STT_FUNC`, and 4,243 functions with
DWARF ranges. `board_init_f` at `0x113b65d`, `board_init_r` at `0x113bbb9` and
`do_bootm` at `0x1123650` are all in it and CLE sees none of them, because the
exception comes out of the constructor and there is no object at all.

Both readelfs read the file: GNU readelf 2.46 prints its dynamic section with no
complaint, llvm-readelf 21 warns about the same dangling link and carries on, both
exit 0.

### Root cause

The file has no dynamic string table, and pyelftools will not go near a dynamic
segment without one. CLE walks into that twice.

`_get_relro` asks whether a `PT_GNU_RELRO` program header is present. It asks through
`iter_segments()`, and pyelftools builds each segment before its type can be read;
building the `PT_DYNAMIC` one walks the entire section table for the matching `.dynamic`
section. That table, read straight out of the file:

```
15 .hash    SHT_HASH    sh_link=20
20 .dynsym  SHT_DYNSYM  sh_link=0    (SHT_NULL)   size 0x18, one entry: the null symbol
40 .symtab  SHT_SYMTAB  sh_link=41 -> .strtab     13,273 entries
```

There is no `.dynstr`. u-boot's linker script discards it and GNU ld leaves `.dynsym`'s
link pointing at section 0, so the walk goes `.hash` -> `.dynsym` -> string table and
raises. The whole load is lost to a question whose answer is `Relro.NONE`: the file has
three program headers, `PT_LOAD`, `PT_DYNAMIC` and `PT_GNU_STACK`, and no RELRO at all.

`__register_dyn` is the second. pyelftools resolves a tag's string as it hands the tag
back, so `iter_tags()` wants the dynamic string table for every tag rather than for the
four whose value is a string offset. This object's dynamic array is `DT_DEBUG`,
`DT_RELA`, `DT_RELASZ`, `DT_RELAENT`, `DT_FLAGS_1`, `DT_RELACOUNT`, `DT_NULL` -- no
`DT_STRTAB`, and not one string among them. pyelftools 0.33 asserts, 0.29 through 0.32
raise. CLE already handles a missing dynamic string table three lines further down:

```python
        strtab = seg_readelf._get_stringtable()
        if strtab is None:
            log.warning("Unexpected return value from pyelftools: stringtable object is None.")
            return
```

The tag loop above it just runs first.

### Fix

`_get_relro` reads the program headers rather than materialising the segments, which is
what the question was. `__register_dyn` takes the string table before the loop rather than
after it, treats "there is none" as an answer rather than an error, and records every
tag's value either way, skipping only the four string-valued tags when there is no table
to resolve them with. Objects that have one behave exactly as before.

It does not close the next line. `get_section_by_name(".dynamic")` walks the section
table too, so a file with a `PT_GNU_RELRO` header *and* a table pyelftools refuses still
fails in `_get_relro`. Nothing I can measure has both.

It is also not the whole of `_get_relro`: the open #731 guards the `DT_FLAGS` read further
down and `MetaELF.extract_soname`, which fail the same way. The two do not overlap and
merge cleanly in either order. #731 says an object like this "still will not load, since
`ELF.__register_dyn()` genuinely needs the strings"; it does not, when no tag carries
one.

It also does not restore the sections. On master the load now
completes with zero sections and zero symbols, because a second, independent failure --
the same dangling `sh_link` seen from `ELF.__init__` -- makes CLE discard the section
header table. That is #802, which at `03316c16` does not overlap this diff and
merges with it cleanly. With both in, the object loads with its 43 sections, 13,273 symbols and 4,372
function symbols, and the loaded image is byte-identical to the file's `PT_LOAD`
contents.

### Testing

No regression test comes with this. Nothing tracked in `angr/binaries` reproduces it: of
its 858 ELF files, none raises out of `_get_relro`, and every one of the 606 that has a
`PT_DYNAMIC` segment yields a dynamic string table, so there is nothing already in the
tree to write a test against. The image above is 24 MB and does not belong in a test
repository. Objects that do reproduce the second site are public and small -- the
smallest I have is a 6,912-byte Alpine debug ELF -- so a fixture is available and I will
add one on request; it is left out here so this change does not depend on an open
`angr/binaries` pull request.

Loading all 858 before and after gives identical results on every field recorded, down to
a sha256 over every backer of the loaded image and the traceback frames of the ten that
fail on both sides. Both hunks run on that corpus, and the 598 files carrying a
`DT_NEEDED`, `DT_SONAME`, `DT_RUNPATH` or `DT_RPATH` resolve every one of those strings to
the same bytes. The cle suite is 3 failed, 257 passed, 9 skipped either way, the three
being pre-existing missing Mach-O fixtures.

Beyond that image, a corpus sweep here has at least 645 further ELF objects failing on
master in `__register_dyn` for want of a dynamic string table. I re-ran eight: all eight
load, one giving 38 sections and 8,359 symbols where master raised.

Validation: https://github.com/angr/cle/pull/815#issuecomment-5535435742

session: sharpen
