### PR TITLE
PE TLS: do not crash on a TLS directory the object does not back

### DIFF
--- a/cle/backends/tls/tls_object.py
+++ b/cle/backends/tls/tls_object.py
@@ -43,7 +43,30 @@ class ThreadManager:
             return None
         if obj.tls_data_size == 0:
             return b"".ljust(obj.tls_block_size, b"\0")
-        return obj.memory.load(obj.tls_data_start, obj.tls_data_size).ljust(obj.tls_block_size, b"\0")
+        if obj.tls_data_start + obj.tls_data_size > obj.max_addr - obj.mapped_base + 1:
+            # Only the range that is read is bounded, never tls_block_size: an ELF's .tbss legitimately runs
+            # past the end of the segment that holds the initial data.
+            log.warning(
+                "The provided object's TLS data at %#x runs past the end of the object. Skip TLS loading.",
+                obj.tls_data_start,
+            )
+            return None
+        try:
+            data = obj.memory.load(obj.tls_data_start, obj.tls_data_size)
+        except KeyError:
+            # The range is inside the object but nothing backs it, because the object's backed memory ends
+            # before its virtual extent. Clemory.load raises only when the start itself is unbacked; a range
+            # that starts in mapped memory and runs out of it comes back short, and means the same thing.
+            # Nothing here is real data, so a block that does not fit in the object is not worth building.
+            if obj.tls_data_start + obj.tls_block_size > obj.max_addr - obj.mapped_base + 1:
+                log.warning(
+                    "The provided object's TLS block at %#x is unmapped and does not fit. Skip TLS loading.",
+                    obj.tls_data_start,
+                )
+                return None
+            log.warning("The provided object's TLS data at %#x is not mapped. Zero-filling.", obj.tls_data_start)
+            data = b""
+        return data.ljust(obj.tls_block_size, b"\0")
 
     def new_thread(self, insert=True):
         thread = self._thread_cls(self)


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`Loader.tls.new_thread()` raises `KeyError` on a PE whose TLS directory points at
memory the image does not map. `SimWindows.configure_project` calls it unguarded,
so `angr.Project` fails on the binary even though `cle.Loader` itself succeeded.

Truncating a fixture `angr/binaries` already tracks reproduces it. Run from the
directory holding the `binaries` checkout, at `44a93d4f`:

```python
import logging, os, tempfile, cle
logging.basicConfig(level=logging.WARNING, format="%(levelname)s | %(name)s | %(message)s")
fd, p = tempfile.mkstemp(suffix=".exe")
os.write(fd, open("binaries/tests/x86/windows/TLS.exe", "rb").read()[:0x8000]); os.close(fd)
ld = cle.Loader(p, auto_load_libs=False)
th = ld.tls.new_thread()
```

```
  File "cle/backends/tls/pe_tls.py", line 100, in __init__
    image = thread_manager.initialization_image(obj)
  File "cle/backends/tls/tls_object.py", line 46, in initialization_image
    return obj.memory.load(obj.tls_data_start, obj.tls_data_size).ljust(obj.tls_block_size, b"\0")
  File "cle/memory.py", line 422, in load
    raise KeyError(addr)
KeyError: 110592
```

`110592` is `0x1b000`, which is `tls_data_start` exactly. The output comment has
both sides in full.

### Root cause

`initialization_image` copies a module's initial TLS data out of the module's own
memory with `obj.memory.load(tls_data_start, tls_data_size)`. For a PE both values
come from the TLS directory's `StartAddressOfRawData` and `EndAddressOfRawData`
(`cle/backends/pe/pe.py`, `_register_tls`). `Clemory.load` ends with
`raise KeyError(addr)` when no backer covers the start.

cle maps a PE as one blob built by `PE._get_memory_mapped_image`, which ends at the
last section's *raw* data, so an object's backed memory can stop well short of its
virtual extent. That method replicates pefile's equivalent but adds handling for
partially mapped sections, and it is what skips a section whose raw data runs past
the end of the file. A TLS directory pointing into that gap — the zero-fill tail of a
section whose `VirtualSize` exceeds its `SizeOfRawData` is the usual case — reads as
unbacked while the rest of the file is ordinary. Packed and damaged binaries reach
the same line from further out, naming a start hundreds of megabytes outside.

A range that merely *runs off* the end of a backer does not raise: `Clemory.load`
clips and returns a short buffer, which the caller zero-pads. Only an unbacked
*start* raises, and the two cases mean the same thing.

### Fix

Two additions to `initialization_image`, beside the guards that already reject a
negative start and a negative size:

- **Zero-fill when the range is inside the object but nothing backs it.** That gap
  reads as zeroes at run time, so the module gets the template it should have. On
  the reproducer above, `new_thread()` now returns and the image is the full 520 bytes
  the directory asks for. `cle#538` gave `pack_word` the same treatment in this package. Nothing
  reached on that path is real data, so a `tls_block_size` that does not fit in the
  object is skipped there rather than allocated.

- **Skip TLS for the module when the range to be read ends past the object.** It
  cannot then be describing the object's data. This is the disposition the two
  existing guards already use: `initialization_image` returns `None`,
  `PETLSObject.__init__` skips the module, and `get_tls_data_addr()` for its index
  returns 0 rather than a pointer.

That second guard bounds only the range that is *read*, never `tls_block_size`. The
difference between the two is zero fill, which need not lie inside the object at all —
an ELF's `.tbss` is exactly that. The bound is exact: `tls_data_start + tls_data_size == span`
still yields an image, `span + 1` yields `None`.

Deliberately not done: a directory naming a valid, *backed* range and a
multi-gigabyte zero fill still allocates it. That is master's behaviour and this
change neither widens nor narrows it.

### Testing

No new regression test. The reproducer is a truncated copy of a tracked file rather
than compiler output, and I would rather give you the recipe than commit a fixture no
toolchain emits — say the word and I will add one to `angr/binaries`.

`tests/test_tls_resiliency.py::test_tls_pe_incorrect_tls_data_start`, which covers the
negative-start guard on `i386/windows/2.exe`, still passes, and the cle suite is green.

Measured on 18 Windows PE objects from a corpus that cannot be redistributed:
`angr.Project(path)` raises on all 18 before and constructs on all 18 after.
`initialization_image` is unchanged for every object with TLS reachable from
`binaries/tests`, and for every one of the 3,616 TLS-bearing objects in a
72,664-object public PE survey — none of which reproduces this, because a linker puts
the TLS template inside a section's raw data.

Validation: https://github.com/angr/cle/pull/830#issuecomment-5572199405

session: sharpen