### PR TITLE
Fix the range Clemory.find searches

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -451,7 +451,7 @@ class Clemory(ClemoryBase):
 
         :param bytes data:          The bytestring to search for
         :param int search_min:      Optional: The first address to include as valid
-        :param int search_max:      Optional: The last address to include as valid
+        :param int search_max:      Optional: The address to stop searching at, exclusive
         :return Iterator[int]:      Iterates over addresses at which the bytestring occurs
         """
         if search_min is None:
@@ -467,13 +467,14 @@ class Clemory(ClemoryBase):
             elif isinstance(backer, list):
                 raise TypeError("find is not supported for list-backed clemories")
             else:
-                if search_max < start or search_min > start + len(data):
+                if search_max < start or search_min > start + len(backer):
                     continue
+                limit = min(len(backer), search_max - start)
                 ptr = search_min - start - 1
                 while True:
                     ptr += 1
                     ptr = backer.find(data, max(0, ptr))
-                    if ptr == -1 or ptr + len(data) > search_max - start - 1:
+                    if ptr == -1 or ptr >= limit or ptr + len(data) > search_max - start:
                         break
                     yield ptr + start
 

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import timeit
 import unittest
@@ -7,6 +8,8 @@ import unittest
 import cffi
 
 import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
 
 
 @unittest.skipIf(sys.platform == "emscripten", "runtime CFFI compilation is unavailable in Pyodide")
@@ -72,6 +75,54 @@ def test_clemory():
     clemory.seek(0)
     assert clemory.read(25) == b""
     assert clemory.load(10, 25) == b"A" * 20
+
+
+def test_clemory_find_bounds():
+    loader = cle.Loader(os.path.join(TEST_BASE, "x86_64", "fauxware"), auto_load_libs=False)
+    memory = loader.memory
+
+    # A match that ends on the last byte of the searched range is still a match. The default
+    # search_max is max_addr, so this is the last eight bytes of the loaded image.
+    end = memory.max_addr
+    tail = memory.load(end - 8, 8)
+    assert (end - 8) in set(memory.find(tail))
+
+    needle = b"SOSNEAKY"
+    (addr,) = memory.find(needle)
+
+    # search_max is exclusive: a range ending where the match ends still reports it.
+    assert list(memory.find(needle, search_max=addr + len(needle))) == [addr]
+    assert list(memory.find(needle, search_max=addr + len(needle) - 1)) == []
+
+    # search_min bounds where a match may start. A backer is out of range once search_min is
+    # past the end of the backer, not past its start plus the length of the needle.
+    assert list(memory.find(needle, search_min=addr)) == [addr]
+    assert list(memory.find(needle, search_min=addr + 1)) == []
+
+
+def test_clemory_find_stays_inside_its_backers():
+    loader = cle.Loader(os.path.join(TEST_BASE, "x86_64", "fauxware"), auto_load_libs=False)
+    memory = loader.memory
+
+    # The empty bytestring is the only needle a buffer reports at the offset one past its own
+    # end, and that offset is not an address in memory. fauxware leaves a gap after each of its
+    # first two backers, so master reports two addresses here that it does not contain.
+    assert [addr for addr in memory.find(b"") if addr not in memory] == []
+
+
+def test_clemory_find_stays_inside_the_range_it_was_given():
+    loader = cle.Loader(os.path.join(TEST_BASE, "x86_64", "fauxware"), auto_load_libs=False)
+    memory = loader.memory
+    entry = loader.main_object.entry
+
+    # A zero-length match has no bytes to run past search_max, so only a bound on where a match
+    # may start keeps the empty bytestring out of the searched range's own end.
+    assert list(memory.find(b"", search_min=entry, search_max=entry + 4)) == [
+        entry,
+        entry + 1,
+        entry + 2,
+        entry + 3,
+    ]
 
 
 def performance_clemory_contains():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Clemory.find` misses matches. On `binaries/tests/x86_64/fauxware`, loaded with
`auto_load_libs=False`:

```pycon
>>> tail = loader.memory.load(loader.memory.max_addr - 8, 8)
>>> [hex(a) for a in loader.memory.find(tail)][-3:]
['0x700026', '0x700027', '0x700028']
>>> [hex(a) for a in loader.memory.find(b'SOSNEAKY')]
['0x4008d0']
>>> [hex(a) for a in loader.memory.find(b'SOSNEAKY', search_min=0x4008d0)]
[]
```

The first search cannot report `0x700029`, which is where `tail` was read from,
and the third cannot report a match at the very address it was told to start
from.

`CFGFast._find_thunks` calls `loader.memory.find` with the default bounds to
locate `__x86_return_thunk` and its siblings, and `ELFCore` calls it to place
x86 TLS regions from `AT_RANDOM`. Both lose a match that sits on the last bytes
of the loaded image.

### Root cause

Two bounds in the bytes-backer branch, both from `c874b2df`, which added the
method in 2018.

The skip test measures the needle instead of the backer:

```python
if search_max < start or search_min > start + len(data):
    continue
```

`data` is the bytestring being searched for, so any `search_min` more than
`len(data)` bytes past a backer's start skips that whole backer. The
nested-clemory branch just above is the same test written correctly, over
`backer.max_addr + start`.

The stop test sits one below the last offset the range allows:

```python
if ptr == -1 or ptr + len(data) > search_max - start - 1:
```

`ptr + len(data)` is the match's exclusive end, so a match ending on the last
byte of the searched range is dropped. `search_max` defaults to `max_addr`, so
with no bounds given at all `find` cannot report a match on the last bytes of
the image.

### Fix

Measure the backer in the skip test, and drop the `- 1` from the stop test.

```pycon
>>> [hex(a) for a in loader.memory.find(tail)][-3:]
['0x700027', '0x700028', '0x700029']
>>> [hex(a) for a in loader.memory.find(b'SOSNEAKY', search_min=0x4008d0)]
['0x4008d0']
```

Widening that test needs a bound on where a match may *start*, which it did not
have, and adding one repairs answers master already gets wrong. The old test
bounded only the match's end, and a zero-length needle's end is its start, so
`find(b"")` reports an offset one past a backer -- two of them on fauxware,
`0x400a74` and `0x601060`, and the memory contains neither -- and an address
equal to `search_max`. The loop also trusts `backer.find` to return `-1` once
the search start is past the end of the buffer, which `bytes` and `bytearray` do
and `mmap` does not: `mmap` clamps the start to its length and returns that, so
`find(b"", None, max_addr + 2)` over an `mmap` backer never terminates on
master. `limit` is an upper bound on where a match may start, the smaller of the
backer's length and the searched range, and it settles all three. It also stops
the junction between two adjacent backers being reported twice.

`search_max` is exclusive, not inclusive as the docstring said. It defaults to
`max_addr`, which this class treats as one past the end everywhere else --
`__contains__` is `min_addr <= k < max_addr` -- so reading the parameter as
inclusive would make the default one byte wider than the memory it describes.

### Testing

`test_clemory_find_bounds` loads fauxware and asserts that a match ending at
`max_addr` is reported, that `search_max` is exclusive at both boundary values,
and that a backer is skipped only once `search_min` is past its end. It fails on
master at the first assertion. `test_clemory_find_stays_inside_its_backers`
asserts that no address `find(b"")` reports is outside the memory it searched;
it fails on master, which reports two.
`test_clemory_find_stays_inside_the_range_it_was_given` asserts that a bounded
search for the empty bytestring stops before its own `search_max`; it fails on
master, which reports nothing there at all because of the skip test above.
Across the 424 tracked x86_64 fixtures that load, the change adds 521 matches
and removes none, and leaves every search from the middle of a backer exactly
where it was.

Validation: https://github.com/angr/cle/pull/824#issuecomment-5557814656

session: sharpen