### PR TITLE
Fix ClemoryView.find translating its bounds twice

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -601,11 +601,12 @@ class ClemoryView(ClemoryBase):
         self._backer.store(addr + self._rebase, data)
 
     def find(self, data, search_min=None, search_max=None) -> Iterator[int]:
-        if search_min is None or search_min < self._start:
-            search_min = self._start
-        if search_max is None or search_max > self._end:
-            search_max = self._end
-        return self._backer.find(data, search_min=search_min + self._rebase, search_max=search_max + self._rebase)
+        if search_min is None or search_min < self._offset:
+            search_min = self._offset
+        if search_max is None or search_max > self._endoffset:
+            search_max = self._endoffset
+        for addr in self._backer.find(data, search_min=search_min + self._rebase, search_max=search_max + self._rebase):
+            yield addr - self._rebase
 
 
 class ClemoryTranslator(ClemoryBase):

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -118,6 +118,27 @@ def test_clemory_contains():
     assert clemory.consecutive is True
 
 
+def test_clemory_view_find():
+    clemory = cle.Clemory(None, root=True)  # type: ignore[arg-type]
+    clemory.add_backer(0x1000, b"AAAABBBBCCCCDDDD")
+
+    view = cle.ClemoryView(clemory, 0x1000, 0x1010)
+    assert list(clemory.find(b"CCCC")) == [0x1008]
+    assert list(view.find(b"CCCC")) == [0x8]
+    assert view[0x8] == ord("C")
+    assert list(view.find(b"CCCC", search_max=0x4)) == []
+
+    offset_view = cle.ClemoryView(clemory, 0x1000, 0x1010, offset=0x20)
+    assert list(offset_view.find(b"CCCC")) == [0x28]
+    assert offset_view[0x28] == ord("C")
+
+    windowed = cle.Clemory(None, root=True)  # type: ignore[arg-type]
+    windowed.add_backer(0x1000, b"CCCCAAAACCCCAAAA")
+    inner = cle.ClemoryView(windowed, 0x1004, 0x1010)
+    assert list(windowed.find(b"CCCC")) == [0x1000, 0x1008]
+    assert list(inner.find(b"CCCC")) == [0x4]
+
+
 def main():
     g = globals()
     for func_name, func in g.items():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ClemoryView.find` reports nothing where the parent `Clemory` finds a match:

```python
>>> m = cle.Clemory(arch, root=True)
>>> m.add_backer(0x1000, b'AAAABBBBCCCCDDDD')
>>> view = cle.ClemoryView(m, 0x1000, 0x1010)
>>> list(m.find(b'CCCC'))
[4104]
>>> list(view.find(b'CCCC'))
[]
```

An empty result reads as an answer rather than a failure, so a caller searching through a view
gets a wrong one silently.

### Root cause

The bounds are translated twice. `search_min` and `search_max` are clamped against
`self._start` and `self._end`, which are addresses in the *parent's* space, and then
`self._rebase` is added to them:

```python
if search_min is None or search_min < self._start:
    search_min = self._start
if search_max is None or search_max > self._end:
    search_max = self._end
return self._backer.find(data, search_min=search_min + self._rebase, search_max=search_max + self._rebase)
```

For the view above `_rebase` is `0x1000`, so a default search runs over the parent's
`0x2000`-`0x2010`, which is past the end of the view and past the end of the backer. Which way
it goes wrong depends on the `offset`: where `offset` equals `start`, `_rebase` is zero and the
arithmetic comes out right by accident.
`__getitem__`, `__setitem__`, `load` and `store` all take an address in the view's space and add
`_rebase` once; only `find` starts from the parent's.

The results have the same problem in the other direction: `find` yields the parent's addresses,
so unless `_rebase` is zero a match cannot be handed back to `view[...]`.

### Fix

Clamp against `self._offset` and `self._endoffset`, which are the view's own bounds, and
subtract `_rebase` from each result. `find` takes and gives addresses in the view's space, like
the rest of the class.

This does not touch `Clemory.find`, which has bound bugs of its own that the view inherits
either way.

Nothing in `cle`, `angr` or `angr-management` constructs a `ClemoryView`, so this has no
in-tree caller; the class is exported from `cle` and the method is wrong for anyone who does.

### Testing

`tests/test_clemory.py` gains `test_clemory_view_find`: that the view reports the match at the
offset that indexes it, that the byte there is the one expected, that a `search_max` below the
match excludes it, that a view built with a non-zero `offset` reports the match at that offset,
and that a view starting inside a backer reports only the match its window covers and not one
before it. It fails on master with `assert [] == [8]`.

Validation: https://github.com/angr/cle/pull/820#issuecomment-5557108234

session: sharpen