### PR TITLE
Mach-O: guard the reads of an encrypted region and survive pickling

### DIFF
--- a/cle/backends/macho/encrypted_sentinel_backer.py
+++ b/cle/backends/macho/encrypted_sentinel_backer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import struct
+
 from cle.memory import Clemory
 
 
@@ -19,6 +21,33 @@ class CryptSentinel(Clemory):
         self._crypt_start = None
         self._crypt_end = None
         self._is_encrypted: bool = False
+
+    def __iter__(self):
+        if self._is_encrypted:
+            raise EncryptedDataAccessException("Cannot iterate encrypted memory region", self._crypt_start)
+        return super().__iter__()
+
+    def __getitem__(self, k):
+        self._assert_unencrypted_access(k, 1)
+        return super().__getitem__(k)
+
+    def __setitem__(self, k, v):
+        self._assert_unencrypted_access(k, 1)
+        return super().__setitem__(k, v)
+
+    def __contains__(self, k):
+        try:
+            return super().__contains__(k)
+        except EncryptedDataAccessException:
+            # Clemory.__contains__ probes __getitem__ when the memory is not consecutive, and that
+            # probe goes through the guard above. Whether an address is mapped is a question about
+            # the memory map rather than about the bytes, so answer it with a read that skips the
+            # guard and discards the byte.
+            try:
+                Clemory.__getitem__(self, k)
+            except KeyError:
+                return False
+            return True
 
     def __getstate__(self):
         s = super().__getstate__()
@@ -41,6 +70,14 @@ class CryptSentinel(Clemory):
         self._assert_unencrypted_access(addr, len(data))
         return super().store(addr, data)
 
+    def unpack(self, addr, fmt):
+        self._assert_unencrypted_access(addr, struct.calcsize(fmt))
+        return super().unpack(addr, fmt)
+
+    def pack(self, addr, fmt, *data):
+        self._assert_unencrypted_access(addr, struct.calcsize(fmt))
+        return super().pack(addr, fmt, *data)
+
     def find(self, data, search_min=None, search_max=None):
         if self._is_encrypted:
             raise EncryptedDataAccessException("Cannot search encrypted memory region", self._crypt_start)
@@ -62,10 +99,8 @@ class CryptSentinel(Clemory):
         Make sure that the access does not cover encrypted memory regions
         If it does, raise an error
 
-        Cases:
-        - Access starts before encrypted region and ends after it
-        - Access starts within encrypted region
-        - Access ends within encrypted region
+        The access covers the half-open interval [addr, addr + size), so it overlaps the encrypted
+        region when it starts before the region ends and ends after the region starts.
 
         :param addr:
         :param size:
@@ -74,8 +109,7 @@ class CryptSentinel(Clemory):
         if not self._is_encrypted:
             return
 
-        encrypted_range = range(self._crypt_start, self._crypt_end)
-        if addr in encrypted_range or (addr + size) in encrypted_range or (addr < self._crypt_start < addr + size):
+        if size > 0 and addr < self._crypt_end and addr + size > self._crypt_start:
             raise EncryptedDataAccessException("Accessing encrypted memory region", addr)
 
 

--- a/cle/backends/macho/encrypted_sentinel_backer.py
+++ b/cle/backends/macho/encrypted_sentinel_backer.py
@@ -20,6 +20,19 @@ class CryptSentinel(Clemory):
         self._crypt_end = None
         self._is_encrypted: bool = False
 
+    def __getstate__(self):
+        s = super().__getstate__()
+        s["_crypt_start"] = self._crypt_start
+        s["_crypt_end"] = self._crypt_end
+        s["_is_encrypted"] = self._is_encrypted
+        return s
+
+    def __setstate__(self, s):
+        super().__setstate__(s)
+        self._crypt_start = s.get("_crypt_start")
+        self._crypt_end = s.get("_crypt_end")
+        self._is_encrypted = s.get("_is_encrypted", False)
+
     def load(self, addr, n):
         self._assert_unencrypted_access(addr, n)
         return super().load(addr, n)

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -12,6 +12,7 @@ import pytest
 import cle
 from cle import MachO
 from cle.backends.backend import FunctionHintSource
+from cle.backends.macho.encrypted_sentinel_backer import CryptSentinel, EncryptedDataAccessException
 from cle.backends.macho.macho_enums import LoadCommands, MachoFiletype, SectionAttributes, SectionType
 from cle.backends.macho.section import MachOSection
 
@@ -507,3 +508,74 @@ def test_encryption_guard_survives_pickling():
     assert base + 0x4688 in ld.memory
     assert ld.memory.load(base + 0x4688, 4) == b"\xf6W\xbd\xa9"
 
+
+def test_encrypted_range_refuses_every_read():
+    """
+    The same binary with cryptid set to 1, which is what a genuinely encrypted one looks like. Every
+    read touching [0x4000, 0x8000) must raise rather than hand back the bytes on disk, which are
+    ciphertext. Single-byte reads and reads through the loader's own memory used to walk past the
+    guard and return them.
+    """
+    machofile = os.path.join(TEST_BASE, "tests", "armhf", "FileProtection-05.arm64.macho")
+    ld = cle.Loader(machofile, auto_load_libs=False)
+    obj = ld.main_object
+    assert isinstance(obj, cle.MachO)
+    memory = obj.memory
+    assert isinstance(memory, CryptSentinel)
+    base = obj.mapped_base
+
+    # The range the file's own load command records, with cryptid flipped on.
+    memory.set_crypt_info(1, 0x4000, 0x4000)
+
+    with pytest.raises(EncryptedDataAccessException):
+        memory.load(0x4688, 4)
+    with pytest.raises(EncryptedDataAccessException):
+        _ = memory[0x4688]
+    with pytest.raises(EncryptedDataAccessException):
+        _ = ld.memory[base + 0x4688]
+    with pytest.raises(EncryptedDataAccessException):
+        ld.memory.load_null_terminated_bytes(base + 0x4688)
+    with pytest.raises(EncryptedDataAccessException):
+        iter(memory)
+
+    # A word read starting two bytes before the range still covers its first two bytes.
+    with pytest.raises(EncryptedDataAccessException):
+        memory.unpack_word(0x3FFE, size=4)
+    with pytest.raises(EncryptedDataAccessException):
+        memory.pack_word(0x3FFE, 0, size=4)
+
+    # A read ending exactly where the range starts does not touch it, and neither does one after it.
+    assert memory.load(0x3FFC, 4) == b"\x00" * 4
+    assert memory.unpack_word(0x3FFC, size=4) == 0
+    assert memory.load(0x8000, 4) == bytes((0xA0, 0x00, 0x10, 0x00))
+
+    # Refusing to read an address does not stop the loader knowing which object holds it.
+    assert ld.find_object_containing(base + 0x4688) is obj
+
+
+def test_encrypted_range_answers_membership_across_a_gap():
+    """
+    A Mach-O whose object memory has holes in it. Refusing to read an encrypted address must not
+    stop the loader answering which object maps it, and Clemory.__contains__ only probes
+    __getitem__ when the memory is not consecutive, so this is the file that reaches that path.
+    """
+    machofile = os.path.join(TEST_BASE, "tests", "aarch64", "langdetect_go.macho")
+    ld = cle.Loader(machofile, auto_load_libs=False)
+    obj = ld.main_object
+    assert isinstance(obj, cle.MachO)
+    memory = obj.memory
+    assert isinstance(memory, CryptSentinel)
+    assert not memory.consecutive
+
+    base = obj.mapped_base
+    # The second backer ends at 0x16b718 and the third starts at 0x16c000, so 0x16b728 is mapped by
+    # no backer at all. Declare a range covering both it and a backed address.
+    backed, unmapped = 0x4688, 0x16B728
+    memory.set_crypt_info(1, 0x4000, 0x168000)
+
+    with pytest.raises(EncryptedDataAccessException):
+        _ = memory[backed]
+    assert backed in memory
+    assert unmapped not in memory
+    assert ld.find_object_containing(base + backed) is obj
+    assert ld.find_object_containing(base + unmapped) is None

--- a/tests/test_macho.py
+++ b/tests/test_macho.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
+import pickle
 import struct
 from io import BytesIO
 
@@ -480,3 +481,29 @@ def test_relocatable_object():
         # The defined symbols carry real section-relative addresses; undefined externals stay at 0.
         defined = {sym.name for sym in obj.symbols if sym.rebased_addr}
         assert defined, "no defined symbol carries an address"
+
+
+def test_encryption_guard_survives_pickling():
+    """
+    This binary carries an LC_ENCRYPTION_INFO_64 command with cryptid 0, so it records an encrypted
+    range and holds nothing encrypted. Its memory is a CryptSentinel all the same, and every read of
+    that range has to work. Pickling the loader used to lose the sentinel's crypt fields, so the
+    first load after unpickling raised
+    AttributeError: 'CryptSentinel' object has no attribute '_is_encrypted'.
+    """
+    machofile = os.path.join(TEST_BASE, "tests", "armhf", "FileProtection-05.arm64.macho")
+    ld = cle.Loader(machofile, auto_load_libs=False)
+    assert isinstance(ld.main_object, cle.MachO)
+    base = ld.main_object.mapped_base
+
+    # 0x4688 is the first non-zero byte in the range the load command records, [0x4000, 0x8000).
+    assert ld.memory[base + 0x4688] == 0xF6
+    assert base + 0x4688 in ld.memory
+    assert ld.memory.load(base + 0x4688, 4) == b"\xf6W\xbd\xa9"
+
+    ld = pickle.loads(pickle.dumps(ld))
+    base = ld.main_object.mapped_base
+    assert ld.memory[base + 0x4688] == 0xF6
+    assert base + 0x4688 in ld.memory
+    assert ld.memory.load(base + 0x4688, 4) == b"\xf6W\xbd\xa9"
+


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Every Mach-O gets a `CryptSentinel` for its object memory, and an `LC_ENCRYPTION_INFO`/`_64` command tells it which part of the image is encrypted. It overrides `load`, `store`, `find` and `backers` to refuse, which also covers `read`, and covers `unpack` and `pack` when the access starts inside the region. It does not cover `__getitem__`, `__setitem__`, `load_null_terminated_bytes`, `__iter__`, or a word read that starts just before the region and runs into it. Those return the bytes on disk.

On `binaries/tests/armhf/FileProtection-05.arm64.macho`, with its own recorded range marked encrypted:

```text
obj.memory.load(0x4688, 4)                       EncryptedDataAccessException
obj.memory[0x4688]                               246
loader.memory[base + 0x4688]                     246
loader.memory.load_null_terminated_bytes(...)    b'\xf6W\xbd\xa9\xf4O\x01\xa9\xfd{\x02\xa9\xfd\x83'
obj.memory.load(0x3FFC, 4)  ends at 0x4000       EncryptedDataAccessException
list(iter(obj.memory))[0x4688:0x468c]            ['0xf6', '0x57', '0xbd', '0xa9']
```

`246` is the byte on disk. angr's `CFGBase` reads a single byte with `loader.memory[addr]` and a run of bytes with `loader.memory.load(...)`, so one analysis gets both answers about the same address. The `0x3FFC` line is the mirror defect: a read ending exactly at the first encrypted byte lies outside the region and is refused anyway.

A second failure needs no encryption at all. Pickle the loader for any Mach-O and the next read raises:

```text
loader.memory.load(base + 0x4688, 4)             AttributeError: 'CryptSentinel' object has no attribute '_is_encrypted'
```

### Root cause

`CryptSentinel` overrides `load`, `store`, `find` and `backers`. `Clemory.__getitem__` and `Clemory.__iter__` read `self._backers` directly and never call `backers()`, and `load_null_terminated_bytes` is built on `__getitem__`. `ClemoryBase.unpack` and `ClemoryBase.pack` do call `backers()`, but it gets a start address and no size, so it cannot see a word read that begins before the region and ends inside it.

`Clemory.__getstate__` builds its state from a fixed list of slot names. `CryptSentinel` is the only subclass that adds attributes, and `_crypt_start`, `_crypt_end` and `_is_encrypted` live in `__dict__`, so the round trip drops them and the first guarded read dies looking for one.

`_assert_unencrypted_access` tested `addr in range(start, end) or (addr + size) in range(start, end) or ...`, which treats the exclusive end of the access as a member of the region.

### Fix

Guard `__getitem__` and `__setitem__` with `_assert_unencrypted_access`. That alone breaks membership, because `Clemory.__contains__` probes `__getitem__` whenever the memory is not consecutive, so `rva in obj.memory` and `Loader.find_object_containing` start raising for an encrypted address on any image with a hole in it — `binaries/tests/aarch64/langdetect_go.macho` is one. Whether an address is mapped is a question about the memory map, not about the bytes, so `__contains__` answers it with a probe that skips the guard and discards the byte; an address inside the region that no backer maps still answers `False`.

Guard `unpack` and `pack` too, where the format string gives the size `backers()` never sees; `unpack_word` and `pack_word` are built on them. Refuse `__iter__` while the image is encrypted, as `find` already is.

Give `CryptSentinel` a `__getstate__`/`__setstate__` pair that carries its three fields, using `s.get()` so a pickle written before this change still loads, as an unencrypted sentinel. Replace the membership test with the half-open overlap it meant: `size > 0 and addr < self._crypt_end and addr + size > self._crypt_start`.

Two stay open, unchanged from master: `Loader.memory_ro_view`, which flattens the backers into plain `bytearray`s when it is built and is what angr's VEX and p-code lifters read through; and `backers()`, which is given an address and no size, so it hands out the whole `bytearray` covering the region for angr's icicle engine to slice — which is also why an access straddling the region start still reaches bytes inside it through the loader's root memory. Closing either means changing `cle/memory.py`.

`addr in loader.memory` — the root memory, not an object's — now raises for an address inside the region instead of answering. Nothing in cle or angr asks that.

Byte access on a Mach-O costs one extra Python frame, about 45 ns, and `load_null_terminated_bytes` pays it per byte; `unpack_word` and `pack_word` pay a little more, once per call. `load`, `store` and resident memory are unchanged, on Mach-O and on ELF alike.

### Testing

`tests/test_macho.py` gains three tests. Two load `binaries/tests/armhf/FileProtection-05.arm64.macho`, which records an encryption range over `[0x4000, 0x8000)` with `cryptid=0`: one pins the reads that must keep working across a pickle round trip; the other calls `set_crypt_info(1, ...)` and pins the reads that must be refused, iteration and a straddling word read among them, and the reads ending at the region start that must be allowed. The third loads `binaries/tests/aarch64/langdetect_go.macho`, whose object memory has holes, and pins that membership and object lookup still answer for an encrypted address while an address in a hole answers `False`. All three fail on master, and each of the six parts of the fix is individually load-bearing.

No binary here triggers the guard for real. All 18 Mach-O files in `angr/binaries` that carry an encryption load command record `cryptid=0`, and none of the 7,784 Mach-O images in the corpora we sweep carries one at all — though that walk reads top-level file magic, and a `cryptid=1` App Store binary normally lives inside an `.ipa`. If you have a genuinely encrypted image, that is the test worth adding on top.

angr/cle#788 was our own draft over the same file, and its `cle/memory.py` rewrite would have closed the two paths above. It is now closed, so there is no conflict left and nothing lands second. Nothing outside cle writes through the object `backers()` hands out, and at that branch's head `d341e928`, against its own baseline `a4fb8003`, its snapshot cache costs 4.5x on `pack_word` and 5.1x on `pack` — cle's own relocation path — keeps 35.5 MB per `backers()` walk of a 37.6 MB image, and turns a write-then-read loop into a full-image copy per write, 0.0005 s to 1.00 s over 200 iterations. So the two paths above stay open, and closing either still means a check inside `cle/memory.py`.

Validation: https://github.com/angr/cle/pull/817#issuecomment-5556896198

session: sharpen
