### PR TITLE
Refuse packing through a read-only Clemory view

### DIFF
--- a/cle/memory.py
+++ b/cle/memory.py
@@ -768,6 +768,9 @@ class ClemoryReadOnlyView(ClemoryBase):
     def store(self, addr, data):
         raise NotImplementedError("ClemoryReadOnlyView does not support storing")
 
+    def pack(self, addr: int, fmt: str, *data):
+        raise NotImplementedError("ClemoryReadOnlyView does not support packing")
+
     def backers(self, addr: int = 0):
         start_pos = bisect.bisect_right(self._flattened_backers, addr, key=lambda x: x[0])
         if start_pos > 0:

--- a/tests/test_clemory.py
+++ b/tests/test_clemory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import timeit
 import unittest
@@ -7,6 +8,8 @@ import unittest
 import cffi
 
 import cle
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
 
 
 @unittest.skipIf(sys.platform == "emscripten", "runtime CFFI compilation is unavailable in Pyodide")
@@ -116,6 +119,30 @@ def test_clemory_contains():
     assert clemory.min_addr == 0
     assert clemory.max_addr == 70
     assert clemory.consecutive is True
+
+
+def test_clemory_read_only_view_refuses_writes():
+    loader = cle.Loader(os.path.join(TEST_BASE, "x86_64", "fauxware"), auto_load_libs=False)
+    loader.gen_ro_memview()
+    view = loader.memory_ro_view
+    assert view is not None
+
+    entry = loader.main_object.entry
+    before = loader.memory.load(entry, 16)
+    nops = b"\x90" * 8
+
+    for write in (
+        lambda: view.store(entry, nops),
+        lambda: view.pack(entry, "8s", nops),
+        lambda: view.pack_word(entry, int.from_bytes(nops, "little")),
+    ):
+        refused = False
+        try:
+            write()
+        except NotImplementedError:
+            refused = True
+        assert refused
+        assert loader.memory.load(entry, 16) == before
 
 
 def main():


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Loader.gen_ro_memview()` hands out a `ClemoryReadOnlyView`, and it is not read-only. `store` and `__setitem__` refuse, but `pack` and `pack_word` write straight into the parent `Clemory`. Loading `binaries/tests/x86_64/fauxware`, calling `gen_ro_memview()`, and then trying all three writes at the entry point:

```
loader.memory before: 31ed4989d15e4889
store: NotImplementedError: ClemoryReadOnlyView does not support storing
pack: returned, no exception
pack_word: returned, no exception
loader.memory after:  9090909090909090
```

The write lands in loader memory, so the entry point is the rewritten one. `CFGFast` builds one of these views in `_pre_analysis` and discards it in `_post_analysis`, and `Block.bytes`, `Clinic._convert_vex_fast` and both the VEX and p-code lifters read through it while it exists.

No code in cle, angr or angr-management packs through the view today, so this is an unguarded public API rather than a live analysis bug. The validation record names the revisions, and an instrumented run counted zero `pack` and `pack_word` calls with a view receiver during `CFGFast` and `Decompiler` over eight fixtures on six architectures.

### Root cause

`ClemoryReadOnlyView` inherits `ClemoryBase.pack`, which takes the backer out of `self.backers(addr)` and calls `struct.pack_into` on it. `ClemoryReadOnlyView._flatten_backers` appends the parent `Clemory`'s own `bytearray` objects rather than copies -- that aliasing is what the class is for, since it exists to make reads fast -- so the `pack_into` writes into the parent. `ClemoryBase.pack_word` ends in `return self.pack(...)`, so it inherits the same hole rather than having one of its own.

### Fix

Override `pack` on `ClemoryReadOnlyView` to raise `NotImplementedError`, the way `store` and `__setitem__` already do. One method covers both spellings, because `pack_word` goes through `self.pack`.

Deliberately not done: holding `memoryview(backer).toreadonly()` in `_flatten_backers` instead. That would close hand-mutation of a backer as well and cost no copy, but it changes the type `backers()` yields, and angr rejects that type. The VEX lifter failed on every fixture I ran, while cle's own suite stayed green.

### Testing

New `test_clemory_read_only_view_refuses_writes` in `tests/test_clemory.py` loads `binaries/tests/x86_64/fauxware`, calls `gen_ro_memview()`, and asserts for `store`, `pack` and `pack_word` both that the call is refused and that `loader.memory` at the entry point is byte-identical afterwards. It fails on master, where the two `pack` calls succeed and rewrite the entry point. `CFGFast` and `Decompiler` over eight tracked fixtures give identical function and decompilation counts on both revisions.

Validation: https://github.com/angr/cle/pull/826#issuecomment-5558172792

session: sharpen