### PR TITLE
Stop Clemory views yielding bytes when iterated

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -32,6 +32,9 @@ class ClemoryBase:
     def __contains__(self, k):
         raise NotImplementedError
 
+    def __iter__(self):
+        raise NotImplementedError
+
     def load(self, addr, n):
         raise NotImplementedError
 

--- a/tests/test_clemory_views.py
+++ b/tests/test_clemory_views.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+
+import cle
+
+test_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
+
+
+def test_clemory_views_refuse_iteration():
+    loader = cle.Loader(os.path.join(test_location, "x86_64", "fauxware"), auto_load_libs=False)
+    memory = loader.memory
+    start = memory.min_addr
+
+    for view in (
+        cle.ClemoryView(memory, start, start + 0x100),
+        cle.ClemoryTranslator(memory, lambda addr: addr + start),
+        cle.ClemoryReadOnlyView(loader.main_object.arch, memory),
+    ):
+        try:
+            iter(view)
+        except NotImplementedError:
+            continue
+        raise AssertionError(f"{type(view).__name__} still falls back to the sequence protocol")
+
+    assert len(list(memory)) == sum(len(backer) for _, backer in memory.backers())
+
+
+if __name__ == "__main__":
+    test_clemory_views_refuse_iteration()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Iterating any of cle's three `Clemory` views yields the byte stored at each
address instead of the address. On `binaries/tests/x86_64/fauxware`:

```
>>> ld = cle.Loader("../binaries/tests/x86_64/fauxware", auto_load_libs=False)
>>> lo = ld.memory.min_addr
>>> list(ld.memory.load(lo, 6))
[127, 69, 76, 70, 2, 1]
>>> list(itertools.islice(cle.ClemoryView(ld.memory, lo, lo + 0x100), 6))
[127, 69, 76, 70, 2, 1]
>>> list(itertools.islice(cle.ClemoryTranslator(ld.memory, lambda k: k + lo), 6))
[127, 69, 76, 70, 2, 1]
```

Those six values are the first six bytes of the image -- `\x7fELF` and the class
and data fields after it -- not addresses. `ClemoryReadOnlyView`, which is what
`Loader.memory_ro_view` hands out, raises `KeyError: 0` instead, and so does a
`ClemoryView` whose address space does not start at zero.

### Root cause

None of the three defines `__iter__`, and neither does `ClemoryBase`. Python
therefore falls back to the legacy sequence protocol, which calls `obj[0]`,
`obj[1]`, ... and stops only on `IndexError`. These classes raise `KeyError`,
so the loop either runs off the end of the address space or dies on its first
step.

`ClemoryBase` declares seven methods and raises `NotImplementedError` in each:
`__getitem__`, `__setitem__`, `__contains__`, `load`, `store`, `backers` and
`find`. That list has been one short since b75fb69 created the class in 2020 --
`__iter__` went to `Clemory` alone and was never declared on the base, so the
protocol fallback has stood in for it ever since.

### Fix

Declare `__iter__` on `ClemoryBase` beside the other seven, so a class that does
not implement it refuses instead of falling through. `Clemory` keeps its own
implementation and is unaffected.

```
ClemoryView(mem, min_addr, min_addr + 0x100)
    -> raises NotImplementedError
ClemoryTranslator(mem, lambda a: a + min_addr)
    -> raises NotImplementedError
ClemoryReadOnlyView(arch, mem)
    -> raises NotImplementedError
```

The other shape is to implement address iteration on the views, and I did not,
for a measured reason rather than a preference. The three observations below are
taken at master `0e77ade3`. `ClemoryReadOnlyView.backers()` is a point query:
asked to enumerate a whole clemory it returns nothing, while
`_flattened_backers` holds three entries for this binary.
`ClemoryView.backers()` mis-clamps -- for the view above, 256 addresses wide, it
yields one backer of 2420 bytes starting at 0. And `ClemoryTranslator` refuses
`backers()` and `find()` outright, because address translation gives it no space
to walk. Say the word if you would rather have iteration. #818 fixes the same
class of defect on `Clemory` itself; the two do not overlap and neither depends
on the other.

### Testing

`tests/test_clemory_views.py` loads `binaries/tests/x86_64/fauxware`, builds all
three views over `loader.memory` and asserts that iterating each one raises
`NotImplementedError`, then checks that `Clemory` still yields one value per
backed byte, so the base declaration cannot shadow the subclass. It fails on
master, where the first view iterates instead.

Validation: https://github.com/angr/cle/pull/821#issuecomment-5557413397

session: sharpen