### PR TITLE
ELF: Record per object the relocations cle cannot apply

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -169,6 +169,8 @@ class ELF(MetaELF):
         self.jmprel = OrderedDict()
         self.rela_type = None
         self.__parsed_reloc_tables = set()
+        # relocation types cle has no class for, mapped to the number of entries it discarded
+        self.unsupported_relocs: dict[int, int] = {}
 
         # DWARF data
         self.has_dwarf_info = bool(self._reader.has_dwarf_info())
@@ -208,6 +210,17 @@ class ELF(MetaELF):
             self.__register_segments()
         if not discard_section_headers:
             self.__register_sections()
+
+        if self.unsupported_relocs:
+            dropped = sum(self.unsupported_relocs.values())
+            log.warning(
+                "%s: dropped %d relocation%s that cle cannot apply on %s (types: %s)",
+                self.binary_basename,
+                dropped,
+                "" if dropped == 1 else "s",
+                self.arch.name,
+                ", ".join(str(r_type) for r_type in sorted(self.unsupported_relocs)),
+            )
 
         if not self.symbols:
             self._desperate_for_symbols = True
@@ -607,6 +620,11 @@ class ELF(MetaELF):
             GenericRelativeReloc if is_relr else get_relocation(self.arch.name, readelf_reloc.entry.r_info_type)
         )
         if RelocClass is None:
+            r_type = readelf_reloc.entry.r_info_type
+            # Type 0 is R_<arch>_NONE: get_relocation declines it because there is nothing to
+            # apply, not because cle is missing a handler for it.
+            if r_type != 0:
+                self.unsupported_relocs[r_type] = self.unsupported_relocs.get(r_type, 0) + 1
             return None
 
         address = AT.from_lva(readelf_reloc.entry.r_offset, self).to_rva()

--- a/cle/backends/elf/relocation/__init__.py
+++ b/cle/backends/elf/relocation/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-
 from .amd64 import relocation_table_amd64
 from .arm import relocation_table_arm
 from .arm64 import relocation_table_arm64
@@ -30,17 +28,10 @@ ALL_RELOCATIONS = {
 }
 
 
-log = logging.getLogger(name=__name__)
-complaint_log = set()
-
-
 def get_relocation(arch, r_type):
     if r_type == 0:
         return None
     try:
         return ALL_RELOCATIONS[arch][r_type]
     except KeyError:
-        if (arch, r_type) not in complaint_log:
-            complaint_log.add((arch, r_type))
-            log.warning("Unknown reloc %d on %s", r_type, arch)
         return None

--- a/tests/test_unsupported_relocations.py
+++ b/tests/test_unsupported_relocations.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import os
+
+from elftools.elf.elffile import ELFFile
+from elftools.elf.relocation import RelocationSection
+
+import cle
+from cle.backends.elf import ELF
+
+TESTS_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "binaries", "tests")
+
+# CLE's AArch64 table holds 12 of the static relocation types and 9 dynamic ones, so this object's
+# static entries are split: 11 resolve to a class and 31 are discarded.
+PARTLY_SUPPORTED = os.path.join(TESTS_BASE, "aarch64", "aarch64-relocs.o")
+# Every entry in this one resolves to a class.
+FULLY_SUPPORTED = os.path.join(TESTS_BASE, "x86_64", "switch_default_abort.o")
+# 902 of this one's 8399 entries are R_PPC_NONE; each of the other 7497 resolves to a class.
+R_NONE_HEAVY = os.path.join(TESTS_BASE, "ppc", "partial.o")
+
+
+def relocation_entries(path):
+    """Count relocation entries per type with pyelftools, without going through CLE.
+
+    Returns the counts for the types that apply something, and separately how many R_<arch>_NONE
+    entries were seen.
+    """
+    counts = {}
+    r_none = 0
+    with open(path, "rb") as stream:
+        for section in ELFFile(stream).iter_sections():
+            if not isinstance(section, RelocationSection):
+                continue
+            for reloc in section.iter_relocations():
+                r_type = reloc.entry.r_info_type
+                if r_type == 0:
+                    r_none += 1
+                else:
+                    counts[r_type] = counts.get(r_type, 0) + 1
+    return counts, r_none
+
+
+def load_elf(path) -> ELF:
+    obj = cle.Loader(path, auto_load_libs=False).main_object
+    assert isinstance(obj, ELF)
+    return obj
+
+
+def test_discarded_relocations_are_counted():
+    """An entry CLE has no class for is recorded under its type instead of vanishing."""
+    entries, r_none = relocation_entries(PARTLY_SUPPORTED)
+    assert (sum(entries.values()), r_none) == (42, 0)
+
+    obj = load_elf(PARTLY_SUPPORTED)
+    dropped = obj.unsupported_relocs
+    assert dropped, "CLE now handles every relocation type in this fixture; the test needs another"
+    assert dropped == {r_type: count for r_type, count in entries.items() if r_type in dropped}
+    assert len(obj.relocs) + sum(dropped.values()) == sum(entries.values())
+
+
+def test_supported_relocations_are_not_counted():
+    """The counter stays empty for an object whose entries all resolve to a class."""
+    entries, r_none = relocation_entries(FULLY_SUPPORTED)
+    assert (sum(entries.values()), r_none) == (20, 0)
+
+    obj = load_elf(FULLY_SUPPORTED)
+    assert obj.unsupported_relocs == {}
+    assert len(obj.relocs) == sum(entries.values())
+
+
+def test_r_none_entries_are_not_counted():
+    """R_<arch>_NONE applies nothing, so discarding it is not a gap in CLE's coverage."""
+    entries, r_none = relocation_entries(R_NONE_HEAVY)
+    assert (sum(entries.values()), r_none) == (7497, 902)
+
+    obj = load_elf(R_NONE_HEAVY)
+    assert obj.unsupported_relocs == {}
+    assert len(obj.relocs) == sum(entries.values())


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`ELF._make_reloc` returns `None` when it has no relocation class for an entry, and all five of its call sites drop it. Nothing on the object records that this happened, so a caller cannot tell an object whose relocations were all applied from one that lost some.

Loading two objects in one process on master, the second of which discards 30 relocations:

```
WARNING | cle.backends.elf.relocation | Unknown reloc 3 on RISCV64
WARNING | cle.backends.elf.relocation | Unknown reloc 2 on RISCV64
WARNING | cle.backends.elf.relocation | Unknown reloc 5 on RISCV64
binaries/tests/riscv/abgate-libabGateQt.so: built 0, dropped n/a
binaries/tests/riscv/autotalent-autotalent.so: built 0, dropped n/a
```

Every line came from the first object; the second prints nothing, and neither carries a record of what it lost. Over the 858 ELF objects in `angr/binaries`, one process emits 59 such lines in total, naming no object and no count.

### Root cause

`get_relocation`'s warning is deduplicated process-wide on a module-level `complaint_log` keyed by `(arch, r_type)`, so at most one object per process reports a given type. It returns `None` both for a type it has no class for and for `R_<arch>_NONE`, and `_make_reloc` turns both into the same silent `None`.

### Fix

`ELF` gains `unsupported_relocs`, mapping relocation type to how many entries were discarded, filled where the drop is decided, plus one warning per object:

```
WARNING | cle.backends.elf.elf | autotalent-autotalent.so: dropped 30 relocations that cle cannot apply on RISCV64 (types: 2, 3, 5)
```

`complaint_log` goes away, so `Unknown reloc` is no longer emitted from the ELF path — the PE backend keeps its own copy of that string. Type 0 is not counted, because `R_<arch>_NONE` applies nothing and counting it would report 902 unsupported relocations for `tests/ppc/partial.o`, whose other 7497 entries all resolve to a class.

What cle loads does not change, and this records one drop path only. An entry whose symbol index does not resolve, and one in a section skipped whole, are still dropped without a trace; one whose relocation class raises on an unmapped address already logs an error, but is no more recorded on the object than it was.

Most of what it exposes is somebody else's fix, since 2763 of the 2843 entries counted across `angr/binaries` are RISC-V and #637 adds that table. The other 80 are in 9 objects on architectures that already have tables: AArch64, ARM, MIPS, PPC64 and s390x. On ordinary compiler output the counter is quiet — over the 794 ELF binaries in the public `noelo-lab/decbench-dataset` it fires on 3 objects, one `R_ARM_V4BX` each.

### Testing

`tests/test_unsupported_relocations.py` reads each fixture's relocation entries with pyelftools and asserts the counter agrees per type, that built plus discarded accounts for every entry, and that `R_<arch>_NONE` is not counted. All three fail on master with `AttributeError: 'ELF' object has no attribute 'unsupported_relocs'`. Loading all 858 ELF objects in `angr/binaries` builds the same 597372 relocations before and after, with identical per-object contents.

Validation: https://github.com/angr/cle/pull/827#issuecomment-5562466381

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen
