### PR TITLE
Implement __contains__ on ClemoryReadOnlyView

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -724,6 +724,13 @@ class ClemoryReadOnlyView(ClemoryBase):
     def __setitem__(self, k, v):
         raise NotImplementedError("ClemoryReadOnlyView does not support item assignment")
 
+    def __contains__(self, k) -> bool:
+        try:
+            self[k]
+        except KeyError:
+            return False
+        return True
+
     def load(self, addr: int, n: int) -> bytes:
         """
         Read up to `n` bytes at address `addr` in memory and return a bytes object.

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import timeit
 import unittest
@@ -7,6 +8,8 @@ import unittest
 import cffi
 
 import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
 
 
 @unittest.skipIf(sys.platform == "emscripten", "runtime CFFI compilation is unavailable in Pyodide")
@@ -72,6 +75,23 @@ def test_clemory():
     clemory.seek(0)
     assert clemory.read(25) == b""
     assert clemory.load(10, 25) == b"A" * 20
+
+
+def test_clemory_read_only_view_contains():
+    loader = cle.Loader(os.path.join(TEST_BASE, "x86_64", "fauxware"), auto_load_libs=False)
+    loader.gen_ro_memview()
+    view = loader.memory_ro_view
+    assert view is not None
+
+    entry = loader.main_object.entry
+    assert entry in view
+    assert entry - 0x10000 not in view
+
+    # The view answers the same as the clemory it was flattened from, including in the gaps
+    # between backers.
+    for start, backer in loader.memory.backers():
+        for addr in (start - 1, start, start + len(backer) - 1, start + len(backer)):
+            assert (addr in view) == (addr in loader.memory)
 
 
 def performance_clemory_contains():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`addr in view` raises on a `ClemoryReadOnlyView`. On
`binaries/tests/x86_64/fauxware`:

```pycon
>>> loader.gen_ro_memview()
>>> entry = loader.main_object.entry
>>> entry in loader.memory
True
>>> entry in loader.memory_ro_view
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "cle/memory.py", line 33, in __contains__
    raise NotImplementedError
NotImplementedError
```

`Loader.gen_ro_memview()` builds one of these for every `CFGFast` run and the
class is exported from `cle`, so a question the `Clemory` behind it answers
cannot be asked of the view. No caller asks it today: nothing in angr or
angr-management tests membership against the view. Nothing is broken; a public
read method cannot be called.

### Root cause

`ClemoryReadOnlyView` does not define `__contains__`, so it reaches
`ClemoryBase.__contains__`, whose body is `raise NotImplementedError`.

### Fix

Answer it the way `Clemory.__contains__` answers it once its own fast paths are
exhausted: look the address up and report whether that raised. This reuses the
last-backer cache `__getitem__` maintains and needs no bounds the class does not
carry.

```pycon
>>> entry in loader.memory_ro_view
True
>>> (entry - 0x10000) in loader.memory_ro_view
False
```

`find` is inherited from `ClemoryBase` here too and still raises. It is left
alone: it needs a decision about whether to search the flattened backers or
delegate to the clemory they were flattened from, which is a separate change.

### Testing

`test_clemory_read_only_view_contains` loads fauxware, builds the read-only view
and asserts that the entry point is in it, that an address 0x10000 below it is
not, and that the view answers the same as the clemory it was flattened from at
every backer boundary, gaps included. It fails on master with
`NotImplementedError`.

Validation: https://github.com/angr/cle/pull/822#issuecomment-5557771595

session: sharpen