### PR TITLE
Stop loading a COFF symbol table that is not numbered for the image

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -1221,6 +1221,7 @@ class PE(Backend):
             return {}
 
         symbol_types: dict[int, set[SymbolType]] = {}
+        symbols: list[WinSymbol] = []
         idx = 0
         while idx < self._pe.FILE_HEADER.NumberOfSymbols:
             offset = self._pe.FILE_HEADER.PointerToSymbolTable + idx * sizeof_symbol_desc
@@ -1232,14 +1233,25 @@ class PE(Backend):
             else:
                 name = name.rstrip(b"\x00").decode("latin-1")
             if section > 0 and type_ in type_to_symbol_type and VALID_SYMBOL_NAME_RE.fullmatch(name):
+                if section > len(self._pe.sections):
+                    # A table numbered for some other section list gives no usable address for any of its
+                    # symbols, including the ones whose section number happens to be in range.
+                    log.warning(
+                        "PE symbol table names section %d of %d; not loading symbols from it",
+                        section,
+                        len(self._pe.sections),
+                    )
+                    return {}
                 rva = self._pe.sections[section - 1].VirtualAddress + value
                 symbol_type = type_to_symbol_type[type_]
                 symbol = WinSymbol(self, name, rva, False, False, None, None, symbol_type)
                 log.debug("Adding symbol %s", symbol)
-                self.symbols.add(symbol)
+                symbols.append(symbol)
                 if storage_class == IMAGE_SYM_CLASS.EXTERNAL:
                     symbol_types.setdefault(rva, set()).add(symbol_type)
             idx += 1 + num_aux_syms
+        for symbol in symbols:
+            self.symbols.add(symbol)
         return symbol_types
 
 

--- a/tests/test_pe_coff_symbols.py
+++ b/tests/test_pe_coff_symbols.py
@@ -59,6 +59,20 @@ def test_coff_symbol_type_hints_only_include_external_definitions():
     assert {symbol.name for symbol in pe.symbols} == {"function", "object", "static"}
 
 
+def test_coff_symbols_are_dropped_when_a_section_number_is_out_of_range():
+    raw_data = b"".join(
+        [
+            _coff_symbol(b"early", 0x10, 1, 0x20, IMAGE_SYM_CLASS.EXTERNAL),
+            _coff_symbol(b"stale", 0x20, 2, 0x20, IMAGE_SYM_CLASS.EXTERNAL),
+            _coff_symbol(b"late", 0x30, 1, 0x20, IMAGE_SYM_CLASS.EXTERNAL),
+        ]
+    )
+    pe = _make_pe(raw_data + b"\0\0\0\0")
+
+    assert not pe._load_symbols_from_coff_header()
+    assert not list(pe.symbols)
+
+
 def test_exports_inherit_only_unambiguous_coff_symbol_types():
     exports = [
         SimpleNamespace(name=b"data", address=0x1010, forwarder=None, ordinal=1),


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`cle.Loader` raises `IndexError` on a PE whose retained COFF symbol table names a
section the image does not have.

```
  File "cle/backends/pe/pe.py", line 166, in __init__
    coff_symbol_types = self._load_symbols_from_coff_header()
  File "cle/backends/pe/pe.py", line 1235, in _load_symbols_from_coff_header
    rva = self._pe.sections[section - 1].VirtualAddress + value
IndexError: list index out of range
```

The two images it was measured on are 32-bit `Machine=0x14c` PEs with **four**
sections whose symbol table names sections **5** and **6**. Both come from a
corpus whose redistribution is prohibited, so there is no committed binary; the
regression is a unit test and Testing says what else was measured.

### Root cause

The section number in a symbol record is read out of the file as a signed short
and used as an index:

```python
if section > 0 and type_ in type_to_symbol_type and VALID_SYMBOL_NAME_RE.fullmatch(name):
    rva = self._pe.sections[section - 1].VirtualAddress + value
```

`section > 0` rejects the reserved values -- `IMAGE_SYM_UNDEFINED` is 0,
`ABSOLUTE` is -1, `DEBUG` is -2 -- and nothing checks the other end.

Bounding the index and skipping that record stops the crash and leaves a worse
problem behind. On both of these images the table is not numbered for the image
at all:

- It is not one stray record. 206 of image A's 379 records name a missing
  section, and 208 of image B's 415.
- The records that survive are mis-attributed. In both, `_mainCRTStartup`
  carries `Value = 0x11cb`, which is `AddressOfEntryPoint` exactly; adding
  `.text`'s `0x1000` puts the entry symbol at `0x21cb`.

So skipping only the out-of-range records trades one loud `IndexError` for a
hundred quiet symbols: 104 and 108 of them, of which 14 and 13 fall outside
`[min_addr, max_addr]`.

That is two images, not a law about the format. What makes the disposition safe
regardless is below.

### Fix

Treat it the way this function already treats a symbol table that runs past the
end of the file, a few lines above -- warn, and load no symbols from it:

```
WARNING | cle.backends.pe.pe | PE symbol table names section 5 of 4; not loading symbols from it
```

**Nothing that loads today can lose a symbol by this.** The new branch needs
`section > 0` and `section > len(sections)`, which is exactly the state that
raises `IndexError` on master. An image with one stray out-of-range record in an
otherwise sound table would be a reason to prefer a bare bounds check -- but such
an image does not load today either, so there is no input whose symbols get
worse.

The two images load with 38 and 36 symbols, all inside the image, from their
import tables. Symbols are collected and added after the walk so that a table
condemned part-way through leaves none behind, and `_handle_exports` gets the
same empty mapping the existing guard already hands it.

### Testing

`tests/test_pe_coff_symbols.py::test_coff_symbols_are_dropped_when_a_section_number_is_out_of_range`
drives `_load_symbols_from_coff_header` with three records, the middle one naming
a section the fixture does not have, and asserts both that the mapping is empty
and that the symbol built before it was not kept. It fails on master with the same `IndexError` out of `pe.py:1235` and passes
here; the file's two existing tests pass on both.
It adds no binary: it packs symbol records against the same fake `_make_pe`
already in that file.

There is no fixture because there is no object to make one from.
`angr/binaries` at `fc07821c` tracks 106 PEs, 23 with a COFF symbol table and 22
with it in bounds. Not one of the 22 has a single record, whether or not it would
reach the indexing, that names a section past the section count. Ten of them name
their own last section and the other twelve stop short of it, the widest being a
16-section image whose table never names a section above 3.

Truncating a tracked fixture cannot produce one. Cutting a file's tail cannot
raise the section number written in a symbol record, and over the 23, truncated
at 1,582 lengths between them, it never lowered the section count either: every
truncation still entered `_load_symbols_from_coff_header`, and of the 129 that
got past the file-extent guard and walked 556,365 records between them, not one
saw a section count different from the untruncated file's.

A wider survey of 183,459 distinct PE objects finds 28,911 carrying a retained,
in-bounds COFF symbol table -- 1,411 Wine, 561 MSYS2, 30 Windows release
binaries, 12 decbench, 9 from the copy of `angr/binaries` this corpus carries at `718e154d`, 8 from a
real-language matrix, 26,880 generated -- and **0** whose records reaching the
indexing name a section past the count. Most of that corpus is not public, so this is
evidence rather than a survey you can re-run.

Nothing else moves. Every MZ file under `angr/binaries` loaded on master
`0e77ade3` and on this branch, comparing section list, entry point, `is_dotnet`
and the full sorted symbol list of `(name, RVA, type, is_export)`:

```
106 PE objects, 41,106 symbols, 0 differing records
```

The same harness unchanged over the two failing images reports 2 of 2 records
differing, so an empty diff is a result and not a broken instrument.

Validation: https://github.com/angr/cle/pull/832#issuecomment-5579651429

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen