### PR TITLE
Fix Clemory.__iter__ yielding bytes instead of addresses

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -286,13 +286,12 @@ class Clemory(ClemoryBase):
         self._update_min_max()
 
     def __iter__(self):
-        for start, string in self._backers:
-            if isinstance(string, bytes | list):
-                for x in range(len(string)):
-                    yield start + x
+        for start, backer in self._backers:
+            if isinstance(backer, Clemory):
+                for addr in backer:
+                    yield start + addr
             else:
-                for x in string:
-                    yield start + x
+                yield from range(start, start + len(backer))
 
     def __getitem__(self, k):
         for start, data in self._backers:

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import os
 import sys
 import timeit
 import unittest
 
+import archinfo
 import cffi
 
 import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
 
 
 @unittest.skipIf(sys.platform == "emscripten", "runtime CFFI compilation is unavailable in Pyodide")
@@ -72,6 +76,33 @@ def test_clemory():
     clemory.seek(0)
     assert clemory.read(25) == b""
     assert clemory.load(10, 25) == b"A" * 20
+
+
+def test_clemory_iter_yields_addresses():
+    arch = archinfo.ArchAMD64()
+
+    # add_backer stores a bytes backer as a bytearray, so the first case covers both
+    for backer in (bytes((0x00, 0x01, 0x41, 0xFF)), [0x00, 0x01, 0x41, 0xFF]):
+        clemory = cle.Clemory(arch, root=True)
+        clemory.add_backer(0x100, backer)
+        assert list(clemory) == [0x100, 0x101, 0x102, 0x103]
+
+    inner = cle.Clemory(arch)
+    inner.add_backer(0x10, bytes((0x00, 0x01, 0x41, 0xFF)))
+    outer = cle.Clemory(arch, root=True)
+    outer.add_backer(0x1000, inner)
+    assert list(outer) == [0x1010, 0x1011, 0x1012, 0x1013]
+
+
+def test_clemory_iter_loaded_binary():
+    loader = cle.Loader(os.path.join(TEST_BASE, "x86_64", "fauxware"), auto_load_libs=False)
+    expected = set()
+    for start, backer in loader.memory.backers():
+        expected.update(range(start, start + len(backer)))
+
+    addresses = list(loader.memory)
+    assert set(addresses) == expected
+    assert len(addresses) == len(expected)
 
 
 def performance_clemory_contains():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Clemory.__iter__` is meant to yield one address per byte a backer holds. For a
`bytearray` backer it yields the bytes themselves added to the backer's start
address, so the addresses it reports are a function of the file's contents.
Loading `binaries/tests/x86_64/fauxware` and iterating `loader.memory`:

```
>>> ld = cle.Loader("../binaries/tests/x86_64/fauxware", auto_load_libs=False)
>>> len(list(ld.memory)), len(set(ld.memory))
(3293, 238)
>>> [hex(a) for a in list(ld.memory)[:8]]
['0x40007f', '0x400045', '0x40004c', '0x400046', '0x400002', '0x400001', '0x400001', '0x400000']
```

3293 addresses are mapped and 3055 of them are never yielded. An `mmap` backer
comes out worse still: iterating an `mmap` gives length-1 `bytes`, so `__iter__`
raises `TypeError: unsupported operand type(s) for +: 'int' and 'bytes'`.

### Root cause

The method dispatches on the backer's type:

```python
for start, string in self._backers:
    if isinstance(string, bytes | list):
        for x in range(len(string)):
            yield start + x
    else:
        for x in string:
            yield start + x
```

`add_backer` converts a `bytes` backer with `data = bytearray(data)` before it
stores it, so `_backers` never holds a `bytes`. Only a `list[int]` backer takes
the first arm; everything else falls to the second one, which exists for a nested `Clemory` --
iterating one of those does yield addresses, so the arm is right for the case it
was written for and wrong for every buffer that reaches it.

Both halves arrived in the same commit. d1b5187 added the bytes-to-bytearray
conversion and rewrote the guard, which until then read
`isinstance(string, (bytes, unicode))` -- on Python 2 that covered every backer
`add_backer` would accept apart from a nested `Clemory`.

### Fix

Dispatch on `Clemory` instead, which is what the second arm is for, and take the
length of everything else. `_update_min_max` already draws the same line between
a nested clemory and a backer with a length, and this covers `bytearray`, `list`
and `mmap` without naming any of them. On the same binary:

```
>>> len(list(ld.memory)), len(set(ld.memory))
(3293, 3293)
>>> [hex(a) for a in list(ld.memory)[:8]]
['0x400000', '0x400001', '0x400002', '0x400003', '0x400004', '0x400005', '0x400006', '0x400007']
```

No caller iterates a `Clemory` in cle at `0e77ade3`, angr at `87411a71` or
angr-management at `aa843e5c`, so this repairs a public method rather than a
live code path.

### Testing

`tests/test_clemory.py` gains two tests. `test_clemory_iter_yields_addresses`
covers a buffer backer, a `list[int]` backer and a nested clemory whose own
backer does not start at zero. `test_clemory_iter_loaded_binary` loads
`binaries/tests/x86_64/fauxware` and compares `set(loader.memory)` against the
union of `range(start, start + len(backer))` over `loader.memory.backers()`.
Both fail on master and pass here.

Validation: https://github.com/angr/cle/pull/818#issuecomment-5557076906

session: sharpen