### PR TITLE
Return False from ClemoryView.__contains__ instead of raising

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -557,7 +557,7 @@ class ClemoryView(ClemoryBase):
 
     def __contains__(self, k):
         if not self._offset <= k < self._endoffset:
-            raise KeyError(k)
+            return False
         return k + self._rebase in self._backer
 
     def backers(self, addr=0):

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -118,6 +118,23 @@ def test_clemory_contains():
     assert clemory.consecutive is True
 
 
+def test_clemory_view_contains():
+    clemory = cle.Clemory(None, root=True)  # type: ignore[arg-type]
+    clemory.add_backer(0x1000, b"AAAABBBBCCCCDDDD")
+    view = cle.ClemoryView(clemory, 0x1000, 0x1010)
+
+    assert 0 in view
+    assert 0xF in view
+    assert 0x10 not in view
+    assert -1 not in view
+
+    offset_view = cle.ClemoryView(clemory, 0x1000, 0x1010, offset=0x20)
+    assert 0x20 in offset_view
+    assert 0x2F in offset_view
+    assert 0x30 not in offset_view
+    assert 0x1F not in offset_view
+
+
 def main():
     g = globals()
     for func_name, func in g.items():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`addr in view` raises instead of answering, where `addr in clemory` answers:

```python
>>> m = cle.Clemory(arch, root=True)
>>> m.add_backer(0x1000, b'AAAABBBBCCCCDDDD')
>>> view = cle.ClemoryView(m, 0x1000, 0x1010)
>>> 0x10 in view
KeyError: 16
>>> 0x1010 in m
False
```

So a caller cannot use a `ClemoryView` where it uses a `Clemory` without wrapping every
membership test in a `try`/`except KeyError`.

### Root cause

`ClemoryView.__contains__` raises for an address outside the view rather than reporting that
it is not in it:

```python
def __contains__(self, k):
    if not self._offset <= k < self._endoffset:
        raise KeyError(k)
    return k + self._rebase in self._backer
```

The range check is right; only what it does with the answer is wrong. `Clemory.__contains__`
returns `False` in the same situation, and `in` is defined to give a boolean.

### Fix

Return `False`. The rest of the method is unchanged, and an address inside the view is still
answered by asking the parent.

Nothing in `cle` at `0e77ade3`, `angr` at `87411a71` or `angr-management` at `aa843e5c`
constructs a `ClemoryView` or subclasses one, so this has no in-tree caller; the class is
exported from `cle` and the method is wrong for anyone who does.

### Testing

`tests/test_clemory.py` gains `test_clemory_view_contains`: both edges of the window, one past
each end, and the same four addresses shifted for a view built with a non-zero `offset`, which
pins that the answer is about the view's own address space. It fails on master with
`KeyError: 16`.

Validation: https://github.com/angr/cle/pull/819#issuecomment-5557079153

session: sharpen