### PR TITLE
Enumerate every backer from a read-only Clemory view

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -769,15 +769,8 @@ class ClemoryReadOnlyView(ClemoryBase):
         raise NotImplementedError("ClemoryReadOnlyView does not support storing")
 
     def backers(self, addr: int = 0):
-        start_pos = bisect.bisect_right(self._flattened_backers, addr, key=lambda x: x[0])
-        if start_pos > 0:
-            start_pos -= 1
-        for idx in range(start_pos, len(self._flattened_backers)):
-            start, data = self._flattened_backers[idx]
-            if start > addr:
-                break
-            if 0 <= addr - start < len(data):
-                yield start, data
+        start_pos = bisect.bisect_right(self._flattened_backers, addr, key=lambda x: x[0] + len(x[1]))
+        yield from itertools.islice(self._flattened_backers, start_pos, None)
 
     def unpack(self, addr, fmt):
         if self._last_backer_pos is not None:

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import timeit
 import unittest
@@ -7,6 +8,8 @@ import unittest
 import cffi
 
 import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
 
 
 @unittest.skipIf(sys.platform == "emscripten", "runtime CFFI compilation is unavailable in Pyodide")
@@ -116,6 +119,24 @@ def test_clemory_contains():
     assert clemory.min_addr == 0
     assert clemory.max_addr == 70
     assert clemory.consecutive is True
+
+
+def test_clemory_read_only_view_backers_match_the_clemory():
+    loader = cle.Loader(os.path.join(TEST_BASE, "x86_64", "fauxware"), auto_load_libs=False)
+    loader.gen_ro_memview()
+    view = loader.memory_ro_view
+    assert view is not None
+
+    def listing(backers):
+        return [(start, bytes(backer)) for start, backer in backers]
+
+    expected = listing(loader.memory.backers())
+    assert len(expected) > 1
+    assert listing(view.backers()) == expected
+
+    for start, backer in expected:
+        for addr in (start - 1, start, start + 1, start + len(backer) - 1, start + len(backer)):
+            assert listing(view.backers(addr)) == listing(loader.memory.backers(addr))
 
 
 def main():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ClemoryReadOnlyView.backers()` is a point query wearing an enumerator's name. The `Clemory` it views returns every backer. On `binaries/tests/x86_64/fauxware`, where `Loader.gen_ro_memview()` builds the view:

```
clemory.backers()       [('0x400000', 2676), ('0x600e28', 568), ('0x700000', 49)]
view._flattened_backers [('0x400000', 2676), ('0x600e28', 568), ('0x700000', 49)]
view.backers()          []
clemory.backers(0x400a74) [('0x600e28', 568), ('0x700000', 49)]
view.backers(0x400a74)    []
```

The data is there -- `_flattened_backers` holds the same three entries -- so a caller that walks the view sees an empty program while the loader is fully populated. Comparing the two at every backer boundary on eight tracked fixtures, 136 of 192 addresses disagree.

### Root cause

The loop bisects on each entry's start address, steps back one, and then breaks on the first entry that starts above `addr`, yielding only where `0 <= addr - start < len(data)`.

`Clemory.backers` bisects on each backer's **end** and `islice`s the rest, which is what its own docstring promises: "all backers before and not including this address will be skipped". `ClemoryBase.backers` only raises, so that rule is written down at one of the two implementations and not the other.

### Fix

Bisect on `start + len(backer)` and hand back the tail. The same 192 comparisons now agree at every address.

This does not implement iteration over the view, and is not meant to. #821 gives this method being a point query as one of three reasons for having the views refuse `__iter__` rather than implement it; repairing it removes one of those three and leaves the question where that pull request put it.

### Testing

New `test_clemory_read_only_view_backers_match_the_clemory` in `tests/test_clemory.py` loads `binaries/tests/x86_64/fauxware`, calls `gen_ro_memview()`, and asserts the view's enumeration equals the clemory's, then repeats the comparison at every backer's first, last and one-past-the-end address. It fails on master, where the view yields nothing and the clemory yields three backers.

angr is unaffected: its three consumers -- the VEX lifter, the p-code lifter and `Clinic._convert_vex_fast` -- all take `next(clemory.backers(addr))` and then guard `start <= addr`, so they already cope with this shape. `CFGFast` and `Decompiler` over eight fixtures on six architectures give identical function and decompilation counts on both revisions.

Validation: https://github.com/angr/cle/pull/825#issuecomment-5558123220

session: sharpen