### PR TITLE
ELF: repair only the header bytes that are loaded

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -259,8 +259,12 @@ class ELF(MetaELF):
         if self.is_relocatable and self.imports and not self._dynamic:
             self.guess_simprocs = True
 
+        # Repair only the header bytes that were loaded. These are file offsets, and nothing requires the
+        # ELF header to be mapped: an image whose first PT_LOAD starts past it maps none of them.
         for offset, patch in patch_undo:
-            self.memory.store(AT.from_lva(self.min_addr + offset, self).to_rva(), patch)
+            for index in range(len(patch)):
+                if self.offset_to_addr(offset + index) is not None:
+                    self.memory.store(AT.from_raw(offset + index, self).to_rva(), patch[index : index + 1])
 
     #
     # Properties and Public Methods

--- a/tests/test_patched_stream.py
+++ b/tests/test_patched_stream.py
@@ -28,7 +28,34 @@ def test_patched_stream():
     assert stream4.read() == b"A" * 0x10
 
 
+def assert_image_matches_file(ld, path):
+    """The loaded image must hold the file's own bytes, not the fields CLE zeroed to reread it."""
+    with open(path, "rb") as f:
+        image = f.read()
+    segment = ld.main_object.segments[0]
+    loaded = ld.memory.load(segment.vaddr, segment.filesize)
+    assert loaded == image[segment.offset : segment.offset + segment.filesize]
+
+
 def test_malformed_sections():
-    ld = cle.Loader(os.path.join(tests_path, "i386", "oxfoo1m3"), auto_load_libs=True)
+    path = os.path.join(tests_path, "i386", "oxfoo1m3")
+    ld = cle.Loader(path, auto_load_libs=True)
     assert len(ld.main_object.segments) == 1
     assert len(ld.main_object.sections) == 0
+
+    # This one maps its ELF header, so the fields have somewhere to go back to.
+    assert ld.main_object.offset_to_addr(0) is not None
+    assert_image_matches_file(ld, path)
+
+
+def test_malformed_sections_unmapped_header():
+    # bios.bin.truncated.elf is bios.bin.elf cut at the end of its only PT_LOAD, so the section
+    # header table is gone and pyelftools cannot walk it. That segment starts at file offset 0x70,
+    # so the ELF header is mapped nowhere and none of the zeroed fields has an address at all.
+    path = os.path.join(tests_path, "i386", "bios.bin.truncated.elf")
+    ld = cle.Loader(path, auto_load_libs=False)
+    assert len(ld.main_object.segments) == 1
+    assert len(ld.main_object.sections) == 0
+
+    assert ld.main_object.offset_to_addr(0) is None
+    assert_image_matches_file(ld, path)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

An ELF whose section header table pyelftools cannot walk, and whose lowest mapped segment does not start at file offset 0, loads with four fields of its own ELF header written over the image. On the new `tests/i386/bios.bin.truncated.elf` six bytes of the loaded image differ from the file:

```text
address    in memory        in the file
0xf9c30    74640000         06080000
0xf9c3e    280003000200     0000c5090000
```

`0x6474` is that file's section header table offset, and `40`, `3`, `2` are `e_shentsize`, `e_shnum` and `e_shstrndx` beside it. They land at `0xf9c30` and `0xf9c3e` because the restore addresses them from `min_addr`, and that image's only `PT_LOAD` starts at file offset `0x70`.

### Root cause

`ELF.__init__` probes the section table, and when the walk raises it zeroes `e_shoff`, `e_shentsize`, `e_shnum` and `e_shstrndx` in a `PatchedStream` so pyelftools rereads the file from the program headers alone. Those zeroes reach memory with everything else the segments map, so the original bytes are stored back at the end of the constructor:

```python
for offset, patch in patch_undo:
    self.memory.store(AT.from_lva(self.min_addr + offset, self).to_rva(), patch)
```

`offset` is a file offset into the ELF header -- `0x20` and `0x2e` for a 32-bit ELF, `0x28` and `0x3a` for a 64-bit one. `min_addr + offset` is that offset's address only when the lowest mapped segment sits at file offset 0. Nothing in ELF requires that, and nothing requires the header to be mapped at all.

### Fix

`offset_to_addr` is what translates a file offset, so the restore asks it and skips a byte whose offset maps nowhere. Byte by byte, because the run can straddle a segment boundary.

This also stops an object with no `PT_LOAD` at all from raising out of the constructor: on master such a file reaches `Clemory.store` on an empty memory and dies with a `KeyError` naming the patched offset, and it now loads with nothing mapped and nothing restored. No tracked object has that shape, so nothing here tests it.

`CGC` subclasses `ELF`, so CGC binaries reach this loop too, and #726 repairs the same defect in the header that backend substitutes. `NRFIN_00059` from the DARPA CGC corpus is a public reproducer for the pair -- `lungetech/cgc-cfe-submission-corpus` at `6e28340`, file `NRFIN_00059/2988916517-NRFIN_00059-5c96c811....rcb`, whose first `PT_LOAD` starts at file offset `0x40`. Master raises the `TypeError` #726 fixes and never loads it; this change alone leaves that same `TypeError`; #726 alone loads it with nine bytes overwritten by *this* defect; with both, none. No tracked CGC fixture has that shape, and the case below needs neither #726 nor a download.

### Testing

`tests/test_patched_stream.py::test_malformed_sections_unmapped_header` loads the new fixture. `::test_malformed_sections`, which already loaded `tests/i386/oxfoo1m3`, gains the same assertion for the case where the header *is* mapped. Both compare the whole loaded `PT_LOAD` against the file's own bytes rather than the four fields, so they fail on a wrong-address write anywhere in the segment. The new test fails on the merge base and passes with the change; deleting the restore loop entirely makes the `oxfoo1m3` test fail with zeroes where the header bytes belong, so the loop is still load-bearing.

The fixture is new because nothing already tracked reaches this path: of the 861 tracked `\x7fELF` objects in `angr/binaries` at `fc07821`, one takes the fallback -- `tests/i386/oxfoo1m3` -- and it is unaffected, its only `PT_LOAD` being at file offset 0. None of the 98 CGC fixtures takes it either. Merge angr/binaries#226 first. Validation: https://github.com/angr/cle/pull/828#issuecomment-5562697297

sync: angr/binaries#226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen
