### PR TITLE
Scale the placement fallback to the address space

### DIFF
--- a/cle/loader.py
+++ b/cle/loader.py
@@ -1082,9 +1082,11 @@ class Loader:
             start = self.main_object.max_addr + 1
 
         # The granularity is a preference, not a constraint: it costs up to one granule per object,
-        # which a small address space runs out of long before the space itself is full.
+        # which a small address space runs out of long before the space itself is full. The rung
+        # below it is a page, or a 4096th of an address space too small to hold many pages.
+        fallback = max(1, min(0x1000, limit >> 12))
         alignments = [self._rebase_granularity]
-        alignments += [a for a in (0x1000, 1) if a < self._rebase_granularity]
+        alignments += [min(a, fallback) for a in (0x1000, 1) if a < self._rebase_granularity]
 
         for alignment in alignments:
             for gap_start, gap_end in self._free_gaps(start, limit):

--- a/tests/test_rebase.py
+++ b/tests/test_rebase.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import os
 
+import pytest
+
 import cle
 
 TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
@@ -69,7 +71,28 @@ def test_rebase_granularity_is_not_a_hard_object_limit():
         assert ld.find_object_containing(obj.min_addr) is obj
 
 
+def test_archive_members_fill_a_16_bit_address_space():
+    """
+    A page is a sixteenth of AVR's 64 KiB, so falling back to one costs a whole page per archive
+    member and leaves nowhere to put a member larger than what is left over.
+    """
+    pytest.importorskip("pypcode")
+    path = os.path.join(TEST_BASE, "tests", "avr", "libgcov_avr31.a")
+    ld = cle.Loader(path)
+
+    members = [obj for obj in ld.all_objects if obj.parent_object is ld.main_object]
+    assert len(members) == 28
+
+    placed = sorted(members, key=lambda o: o.min_addr)
+    assert placed[-1].max_addr < 2**ld.main_object.arch.bits
+    for lower, upper in zip(placed, placed[1:]):
+        assert lower.max_addr < upper.min_addr
+    for obj in members:
+        assert ld.find_object_containing(obj.min_addr, membership_check=False) is obj
+
+
 if __name__ == "__main__":
     test_sparse_main_object()
     test_sparse_main_object_unsorted_program_headers()
     test_rebase_granularity_is_not_a_hard_object_limit()
+    test_archive_members_fill_a_16_bit_address_space()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`cle.Loader` cannot load an AVR gcc runtime archive, and reports the 64 KiB
address space full with a sixteenth of it in use:

```
  File "cle/loader.py", line 1036, in _map_object
    base_addr = self._find_safe_rebase_addr(obj_size)
  File "cle/loader.py", line 1095, in _find_safe_rebase_addr
    raise CLEOperationError("Ran out of room in address space")
cle.errors.CLEOperationError: Ran out of room in address space
```

The archive holds 28 members, which cle maps at `0x70` (21 of them), `0x110` (6)
and `0x1460` (1). Twenty-seven are placed; `_gcov_info_to_gcda.o` at `0x1460` is
not. At that point `0xf90` of `0x10000` bytes are occupied and `0xf070` is free,
spread over sixteen gaps whose largest is `0xf90`.

It is not one archive. Debian Ports `gcc-avr` 1:14.2.0-2 ships 114 archives under
`usr/lib/gcc/avr/14.2.0/`, and all 57 `libgcov.a` among them fail this way.

### Root cause

`Loader._find_safe_rebase_addr` tries each alignment in turn and takes the first
gap that fits:

```python
alignments = [self._rebase_granularity]
alignments += [a for a in (0x1000, 1) if a < self._rebase_granularity]
```

The ladder is right; the constant in it is not. AVR's whole address space is
`0x10000`, so the 1 MiB granule never fits after the first object and the page
rung does all the work -- and a page is a *sixteenth* of the space. The first
sixteen members land at `0x0`, `0x1000` ... `0xf000`, one per page, each leaving
a hole of at most `0xf90`. Everything after that packs into the low holes at byte
alignment, and the first member larger than a hole cannot go anywhere. The byte rung
below does not rescue this: by the time it runs, the page rung has already spent the
space.

### Fix

Scale the page rung to the address space:

```python
fallback = max(1, min(0x1000, limit >> 12))
alignments = [self._rebase_granularity]
alignments += [min(a, fallback) for a in (0x1000, 1) if a < self._rebase_granularity]
```

`0x1000` is an absolute number in a decision about proportion. The rung above it
is already proportionate: `0x100000` is a 4096th of a 32-bit address space and
`0x1000` is a 4096th of a 24-bit one, so `limit >> 12` generalises the two
constants already here instead of adding a third. It is `0x1000` exactly when
`limit >= 2**24`, so every address space of 24 bits or wider gets the alignments
it gets today, and 12 is the largest shift with that property. *Which* rungs
exist is still decided by the caller's `rebase_granularity` exactly as before, so
a caller that asks for `0x1000` or less gets an identical ladder. On AVR the
ladder becomes `[0x100000, 0x10, 1]` and all 28 members fit in `0x23f0` bytes.

A caller's own `rebase_granularity` is deliberately not capped. Capping it also
fixes AVR, and it moves the addresses `cle/tests/test_relocated.py` and
`angr/tests/sim/test_accuracy.py` assert under `rebase_granularity=0x1000000` on
i386, mips, ppc and armel, and moves 24-bit architectures as well. An explicit
granularity is a request; the rung the loader falls back to when that request
does not fit is cle's own choice, and is the part that was wrong.

Placement is first-fit, so a finer rung is a better heuristic and not a
guarantee: packing tighter can leave a differently shaped hole, and the
validation record has the measured rate both ways.

### Testing

`tests/test_rebase.py::test_archive_members_fill_a_16_bit_address_space` loads
the archive and asserts all 28 members are placed, disjoint, inside `2**16` and
each findable through `find_object_containing`. On the merge base it fails with
`CLEOperationError: Ran out of room in address space` at `cle/loader.py:1095`;
with this change it passes.

Over Debian's 114 AVR archives, the 57 `libgcov.a` go from 0 loaded to 57. Full detail, including the placement A/B and the cases where
this packs worse, is in the validation record.

This needs the fixture in angr/binaries#228 merged first, or the new test
has no input to load.

Validation: https://github.com/angr/cle/pull/833#issuecomment-5580005099

session: sharpen
