### PR TITLE
ELF: read the symbol-version tables from the image, not the file

### DIFF
--- a/cle/backends/elf/elf.py
+++ b/cle/backends/elf/elf.py
@@ -1134,6 +1134,11 @@ class ELF(MetaELF):
                     "sh_info": verneed_count,
                 }
                 readelf_verneed = elffile.GNUVerNeedSection(fake_verneed_header, "verneed_cle", self._reader, strtab)
+                # sh_offset above is an RVA, so the section has to read from the image and not
+                # from the file. pyelftools takes the file stream from the ELFFile we hand the
+                # constructor; swap it out the way we do for the symbol table above.
+                readelf_verneed.stream = self.memory  # type: ignore
+                readelf_verneed.elffile = None  # type: ignore
                 for _, aux in readelf_verneed.iter_versions():
                     for vaux in aux:
                         self._versions[vaux.entry.vna_other] = vaux.name
@@ -1150,6 +1155,8 @@ class ELF(MetaELF):
                     "sh_info": verdef_count,
                 }
                 readelf_verdef = elffile.GNUVerDefSection(fake_verdef_header, "verdef_cle", self._reader, strtab)
+                readelf_verdef.stream = self.memory  # type: ignore
+                readelf_verdef.elffile = None  # type: ignore
                 for ver, aux in readelf_verdef.iter_versions():
                     for vaux in aux:
                         self._versions[ver.entry.vd_ndx] = vaux.name

--- a/tests/test_symbol_versions.py
+++ b/tests/test_symbol_versions.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+
+import cle
+from cle.backends.elf import ELF
+
+TEST_BASE = os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.join("..", "..", "binaries"))
+
+# A VMProtect-packed x86-64 ELF. The segment holding its version tables is not laid out at the
+# image base plus its own file offset, so DT_VERNEED points at an RVA well past the end of the
+# file. Reading the version tables out of the file stream at that RVA fails. See angr/cle#383.
+VMPROTECT = os.path.join(TEST_BASE, "tests", "x86_64", "vmprotect_sample1.vmp.bin")
+
+
+def test_symbol_versions_when_rva_is_not_the_file_offset():
+    ld = cle.Loader(VMPROTECT, auto_load_libs=False)
+    obj = ld.main_object
+    assert isinstance(obj, ELF)
+
+    # Guard the fixture. Most ELFs put the version tables at an RVA that is also a valid file
+    # offset, and against one of those this test would pass without covering anything.
+    filesize = os.path.getsize(VMPROTECT)
+    verneed = obj._dynamic["DT_VERNEED"]
+    file_offset = obj.addr_to_offset(verneed)
+    assert file_offset is not None
+    assert file_offset < filesize < verneed - obj.linked_base
+
+    versions = {sym.version for sym in obj.symbols if sym.version is not None}
+    assert {"GLIBC_2.2.5", "GLIBC_2.3", "GLIBCXX_3.4", "CXXABI_1.3"} <= versions
+
+    by_name = {sym.name: sym.version for sym in obj.symbols}
+    assert by_name["printf"] == "GLIBC_2.2.5"
+    assert by_name["__gxx_personality_v0"] == "CXXABI_1.3"
+    assert by_name["_ZNSs6appendEPKcm"] == "GLIBCXX_3.4"
+
+
+if __name__ == "__main__":
+    test_symbol_versions_when_rva_is_not_the_file_offset()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

`cle.Loader` refuses any ELF whose symbol-version tables sit at a virtual address that is not
also a valid file offset. On `binaries/tests/x86_64/vmprotect_sample1.vmp.bin`, the sample
@fkil attached to #383 on 2023-04-11, which has had no reply since:

```
  File "cle/backends/elf/elf.py", line 1137, in __register_dyn
    for _, aux in readelf_verneed.iter_versions():
  File "elftools/elf/gnuversions.py", line 154, in iter_versions
    for verneed, vernaux in super(GNUVerNeedSection, self).iter_versions():
  File "elftools/elf/gnuversions.py", line 108, in iter_versions
    entry = struct_parse(
  File "elftools/common/utils.py", line 45, in struct_parse
    raise ELFParseError(str(e))
elftools.common.exceptions.ELFParseError: expected 2, found 0
```

Nothing is salvaged: the exception escapes `__register_segments`, so the object does not load
and no CFG, symbol table or decompilation follows.

### Root cause

`__register_dyn` builds seven pyelftools section objects out of `DT_` tags, each with an
`sh_offset` taken through `AT.from_lva(...).to_rva()` — an image-relative address, not a file
offset. Five of them are then pointed at the image so that address means something (line numbers
here are master's, `0e77ade3`):

```python
dynsym.stream = self.memory             # line 1107
readelf_versym.stream = self.memory     # line 1168
readelf_relocsec.stream = self.memory   # line 1214
readelf_jmprelsec.stream = self.memory  # line 1235
readelf_relrsec.stream = self.memory    # line 1256
```

`readelf_verneed` and `readelf_verdef` are the two exceptions, so pyelftools keeps the
`ELFFile`'s file stream and seeks an RVA in it. In the sample `DT_VERNEED` is `0xCE3808`
against an image base of `0x400000`, so the seek goes to `0x8E3808` in a `0x2E847B`-byte file —
`0x5FB38D` past the end — and the two-byte read of `vn_version` comes back empty. The table
really begins at file offset `0x2E3808`, `0x600000` lower.

Nothing shows on an ordinary binary because the segment holding the version tables is laid out
at the image base plus its own file offset, so the two numbers coincide. Both lines have been
wrong since 99379ebd (#324) added symbol versioning in April 2022 — it gave the versym table a
memory stream and these two none.

### Fix

Replace the stream on both sections, which is @fkil's second suggestion and what the other five
already do. The four assignments carry `# type: ignore` because pyelftools declares `stream` and
`elffile` with types cle deliberately violates here, and `Typecheck` budgets pyright errors per
file: the five older sections predate the budget, so their identical assignments are
grandfathered while new ones fail the check. His first suggestion, converting the offset with `to_raw()` instead, would leave
these two as the only tables in `__register_dyn` read out of the file, and he flagged himself
that it may be wrong when the stream is a memory dump.

Symbol versions now decode: 112 of the sample's symbols get a library version, including
`printf` `@GLIBC_2.2.5`, `__gxx_personality_v0` `@CXXABI_1.3` and `_ZNSs6appendEPKcm`
`@GLIBCXX_3.4`.

The `verdef` half gets no fixture with a mismatched offset — see Testing — but it is the same
mistake and is fixed with it rather than left half-repaired. It is not untested: on this branch
`GNUVerDefSection.iter_versions` is called with a `Clemory` stream and decodes all 23 versions
of `binaries/tests/x86_64/libc.so.6`, which cle's own suite already loads.

### Testing

`tests/test_symbol_versions.py` loads the sample, checks that `DT_VERNEED`'s file offset is
inside the file while its RVA is past the end — so the test fails loudly if the fixture is
ever swapped for an ordinary binary — and asserts three versioned symbols by name. On master
it fails with the `ELFParseError` above; on this branch it passes.

No tracked fixture had the offsets apart: over the 940 tracked paths whose content is an ELF in
`angr/binaries` at `0166109e` there are 578 `DT_VERNEED` and 40 `DT_VERDEF` entries, and all 618
put the table at an RVA that is also its file offset. Hence the new one.

Depends on angr/binaries#230 for the fixture, which `cle/ci.yml` resolves through
`angr/ci-settings/actions/binaries-ref`.

Expected CI, recorded before the push: all 20 checks green — the 18 Actions runs `ci / Build`,
`ci / Lint`, `ci / Typecheck`, `ci / Test (0..9)`, `ci / Decompiler Snapshot Testing (0)`,
`ci / Publish Unit Tests Results`, `Test (Pyodide)`, `Test macos-15` and `Test windows-2022`,
plus the two commit statuses `docs/readthedocs.org:cle` and `pre-commit.ci - pr`. The previous
head got 19 of those and failed `ci / Typecheck` on the four assignments now marked
`# type: ignore`; every other check passed, including `ci / Build`, so the fixture reached
every job.

Fixes #383. Validation: https://github.com/angr/cle/pull/836#issuecomment-5618893049

🤖 Generated with [Claude Code](https://claude.com/claude-code)

session: sharpen