### PR TITLE
Treat a backend that cannot answer a compatibility probe as declining

### DIFF
--- a/cle/loader.py
+++ b/cle/loader.py
@@ -1326,8 +1326,12 @@ class Loader:
 
         with stream_or_path(spec) as stream:
             for rear in [bk for bk in ALL_BACKENDS.values() if bk is not Blob] + [Blob]:
-                if rear.is_default and rear.is_compatible(stream):
-                    return rear
+                try:
+                    if rear.is_default and rear.is_compatible(stream):
+                        return rear
+                except Exception as e:  # pylint: disable=broad-except
+                    log.warning("Skipping the %s backend for %s: %r", rear.__name__, spec, e)
+                    stream.seek(0)
 
         return None
 

--- a/tests/test_backend_probe.py
+++ b/tests/test_backend_probe.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+import os
+from unittest import mock
+
+import cle
+from cle.backends.cartfile import CARTFile
+from cle.backends.elf.elf import ELF
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
+
+FAUXWARE = os.path.join(TEST_BASE, "tests", "x86_64", "fauxware")
+
+
+def raise_after_reading(stream):
+    stream.read(100)
+    raise ValueError("this probe cannot answer for these bytes")
+
+
+def test_a_raising_probe_does_not_stop_a_later_backend():
+    with mock.patch.object(CARTFile, "is_compatible", side_effect=raise_after_reading):
+        ld = cle.Loader(FAUXWARE, auto_load_libs=False)
+
+    assert isinstance(ld.main_object, cle.ELF)
+    assert ld.main_object.entry == cle.Loader(FAUXWARE, auto_load_libs=False).main_object.entry
+
+
+def test_a_raising_probe_is_reported(caplog):
+    with mock.patch.object(CARTFile, "is_compatible", side_effect=raise_after_reading):
+        with caplog.at_level(logging.WARNING, logger="cle.loader"):
+            cle.Loader(FAUXWARE, auto_load_libs=False)
+
+    reports = [record for record in caplog.records if "CARTFile" in record.getMessage()]
+    assert reports, "the backend that could not answer is not named in the log"
+    assert reports[0].levelno == logging.WARNING
+    assert "this probe cannot answer for these bytes" in reports[0].getMessage()
+
+
+def test_the_next_probe_sees_the_stream_from_the_start():
+    unpatched = ELF.is_compatible
+    positions = []
+
+    def record_position(stream):
+        positions.append(stream.tell())
+        return unpatched(stream)
+
+    with (
+        mock.patch.object(CARTFile, "is_compatible", side_effect=raise_after_reading),
+        mock.patch.object(ELF, "is_compatible", side_effect=record_position),
+    ):
+        ld = cle.Loader(FAUXWARE, auto_load_libs=False)
+
+    assert isinstance(ld.main_object, cle.ELF)
+    assert positions and set(positions) == {0}


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Loader._static_backend` picks a backend by asking each registered default backend's
`is_compatible` whether it can load the stream. A probe that raises instead of returning
False takes the whole load with it, so one backend's inability to parse bytes that are not
its format decides the answer for every backend behind it.

Two examples on cle master, needing nothing but a stock install and `tests/x86_64/fauxware`
from `angr/binaries`:

```text
>>> cle.Loader(io.BytesIO(open("tests/x86_64/fauxware", "rb").read(63)))
ELFParseError: expected 2, found 1

>>> cle.Loader("an-empty-file")
ValueError: cannot mmap an empty file
```

Neither file is loadable, but neither error is cle's. The first comes out of pyelftools via
`ELF.is_compatible`, the second out of `mmap` via `UefiFirmware.is_compatible`, and in both
cases every later backend, `Blob` included, is never asked.

### Root cause

21 of the 22 registered backends are `is_default` and get probed. Five are not total
functions of their input:

| backend | probe | raises | on |
|---|---|---|---|
| `ELF`, `ELFCore` | `elf.py:289`, `elfcore.py:75` | `ELFError`, `ELFParseError` | a truncated ELF; the probe builds a whole `ELFFile` to read `e_type` |
| `Apk`, `Jar` | `apk.py:243`, `jar.py:66` | `BadZipFile` | a local file header with no central directory |
| `UefiFirmware` | `uefi_firmware.py:56` | `AttributeError`, `ValueError` | a stream with no `fileno`; an empty file |

`ELF` is probed second, so a truncated ELF header ends the load before anything but
`CARTFile` has been asked.

### Fix

Hardening those five in turn leaves the next backend exposed and does not stay fixed. The
probes hand arbitrary bytes to `pyelftools`, `zipfile` and `uefi_firmware`, and the set of
exceptions they raise is not bounded: `ELF` and `ELFCore` raise both `ELFParseError` and
`ELFError`, and `uefi_firmware`'s `AttributeError` is documented nowhere. The loop is the one
place the property can be stated once.

```python
try:
    if rear.is_default and rear.is_compatible(stream):
        return rear
except Exception as e:  # pylint: disable=broad-except
    log.warning("Skipping the %s backend for %s: %r", rear.__name__, spec, e)
    stream.seek(0)
```

- **Caught:** any `Exception`; that backend declines and the loop carries on. No probe in cle
  raises deliberately, so nothing intentional is swallowed.
- **Logged:** one warning per raising probe, naming the backend and the exception. Not a
  traceback: a probe that cannot answer for bytes that are not its format is the expected
  case, not a fault.
- **Still propagates:** `BaseException`, so `KeyboardInterrupt` and `SystemExit` end a load.
- **Still fails:** a file no backend claims, with `CLECompatibilityError: Unable to find a
  loader backend ... Perhaps try the 'blob' loader?`

`loader.py:735` already logs a swallowed exception in exactly this form:
`log.warning("Dynamic load failed: %r", e)`.

The rewind matters because a probe that raises leaves the stream wherever it stopped,
measured at 63, 32 and 512 bytes in for the raisers above, and two probes read before they
seek: `PE.is_compatible` (`pe.py:208`) and `Minidump.is_compatible`
(`minidump/__init__.py:92`). Rewinding hands them the stream at the start.

**Overlap with `cle#720`, which is ours and open.** #720 hardens the `UefiFirmware` probe,
so it also fixes the empty-file example above and the ar static archives behind it, and it
fixes a second defect this change cannot reach: that probe maps the whole container when
handed a slice of one. Where the two meet they agree on what `Loader` returns, though #720
also asserts `UefiFirmware.is_compatible` itself returns False, which this change does not
make true. #720's code does not touch `ELF`, `ELFCore`, `Apk` or `Jar`; this change covers
them too. The two need no ordering against each other.

### Testing

`tests/test_backend_probe.py` loads the unmodified `tests/x86_64/fauxware` with
`CARTFile.is_compatible` patched to consume 100 bytes and raise. `CARTFile` is probed first
and `fauxware` is claimed by `ELF` second, so the assertions are that ELF still loads with
the same entry as a clean load, that the failure is reported with the backend named, and that
the next probe finds the stream at position 0. All three fail on the merge base and pass
here.

Validation: https://github.com/angr/cle/pull/829#issuecomment-5572039616

session: sharpen
