### PR TITLE
Fix ClemoryView.backers clamping a backer to the wrong slice

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -570,17 +570,9 @@ class ClemoryView(ClemoryBase):
             else:
                 # clamp it via a memoryview
                 view = memoryview(backer)
-                if taddr + len(backer) - 1 >= self._endoffset:
-                    clamp_end = len(backer) - self._endoffset + taddr
-                else:
-                    clamp_end = len(backer)
-
-                if taddr < self._offset:
-                    clamp_start = self._offset - taddr
-                else:
-                    clamp_start = 0
-
-                yield taddr, view[clamp_start:clamp_end]
+                clamp_start = max(0, self._offset - taddr)
+                clamp_end = min(len(backer), self._endoffset - taddr)
+                yield taddr + clamp_start, view[clamp_start:clamp_end]
 
     def load(self, addr, n):
         if n == 0:

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import timeit
 import unittest
@@ -7,6 +8,8 @@ import unittest
 import cffi
 
 import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
 
 
 @unittest.skipIf(sys.platform == "emscripten", "runtime CFFI compilation is unavailable in Pyodide")
@@ -72,6 +75,22 @@ def test_clemory():
     clemory.seek(0)
     assert clemory.read(25) == b""
     assert clemory.load(10, 25) == b"A" * 20
+
+
+def test_clemory_view_backers_are_clamped_to_the_window():
+    loader = cle.Loader(os.path.join(TEST_BASE, "x86_64", "fauxware"), auto_load_libs=False)
+    memory = loader.memory
+
+    # A window clamped at its high end only.
+    view = cle.ClemoryView(memory, 0x400000, 0x400100)
+    assert [(start, len(backer)) for start, backer in view.backers()] == [(0, 0x100)]
+    assert b"".join(bytes(backer) for _, backer in view.backers()) == memory.load(0x400000, 0x100)
+
+    # A window clamped at both ends, given an offset of its own, so both clamps and the
+    # translation back into the view's address space are exercised together.
+    view = cle.ClemoryView(memory, 0x400010, 0x400100, offset=0x1000)
+    assert [(start, len(backer)) for start, backer in view.backers()] == [(0x1000, 0xF0)]
+    assert b"".join(bytes(backer) for _, backer in view.backers()) == memory.load(0x400010, 0xF0)
 
 
 def performance_clemory_contains():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ClemoryView.backers()` hands out the wrong slice, at the wrong address,
whenever a parent backer runs past either end of the view's window. On
`binaries/tests/x86_64/fauxware`, loaded with `auto_load_libs=False`:

```pycon
>>> [(hex(s), len(b)) for s, b in memory.backers()]
[('0x400000', 2676), ('0x600e28', 568), ('0x700000', 49)]
>>> [(hex(s), len(b)) for s, b in cle.ClemoryView(memory, 0x400000, 0x400100).backers()]
[('0x0', 2420)]
>>> [(hex(s), len(b)) for s, b in cle.ClemoryView(memory, 0x400010, 0x400100).backers()]
[('-0x10', 2404)]
>>> [(hex(s), len(b)) for s, b in cle.ClemoryView(memory, 0x600e30, 0x600e40, offset=0x10).backers()]
[('0x8', 536)]
```

A view covering 256 addresses reports 2420 bytes of them. A view whose window
starts 0x10 into a parent backer reports that backer at a negative address. A
view with an offset of its own reports a 16-address window as 536 bytes at
`0x8`, which is below the view's own `_offset`, so `view.load(0x8, 536)` raises
`KeyError` on the very backer the view just handed out.

### Root cause

Both halves of the clamp are wrong.

```python
if taddr + len(backer) - 1 >= self._endoffset:
    clamp_end = len(backer) - self._endoffset + taddr
```

`self._endoffset - taddr` is the offset inside the backer where the window ends,
and that is what `clamp_end` should be. The expression is `len(backer)` minus
that. The two coincide only when `len(backer)` is exactly twice
`self._endoffset - taddr`, which is a coincidence and not a case. The `else` arm
below it, taken when the backer does not overrun the window, is already right.

```python
yield taddr, view[clamp_start:clamp_end]
```

`taddr` is where the parent backer starts in the view's address space. The slice
starts `clamp_start` bytes later than that, so the address is short by exactly
the amount the low end was clamped by. Where `taddr` is itself negative, because
the parent backer begins below `self._rebase`, so is the address the view
reports.

### Fix

Take the intersection of the backer and the window in the backer's own offsets,
and yield the address the slice really begins at.

```pycon
>>> [(hex(s), len(b)) for s, b in cle.ClemoryView(memory, 0x400000, 0x400100).backers()]
[('0x0', 256)]
>>> [(hex(s), len(b)) for s, b in cle.ClemoryView(memory, 0x400010, 0x400100).backers()]
[('0x0', 240)]
>>> [(hex(s), len(b)) for s, b in cle.ClemoryView(memory, 0x600e30, 0x600e40, offset=0x10).backers()]
[('0x10', 16)]
```

The two branches above it are untouched, so a backer that lies wholly inside the
window is still yielded as itself rather than as a `memoryview`, and one wholly
outside is still skipped.

### Testing

`test_clemory_view_backers_are_clamped_to_the_window` loads fauxware and asserts
the address and the length of what two differently clamped windows hand out
against the window's own bounds, and their bytes against what the parent
`Clemory` returns for the same range. It fails on master at the first assertion,
with `(0, 2420)` where `(0, 256)` is expected.

Validation: https://github.com/angr/cle/pull/823#issuecomment-5557774528

session: sharpen