### PR TITLE
PE TLS: ignore a zero fill that runs past the end of the image

### DIFF
--- a/cle/backends/pe/pe.py
+++ b/cle/backends/pe/pe.py
@@ -1068,6 +1068,17 @@ class PE(Backend):
                 self._register_tls_callbacks(tls.AddressOfCallBacks) if tls.AddressOfCallBacks != 0 else []
             )
             self.tls_block_size = self.tls_data_size + tls.SizeOfZeroFill
+            image_size = self._pe.OPTIONAL_HEADER.SizeOfImage
+            if tls.SizeOfZeroFill != 0 and self.tls_block_size > image_size:
+                # The TLS template is part of the image, so a zero fill that takes it past the end of the
+                # image is not describing this file. The bound is on the image's virtual size rather
+                # than the bytes we back, because a zero fill need not be backed by any file bytes.
+                log.warning(
+                    "TLS zero fill of %#x bytes runs past the end of the %#x-byte image. Ignoring it.",
+                    tls.SizeOfZeroFill,
+                    image_size,
+                )
+                self.tls_block_size = self.tls_data_size
 
     def _register_tls_callbacks(self, addr):
         """

--- a/tests/test_tls_resiliency.py
+++ b/tests/test_tls_resiliency.py
@@ -18,6 +18,22 @@ class TestTlsResiliency(TestCase):
         th = path_ld.tls.new_thread()
         assert th is not None
 
+    @staticmethod
+    def test_tls_pe_zero_fill_larger_than_image():
+        # TLS_huge_zero_fill.exe is TLS.exe with IMAGE_TLS_DIRECTORY32.SizeOfZeroFill, the dword at file
+        # offset 0x68ec, changed from 0 to 0xf0000000: a 3.75 GiB block out of a 124 KiB image.
+        good = cle.Loader(os.path.join(test_location, "x86", "windows", "TLS.exe"), auto_load_libs=False)
+        assert good.main_object.tls_data_size == 520
+        assert good.main_object.tls_block_size == 520
+
+        bad = cle.Loader(os.path.join(test_location, "x86", "windows", "TLS_huge_zero_fill.exe"), auto_load_libs=False)
+        assert bad.main_object.tls_data_size == good.main_object.tls_data_size
+        assert bad.main_object.tls_block_size == bad.main_object.tls_data_size
+
+        good_thread = good.tls.new_thread()
+        bad_thread = bad.tls.new_thread()
+        assert bad_thread.max_addr - bad_thread.mapped_base == good_thread.max_addr - good_thread.mapped_base
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

### Problem

One unchecked header field makes cle allocate gigabytes for a 36 KB file. The
reproducer is a tracked fixture with a single byte changed, added by
angr/binaries#233, which must merge first and which CI resolves the fixture from
while it is open.

```python
import resource, cle

resource.setrlimit(resource.RLIMIT_AS, (2560 << 20,) * 2)
ld = cle.Loader("binaries/tests/x86/windows/TLS_huge_zero_fill.exe", auto_load_libs=False)
print(ld.main_object.tls_data_size, ld.main_object.tls_block_size)   # 520 4026532360
ld.tls.new_thread()                                                  # MemoryError
```

The `MemoryError` comes out of `ljust(obj.tls_block_size, b"\0")` in
`ThreadManager.initialization_image`; `Loader` succeeds, so `angr.Project` reaches
it too, through `SimWindows.configure_project`. The fixture is
`tests/x86/windows/TLS.exe` with `SizeOfZeroFill` changed from `0` to
`0xf0000000`; the unmodified file is the control, giving `tls_block_size == 520`
with `new_thread()` returning.

### Root cause

`PE._register_tls` ends with `tls_block_size = tls_data_size +
tls.SizeOfZeroFill`. `SizeOfZeroFill` is a raw 32-bit field, so that sum reaches
4 GiB whatever the file's size is, and nothing downstream bounds it:
`initialization_image` materialises the block with `ljust()`, and an object that
survives that pays again when `Clemory.add_backer` copies it into a `bytearray`.
The guards already there cover a negative `tls_data_start` and a negative
`tls_data_size`; none looks at the size of what gets allocated.

### Fix

The PE/COFF spec puts the whole TLS template inside the image — *"the total
template size should be the same as the total size of TLS data in the image
file"* — so `OPTIONAL_HEADER.SizeOfImage` is the file's own statement of how big
the block can be. When the zero fill takes the block past it, the directory is not
describing this image: warn, ignore the zero fill, keep the initialized data.
The bound is on the image's *virtual* size rather than the bytes
cle backs, because a zero fill need not be backed by any file bytes.

Three alternatives, and why not:

- **Refusing the object.** These files analyse fine once the allocation is gone
  (below), so refusing trades a blow-up for a dead binary.
- **Clamping to `SizeOfImage`.** A prefix of a fabricated zero fill means
  nothing; the initialized data is the part of the directory that does.
- **The containing section's `Misc_VirtualSize`**, tighter and arguably the
  closer reading of that spec sentence. Over 8,764 TLS-bearing PEs it leaves
  **2,794 under 1 KiB of headroom** and is undefined on 8, where `SizeOfImage`
  leaves every one at least **28,664 bytes**. `TLS.exe` with a `SizeOfZeroFill`
  of 300 already fails it, 820 against 777.

### Beside the two open pieces of work in the same area

#830 bounds the range that is *read*; this bounds the block that is *allocated*,
which its description says it deliberately leaves alone. Measured: applying its
diff verbatim changes the outcome for 0 of the 33 corpus objects below, and with
both applied every number below is unchanged. `merge-tree` between the branches
exits 0, against a control commit editing the line #830 rewrites, which exits 1.
Either order merges.

#767 is the same shape on the ELF side, where a *legitimate* `p_memsz` declares
gigabytes of `.bss`, and waits on your preference between three repairs. Here the
declaration is not legitimate, so the fix is to disbelieve it. No ELF path
changes.

### Testing

`tests/test_tls_resiliency.py::test_tls_pe_zero_fill_larger_than_image` asserts
the good fixture is untouched, the bad one's block collapses to its data size,
and the two give a TLS object of the same extent. With `pe.py` reverted to master
it fails on `assert 4026532360 == 520`, before allocating anything.

**Nothing already tracked changes.** Every blob `angr/binaries` tracks at
`fc07821` was walked — 1,845 of them — and every TLS-bearing object loaded before
and after: 30 PEs with a TLS directory, 58 ELFs with `PT_TLS`, all 88 records
identical, two of them failing to load identically on both sides. That is not evidence the bound is well placed: all 30 PEs have
`SizeOfZeroFill == 0`, so the guard's first condition excludes every one.

**What does calibrate it** is the 8,764 TLS-bearing PEs above, mostly not
redistributable. **Not one has a non-zero `SizeOfZeroFill`**,
and not one declares a block larger than its own `SizeOfImage` — smallest headroom
28,664 bytes, largest block 16.8% of its image. Positive control: writing
`0xf0000000` into that field of a tracked fixture makes the guard fire.

**The objects that fail today.** 33 non-redistributable Windows PE objects — by
content 4 distinct programs, one in 30 repacked variants — each declaring a block
of 169,690,006 to 4,082,740,661 bytes against a `tls_data_size` of 8 or 172.
`RLIMIT_AS` 2,048 MiB, one fresh interpreter each, `Loader(...)` then
`tls.new_thread()`:

| | master `0e77ade3` | this branch |
| --- | ---: | ---: |
| `MemoryError` | 26 | 0 |
| returns | 7 | 33 |

The 7 survivors materialise 169,689,998 to 631,003,330 bytes of zeroes, peaking
at 391 to 1,272 MiB; after the change all 33 peak at 67 to 77 MiB. Six taken on
through `angr.Project` and `CFGFast` under the same cap recover 535 to 4,069
functions at 184 to 321 MiB. Two of the six were rerun on master and both die
under the cap — and **both survive `new_thread()` by themselves**, so it is the
ballast that kills them.

Validation: https://github.com/angr/cle/pull/838#issuecomment-5640171699

**CI prediction, recorded before the first check finished.** Every job here
resolves the `angr/binaries` reference out of this description — the top-level
jobs through `angr/ci-settings/actions/binaries-ref`, the rest through
`resolve_refs.py` — so all should be green while the fixture pull request is
open, and none could find the fixture without it.

session: sharpen