### PR TITLE
Fix ClemoryView.__setitem__ dropping the write

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -553,7 +553,7 @@ class ClemoryView(ClemoryBase):
     def __setitem__(self, k, v):
         if not self._offset <= k < self._endoffset:
             raise KeyError(k)
-        return self._backer[k + self._rebase]
+        self._backer[k + self._rebase] = v
 
     def __contains__(self, k):
         if not self._offset <= k < self._endoffset:

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -5,6 +5,7 @@ import timeit
 import unittest
 
 import cffi
+import pytest
 
 import cle
 
@@ -116,6 +117,20 @@ def test_clemory_contains():
     assert clemory.min_addr == 0
     assert clemory.max_addr == 70
     assert clemory.consecutive is True
+
+
+def test_clemory_view_setitem():
+    clemory = cle.Clemory(None, root=True)  # type: ignore[arg-type]
+    clemory.add_backer(0x1000, b"AAAABBBB")
+    view = cle.ClemoryView(clemory, 0x1000, 0x1008)
+
+    view[0] = 0x5A
+    assert view[0] == 0x5A
+    assert clemory[0x1000] == 0x5A
+    assert clemory.load(0x1000, 8) == b"ZAAABBBB"
+
+    with pytest.raises(KeyError):
+        view[8] = 0x5A
 
 
 def main():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

A write through a `ClemoryView` is silently lost. `cle` exports the class, and assigning a
byte through one leaves the memory unchanged and reports no error:

```python
>>> import archinfo, cle
>>> arch = archinfo.arch_from_id('x86_64')
>>> m = cle.Clemory(arch, root=True)
>>> m.add_backer(0x1000, b'AAAABBBB')
>>> view = cle.ClemoryView(m, 0x1000, 0x1008)
>>> view[0] = 0x5a
>>> view[0]
65
>>> m.load(0x1000, 8)
b'AAAABBBB'
```

### Root cause

`ClemoryView.__setitem__` carries `__getitem__`'s body. After the range check it reads the
byte at the translated address and returns it, and `v` is never used:

```python
def __setitem__(self, k, v):
    if not self._offset <= k < self._endoffset:
        raise KeyError(k)
    return self._backer[k + self._rebase]
```

### Fix

Assign to the translated address instead of reading from it. The range check and the
`KeyError` it raises are unchanged.

Nothing in `cle`, `angr` or `angr-management` constructs a `ClemoryView` or subclasses one,
so this has no in-tree caller today; the class is exported from `cle` and the method is wrong
for anyone who does.

### Testing

`tests/test_clemory.py` gains `test_clemory_view_setitem`, which writes a byte through a view
and reads it back through the view, through the parent `Clemory` and through `Clemory.load`,
and checks that an index outside the view still raises `KeyError`. It fails on master with
`assert 65 == 90`.

Validation: https://github.com/angr/cle/pull/816#issuecomment-5556520552

session: sharpen