### PR TITLE
PE: Map a section over its raw size when that is larger than its virtual size

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -1113,7 +1113,13 @@ class PE(Backend):
             if str_tbl_offset_match:
                 str_tbl_offset = int(str_tbl_offset_match.group(1))
                 name = self._read_from_string_table(str_tbl_offset)
-            section = PESection(pe_section, remap_offset=self.linked_base, name=name)
+            section = PESection(
+                pe_section,
+                remap_offset=self.linked_base,
+                name=name,
+                image_size=self._pe.OPTIONAL_HEADER.SizeOfImage,
+                file_size=len(self._pe.__data__),
+            )
             self.sections.append(section)
             self.sections_map[section.name] = section
 

--- a/cle/backends/pe/regions.py
+++ b/cle/backends/pe/regions.py
@@ -8,12 +8,19 @@ class PESection(Section):
     Represents a section for the PE format.
     """
 
-    def __init__(self, pe_section, remap_offset=0, name: str | None = None):
+    def __init__(
+        self,
+        pe_section,
+        remap_offset=0,
+        name: str | None = None,
+        image_size: int | None = None,
+        file_size: int | None = None,
+    ):
         super().__init__(
             name or pe_section.Name.decode("latin-1"),  # ensure all bytes can be decoded
             pe_section.PointerToRawData,
             pe_section.VirtualAddress + remap_offset,
-            pe_section.Misc_VirtualSize,
+            _mapped_size(pe_section, image_size, file_size),
         )
 
         self.characteristics = pe_section.Characteristics
@@ -38,3 +45,29 @@ class PESection(Section):
     @property
     def only_contains_uninitialized_data(self):
         return self.filesize == 0
+
+
+def _mapped_size(pe_section, image_size: int | None, file_size: int | None) -> int:
+    """
+    How many bytes of a section the Windows loader maps.
+
+    ``Misc_VirtualSize`` alone is not it. The loader copies the section's raw data to the
+    section's virtual address, so a section whose raw data is larger than its virtual size --
+    including one that declares a virtual size of zero, which the PE specification allows -- is
+    mapped over the raw size.
+
+    Two things bound the raw size. Only the bytes the file holds are copied, so a section whose
+    raw data runs off the end of the file gets no more than the file can supply; that is the same
+    reason ``PE._get_memory_mapped_image`` trims such a section, though it works from the adjusted
+    ``PointerToRawData`` and this works from the header's own, which is never smaller. And nothing
+    past the end of the image the optional header declares is mapped, however far a section
+    header's ``SizeOfRawData`` reaches. Both bounds only ever hold the result down toward the
+    declared virtual size, so a section never comes out smaller than its ``Misc_VirtualSize``, and
+    one starting at or past the end of the file keeps that size and gains nothing.
+    """
+    raw_size = pe_section.SizeOfRawData
+    if file_size is not None:
+        raw_size = min(raw_size, max(0, file_size - pe_section.PointerToRawData))
+    if image_size is not None:
+        raw_size = min(raw_size, max(0, image_size - pe_section.VirtualAddress))
+    return max(pe_section.Misc_VirtualSize, raw_size)

--- a/tests/test_pe.py
+++ b/tests/test_pe.py
@@ -326,5 +326,49 @@ class TestPEBackend(unittest.TestCase):
         assert ld.main_object.os == "uefi"
 
 
+# pylint: disable=no-self-use
+class TestPESectionMappedSize(unittest.TestCase):
+    """
+    A PE section is mapped over the larger of its virtual size and its raw size, and never past
+    the end of the image the optional header declares.
+    """
+
+    def test_raw_size_larger_than_virtual_size(self):
+        # .text states VirtualSize 0x7dcf and SizeOfRawData 0x7e00. The loader copies the raw
+        # bytes to the section's address, so the section is mapped over the larger of the two.
+        # .data states the reverse -- VirtualSize 0xa19 against SizeOfRawData 0x400 -- and keeps
+        # its virtual size, because the tail is zero-filled rather than read from the file.
+        exe = os.path.join(TEST_BASE, "tests", "x86_64", "windows", "fauxware.exe")
+        ld = cle.Loader(exe, auto_load_libs=False)
+        sections = ld.main_object.sections_map
+
+        assert sections[".text"].memsize == 0x7E00
+        assert sections[".text"].filesize == 0x7E00
+        assert sections[".data"].memsize == 0xA19
+        assert sections[".data"].filesize == 0x400
+
+    def test_raw_size_past_the_end_of_the_image(self):
+        # This one appends 14 MiB to the file and counts it in .reloc's SizeOfRawData, which
+        # reaches 0xe25000 against a SizeOfImage of 0x4f02e. Windows maps SizeOfImage bytes and
+        # no more, so the section stops at the end of the image and the object does not grow.
+        exe = os.path.join(
+            TEST_BASE,
+            "tests",
+            "i386",
+            "windows",
+            "aa893de523f58ee14972b94fef7ecdbb930cbdc700d8be097eb8a6de2549ce73",
+        )
+        ld = cle.Loader(exe, auto_load_libs=False)
+        obj = ld.main_object
+        reloc = obj.sections_map[".reloc"]
+
+        # .text in the same file grows the ordinary way, from VirtualSize 0x1a55d to the raw
+        # size 0x1a600, so this covers both halves of the rule on one object.
+        assert obj.sections_map[".text"].memsize == 0x1A600
+        assert reloc.memsize == 0x202E
+        assert reloc.filesize == 0xE25000
+        assert obj.max_addr - obj.mapped_base < 0x4F02E
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`PESection` reports a section's mapped size as `Misc_VirtualSize` alone. Windows maps a section
over its raw data as well, so a section whose `SizeOfRawData` exceeds its `Misc_VirtualSize` is
short in cle unless the file or the image runs out first. It is not a corner case: over the 106 PE
files `angr/binaries` tracks at `fc07821c`, this change grows 706 sections in 101 of them.

`tests/x86_64/windows/fauxware.exe` is the plain version. `.text` states
`VirtualSize 0x7dcf` and `SizeOfRawData 0x7e00`, and cle stops it at `0x7dcf`:

```
>>> ld = cle.Loader("tests/x86_64/windows/fauxware.exe", auto_load_libs=False)
>>> ld.main_object.sections_map[".text"]
<.text | offset 0x400, vaddr 0x140001000, size 0x7dcf>
```

The 0x31 bytes it drops are in the file and already in cle's memory. Here they are zero padding,
which is the ordinary case.

Where the shortfall covers the entry point, the binary loads and analyses to nothing.
`CFGBase._executable_memory_regions` builds its regions for PE and COFF from `section.min_addr`
and `min(section.memsize, section.filesize)`, so an entry outside every section's `memsize` is in no
executable region, `CFGFast` refuses every address, and the result is 0 functions and 0 nodes.
A section that declares `VirtualSize` 0 — which the PE specification permits, and which Windows
handles by using the raw size — gets `memsize` 0 and loses its whole content this way.

### Root cause

`cle/backends/pe/regions.py`, `PESection.__init__`:

```python
super().__init__(
    name or pe_section.Name.decode("latin-1"),
    pe_section.PointerToRawData,
    pe_section.VirtualAddress + remap_offset,
    pe_section.Misc_VirtualSize,
)
```

`Section.__init__` uses that value for `memsize`, and `Region.contains_addr` is
`vaddr <= addr < vaddr + memsize`, which is what `find_section_containing` walks.

cle#285 reported the same geometry in 2021 and `6cf00b4b` fixed half of it: it gave `PESection` a
`filesize` of its own, taken from `SizeOfRawData`, and left the `memsize` argument passed to
`Section.__init__` as `Misc_VirtualSize`. That half has not been revisited since.

### Fix

`_mapped_size` takes the larger of the virtual size and the raw size, and bounds the raw size
twice: to the bytes the file actually holds, and to the end of the image the optional header
declares. Both bounds only ever hold the result down toward `Misc_VirtualSize`, so no section
comes out smaller than it does today.

The image bound matters on real files:
`tests/i386/windows/aa893de523f58ee14972b94fef7ecdbb930cbdc700d8be097eb8a6de2549ce73` appends
14 MiB to itself and counts it in `.reloc`'s `SizeOfRawData`, which reaches `0xe25000` against a
`SizeOfImage` of `0x4f02e`. Without the bound that object's span would grow from `0x4f02e` to
`0xe72000`; with it, `.reloc` stays at `0x202e`.

`max_addr` follows `memsize`, so the tail `pe.py` keeps of the mapped image grows on 97 of the
106: more bytes retained, never fewer, and the shortfall between an object's claimed span and its
backed bytes is unchanged object for object. Two of our open items are in the same code. cle#790
backs the last byte and the last section's virtual-size tail; with both changes applied, 105 of
the 106 tracked files come out with no shortfall at all, and the one that does not is cle#794's,
which is about a section whose raw data begins past the end of the file. The two compose and
neither needs the other.

Deliberately not done: `filesize` still comes from `SizeOfRawData`; the section is not rounded up
to `SectionAlignment`; and a section is not clamped to the next section's virtual address. That
last is left out on a measurement: across both corpora no section reaches the clamp, so it would
be an untested branch.

### Testing

`tests/test_pe.py::TestPESectionMappedSize`, two methods on files `angr/binaries` already tracks.
The first asserts `fauxware.exe`'s `.text` maps `0x7e00` while `.data`, which states the reverse
(`VirtualSize 0xa19` against `SizeOfRawData 0x400`), keeps its virtual size. The second asserts
both halves of the rule on the 14 MiB object above. Both fail on master and pass here. The
pre-existing `test_loading_incomplete_pe_file` covers the file bound: an earlier version of this
change without that bound failed it.

`CFGFast(normalize=False)` over all 106 tracked PE files, both arms: **nothing is lost** — no
object loses a function or a node — and four gain one function each, 244,228 -> 244,232. Those
four are not recoveries. Each starts nine bytes before the old end of `.text`, in bytes master
already had, and runs into the zeros past it, so a block master could not finish now decodes to
its end: one `0xff` and 197 zeros. The count that matters is the zero losses.

The binaries whose CFG this recovers are in a private corpus and cannot be named here. Three go
from 0 functions to 125, 281 and 490. A fourth already recovered 1 function and now recovers 4,
and it answers whether this only ever maps padding: its `.text` states `VirtualSize 0xcb4` against
`SizeOfRawData 0xe00`, and at `0x401db0`, `0xfc` bytes past the section as cle reports it, sits
`mov eax, [esp+4]; sub esp, 0x12c` with four callee-saved pushes and `push 0x1f0fff`
(`PROCESS_ALL_ACCESS`). That is a compiler-emitted prologue, and today it is outside every
section. No file in `angr/binaries` shows the entry-point symptom — 105 of the 106 already have
their entry inside a section — so the public evidence is the geometry and the control.

Validation: https://github.com/angr/cle/pull/835#issuecomment-5589084621.

session: sharpen
