### PR TITLE
PE: Record the import hint/name entries, not the span between them

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -656,9 +656,8 @@ class PE(Backend):
             )
         )
 
-        # Per-DLL ILT arrays and track hint/name range
-        hn_min = None
-        hn_max = None
+        # Per-DLL ILT arrays and hint/name entry extents
+        hint_name_spans: list[tuple[int, int]] = []
         for entry in entries:
             ilt_rva = entry.struct.OriginalFirstThunk
             if ilt_rva:
@@ -672,7 +671,6 @@ class PE(Backend):
                     )
                 )
 
-            # Track hint/name table extent
             for imp in entry.imports:
                 if imp.hint_name_table_rva:
                     rva = imp.hint_name_table_rva
@@ -681,18 +679,21 @@ class PE(Backend):
                     entry_size = 2 + name_len
                     if entry_size % 2:
                         entry_size += 1
-                    entry_end = rva + entry_size
-                    if hn_min is None or rva < hn_min:
-                        hn_min = rva
-                    if hn_max is None or entry_end > hn_max:
-                        hn_max = entry_end
+                    hint_name_spans.append((rva, rva + entry_size))
 
-        # Hint/Name table blob
-        if hn_min is not None and hn_max is not None:
+        # Hint/Name table. Nothing requires the entries to be contiguous or ordered, so
+        # coalesce the ones that touch and record a blob per run.
+        merged_spans: list[list[int]] = []
+        for start, end in sorted(hint_name_spans):
+            if merged_spans and start <= merged_spans[-1][1]:
+                merged_spans[-1][1] = max(merged_spans[-1][1], end)
+            else:
+                merged_spans.append([start, end])
+        for start, end in merged_spans:
             sub_regions.append(
                 StringBlob(
-                    vaddr=base + hn_min,
-                    size=hn_max - hn_min,
+                    vaddr=base + start,
+                    size=end - start,
                     sort=MemRegionSort.IMPORT_HINT_NAME_TABLE,
                 )
             )

--- a/tests/test_pe_meta_regions.py
+++ b/tests/test_pe_meta_regions.py
@@ -233,5 +233,29 @@ class TestPEMetaRegions(unittest.TestCase):
         assert flat == list(exp.sub_regions)
 
 
+class TestPEScatteredHintNameTable(unittest.TestCase):
+    """A hint/name table whose entries are scattered must not be recorded as one span."""
+
+    @classmethod
+    def setUpClass(cls):
+        # This binary's imports point at hint/name entries spread over two megabytes of the
+        # image. Recording the lowest-to-highest span as a single blob covered the entry
+        # point, and CFGFast then treats the entry as data and decodes nothing.
+        TEST_BINARY = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "Project1.vmp.exe")
+
+        cls.loader = cle.Loader(TEST_BINARY, auto_load_libs=False)
+        cls.pe_obj: cle.PE = cls.loader.main_object  # type: ignore
+        assert isinstance(cls.pe_obj, cle.PE)
+
+    def test_scattered_hint_name_entries(self):
+        imp = _find_regions(self.pe_obj, MemRegionSort.IMPORT_DIRECTORY)[0]
+        assert isinstance(imp, DataDirectory)
+        hnt = _find_sub_regions(imp, MemRegionSort.IMPORT_HINT_NAME_TABLE)
+
+        assert len(hnt) == 179
+        assert sum(r.size for r in hnt) == 3360
+        assert not any(r.vaddr <= self.pe_obj.entry < r.vaddr + r.size for r in hnt)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

Two PE files `angr/binaries` already tracks have their entry point covered by a
cle metadata region, so `CFGFast` treats the entry as data and decodes nothing
there. The entry sits in an executable section in both cases:

```
tests/x86_64/windows/Project1.vmp.exe
    entry 0x706467   section .vmp1    exec=True
    covering region: 0x63b512 +0x1f65dc (2,057,692 bytes) import-hint-name-table
tests/x86_64/windows/7107ab06446ce4a51226196453066e7d361972364ad1543fe8a3a03a957e1bd5
    entry 0x142a401b4 section .tempest exec=True
    covering region: 0x141c1e670 +0xe4cfcc (14,995,404 bytes) import-hint-name-table
```

Every address inside such a region is refused the same way, so on an image where
the region covers the code the analysis can come back with nothing at all.

### Root cause

`PE._meta_imports` in `cle/backends/pe/pe.py` keeps only the lowest and highest
hint/name RVA it sees and records the whole range as one region:

```python
if hn_min is not None and hn_max is not None:
    sub_regions.append(
        StringBlob(vaddr=base + hn_min, size=hn_max - hn_min, ...)
    )
```

Nothing in the PE format requires the `IMAGE_IMPORT_BY_NAME` entries to be
contiguous or in order — each ILT and IAT slot points at one independently. On
`Project1.vmp.exe` the entries themselves
total 3,360 bytes inside that 2,057,692-byte span, so 99.8% of what cle reports
as an import string table is whatever else happens to lie between the first entry
and the last, including the entry point.

angr's `_flatten_regions` emits the sub-region, `CFGFast._process_metadata_regions`
occupies it in `_seg_list`, and the lift distance at any covered address is then
0, so `_lift` raises `SimTranslationError` and the address is dropped.

### Fix

Record each hint/name entry's own extent and coalesce the ones that touch, so the
region describes the bytes cle actually parsed. cle owns this: it is the producer,
and a consumer cannot tell a real string table from a span that merely contains
one.

```
Project1.vmp.exe   hint/name regions 1 -> 179, bytes 2,057,692 -> 3,360
7107ab06...bd5     hint/name regions 1 ->  21, bytes 14,995,404 ->   382
```

Coalescing runs rather than emitting one blob per import is deliberate: a normal
contiguous table still comes out as a single region, so 37 of the 99 PE files in
`angr/binaries` that have an import hint/name table keep exactly the region they
had. It follows the same shape as the region merging in `cle/backends/ihex.py`
and `cle/backends/srec.py`, which merge only exactly abutting regions where this
also merges overlapping ones.

Two other PE producers can also report a region larger than the data it
describes — the load-config sub-tables, built from header fields nothing
validates, and the resource directory's declared `Size` — but neither is this
table and each wants its own change with its own reproducer.

### Testing

`tests/test_pe_meta_regions.py::TestPEScatteredHintNameTable::test_scattered_hint_name_entries`
loads `tests/x86_64/windows/Project1.vmp.exe` and asserts 179 hint/name regions
totalling 3,360 bytes with none covering `obj.entry`. On master it fails with
`assert 1 == 179` and prints the single 2,057,692-byte blob. The rest of cle's
suite is unaffected.

The checkable effect on angr: running `CFGFast` restricted to the entry's own
neighbourhood, `_seg_list` at the entry goes from `string` to `code` on both
files and the entry is recovered as a function, where in that same window before
the change neither file produced a function or a node. These are packed
binaries, and an unbounded `CFGFast` over either of them was not run to
completion, so this makes no claim about whole-binary function counts.

Validation: https://github.com/angr/cle/pull/834#issuecomment-5585480845

session: sharpen
